### PR TITLE
fix: SEO structure + protect private routes from indexing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const PRIVATE_PATH_PREFIXES = [
+  "/admin",
+  "/dashboard",
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/auth",
+  "/wireframes",
+];
+
+function startsWithPrivatePath(pathname: string) {
+  return PRIVATE_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+
+  if (!startsWithPrivatePath(pathname)) {
+    return NextResponse.next();
+  }
+
+  const response = NextResponse.next();
+  response.headers.set("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
+
+  if (search.includes("token=") || search.includes("redirect=")) {
+    response.headers.set("Cache-Control", "private, no-store, max-age=0");
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/admin/:path*",
+    "/dashboard/:path*",
+    "/login/:path*",
+    "/register/:path*",
+    "/forgot-password/:path*",
+    "/auth/:path*",
+    "/wireframes/:path*",
+  ],
+};


### PR DESCRIPTION
## Fix SEO Structure and Indexing Issues

### What this PR fixes
- Prevents login, admin, dashboard and auth routes from being indexed by Google
- Adds middleware to enforce noindex headers on private routes
- Protects token and redirect query params from being cached

### Why this matters
Your current structure was exposing:
- /login
- /admin
- /dashboard

These should NEVER be indexed and were hurting SEO quality signals.

### Result after merge
- Clean SEO surface (only public pages indexed)
- Protected private routes
- Ready for programmatic SEO scaling

### Next step
Move all auth and dashboard UI to app.masseurmatch.com
