### PR TITLE
Fix build failures: remove Google font fetches, fix duplicate Link import, add incident report

### DIFF
--- a/docs/deployment-log-analysis-2026-04-10.md
+++ b/docs/deployment-log-analysis-2026-04-10.md
@@ -1,0 +1,56 @@
+# Deployment Incident Analysis — 2026-04-10
+
+## Scope
+This document analyzes the latest deployment/build failure reproduced from the project build pipeline and records the remediation steps.
+
+## Most recent deployment/build errors observed
+Command used:
+
+```bash
+pnpm build
+```
+
+### 1) Next.js font download failures (`next/font/google`)
+**Errors**
+- `Failed to fetch font 'DM Sans' from Google Fonts`
+- `Failed to fetch font 'Playfair Display' from Google Fonts`
+- `Failed to fetch font 'Inter' from Google Fonts`
+
+**Nature of error**
+- Build-time external dependency/network fetch error.
+- Next.js tries to download Google Fonts at build time when using `next/font/google`.
+
+**Root cause**
+- Build environment could not reach `fonts.googleapis.com`/Google Fonts endpoints during compilation.
+- This made the build non-deterministic and environment-dependent.
+
+### 2) Webpack parse error from duplicate import
+**Error**
+- `Module parse failed: Identifier 'Link' has already been declared`
+- File: `src/app/reset-password/ResetPasswordPageClient.tsx`
+
+**Nature of error**
+- Static compile-time syntax/module error.
+
+**Root cause**
+- `Link` from `next/link` was imported twice in the same module.
+
+## Corrective actions implemented
+
+### A) Remove network dependency from root layout fonts
+- Replaced `next/font/google` usage in `src/app/layout.tsx` with the existing CSS variable fallback font stack already defined in `src/index.css`.
+- This removes build-time outbound font fetches and makes deployments resilient in restricted CI/deployment environments.
+
+### B) Fix duplicate import in reset password client page
+- Removed the duplicate `import Link from "next/link";` in `src/app/reset-password/ResetPasswordPageClient.tsx`.
+
+## Verification
+After the fixes:
+
+- `pnpm build` completed successfully.
+- Next.js finished compilation and static generation without deployment-blocking errors.
+
+## Preventive follow-ups
+1. Keep build-critical assets local or bundled to avoid hard external runtime/build dependencies.
+2. Add lint rule coverage for duplicate imports (`no-duplicate-imports`) if not already enforced.
+3. Keep this incident record for future triage of environment-specific deployment failures.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Inter, Playfair_Display, DM_Sans } from "next/font/google";
 import { AppMotionShell } from "@/app/_components/app-motion-shell";
 import { JsonLd } from "@/app/_components/json-ld";
 import { SiteFooter } from "@/app/_components/site-footer";
@@ -10,30 +9,6 @@ import { AppProviders } from "@/app/providers";
 import { SITE_URL } from "@/lib/site";
 import "leaflet/dist/leaflet.css";
 import "@/index.css";
-
-const fontSans = DM_Sans({
-  subsets: ["latin"],
-  variable: "--font-dm-sans",
-  weight: ["300", "400", "500", "600", "700"],
-  display: "swap",
-  preload: true,
-});
-
-const fontSerif = Playfair_Display({
-  subsets: ["latin"],
-  variable: "--font-playfair",
-  weight: ["400", "500", "600", "700"],
-  display: "swap",
-  preload: true,
-});
-
-const fontBody = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-  weight: ["300", "400", "500", "600"],
-  display: "swap",
-  preload: true,
-});
 
 const rootMetadata = createPageMetadata({
   title: "The safest and most trusted premium male massage directory",
@@ -57,9 +32,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body
-        className={`${fontSans.variable} ${fontSerif.variable} ${fontBody.variable} theme-masseurmatch min-h-screen overflow-x-hidden font-sans text-foreground antialiased`}
-      >
+      <body className="theme-masseurmatch min-h-screen overflow-x-hidden font-sans text-foreground antialiased">
         <AppProviders>
           <JsonLd data={buildOrganizationJsonLd()} />
           <JsonLd data={buildWebsiteJsonLd()} />

--- a/src/app/reset-password/ResetPasswordPageClient.tsx
+++ b/src/app/reset-password/ResetPasswordPageClient.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";


### PR DESCRIPTION
### Motivation
- The production build was failing due to build-time Google Fonts fetches and a syntax error from a duplicate import, so the pipeline needed hardening to be resilient in network-restricted CI environments. 
- The goal was to eliminate external build-time dependencies and fix the compile-time module error so builds complete reliably.

### Description
- Removed `next/font/google` usage from `src/app/layout.tsx` and reverted to the local/CSS font-variable fallbacks to avoid build-time network font downloads. 
- Fixed a duplicate `import Link from "next/link";` in `src/app/reset-password/ResetPasswordPageClient.tsx` that caused a webpack parse error. 
- Added `docs/deployment-log-analysis-2026-04-10.md` recording the error signatures, root causes, corrective actions, and preventive recommendations for future reference. 
- Modified files: `src/app/layout.tsx`, `src/app/reset-password/ResetPasswordPageClient.tsx`, and added `docs/deployment-log-analysis-2026-04-10.md`.

### Testing
- Ran `pnpm build`, which completed successfully (compile, static generation, and optimization finished without the previous font- or webpack-related errors). 
- Ran `pnpm lint`, which passed and did not report the duplicate-import or related issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d957bda850832090dbe2357ac22d09)