### PR TITLE
Fix mobile UI overflow & clipping on world-class homepage

### DIFF
--- a/src/components/homepage/world-class.css
+++ b/src/components/homepage/world-class.css
@@ -2230,6 +2230,156 @@
   }
 }
 
+/* ══════════════════════════════════════
+   MOBILE UI OVERFLOW + CLIPPING FIXES
+   (PR #66 follow-up hardening)
+══════════════════════════════════════ */
+
+/* 1) Hero headline overlap on mobile */
+@media (max-width: 768px) {
+  .wc-hero-h1 {
+    line-height: 1.14;
+    margin-bottom: 0;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+  .wc-hero-h1 .wc-hero-line,
+  .wc-hero-h1 .wc-sub-line {
+    position: relative;
+    z-index: 1;
+  }
+  .wc-hero-h1 .wc-sub-line {
+    line-height: 1.18;
+    margin-top: 6px;
+    padding-bottom: 0.08em;
+  }
+}
+
+/* 2) Search/filter panel horizontal overflow */
+@media (max-width: 768px) {
+  .wc-search-wrap,
+  .wc-search-outer,
+  .wc-s-suggestions {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+  .wc-search-outer {
+    overflow: hidden;
+    padding-inline: 12px;
+  }
+  .wc-search-outer input {
+    max-width: 100%;
+  }
+  .wc-s-loc,
+  .wc-btn-search {
+    min-width: 0;
+  }
+  .wc-s-suggestions {
+    left: 0;
+    right: 0;
+  }
+}
+
+/* 3) Therapist card clipping, especially CONTACT FOR PRICING */
+@media (max-width: 768px) {
+  .wc-t-grid {
+    gap: 14px;
+  }
+  .wc-tc {
+    min-width: 0;
+  }
+  .wc-tc-body {
+    min-width: 0;
+  }
+  .wc-tc-foot {
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .wc-tc-rating {
+    min-width: 0;
+    flex: 1 1 auto;
+  }
+  .wc-tc-price {
+    flex: 0 1 auto;
+    min-width: 0;
+    text-align: right;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    line-height: 1.35;
+  }
+}
+
+/* 4) FAQ accordion ghost text + clipped answers */
+.wc-faq-a {
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    max-height .45s var(--ease),
+    opacity .25s var(--ease2),
+    visibility .25s var(--ease2);
+  will-change: max-height;
+}
+.wc-faq-item.open .wc-faq-a {
+  max-height: 900px;
+  opacity: 1;
+  visibility: visible;
+}
+.wc-faq-a p {
+  margin: 0;
+}
+@media (max-width: 768px) {
+  .wc-faq-a p {
+    padding: 0 0 22px;
+    line-height: 1.72;
+  }
+}
+
+/* 5) Knotty chat contrast, mobile height, and scroll behavior */
+.wc-kg-status {
+  color: rgba(255,255,255,.62);
+}
+.wc-kg-messages {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,.25) transparent;
+  overscroll-behavior: contain;
+}
+@media (max-width: 768px) {
+  .wc-knotty-glass {
+    max-width: 100%;
+    min-height: 360px;
+  }
+  .wc-kg-messages {
+    min-height: 190px;
+    max-height: min(46vh, 360px);
+    -webkit-overflow-scrolling: touch;
+  }
+  .wc-kg-bubble {
+    max-width: 92%;
+  }
+}
+
+/* 6) Global .wc-home mobile overflow safety */
+@media (max-width: 768px) {
+  .wc-home {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: clip;
+  }
+  .wc-home *,
+  .wc-home *::before,
+  .wc-home *::after {
+    max-width: 100%;
+  }
+  .wc-home img,
+  .wc-home svg,
+  .wc-home video,
+  .wc-home canvas {
+    max-width: 100%;
+    height: auto;
+  }
+}
+
 /* Therapist section padding */
 @media (max-width: 768px) {
   .wc-ther-sec {


### PR DESCRIPTION
### Motivation
- Harden mobile presentation for the world-class homepage to eliminate headline overlap, horizontal bleed, clipped therapist info, FAQ ghosting/clipping, and Knotty chat UX issues without changing layout, copy, or brand colors.

### Description
- Added scoped CSS overrides in `src/components/homepage/world-class.css` to address mobile wrapping/overflow and clipping (no changes to `WorldClassHomepage.tsx`).
- Fixed hero headline stacking and wrapping by adjusting line-height, overflow-wrap, and sub-line spacing at mobile breakpoints.
- Constrained the search/filter panel and suggestions to full-width box-sizing and prevented horizontal overflow by limiting input/buttons and suggestion positioning.
- Prevented therapist card clipping (including long price text like "CONTACT FOR PRICING") by ensuring cards and footer items can shrink and wrapping price text.
- Resolved FAQ accordion ghosting/clipped answers by adding opacity/visibility transitions and increasing `max-height` for open items and mobile spacing.
- Improved Knotty chat contrast and mobile behavior by tweaking status color, scrollbar behavior, min/max heights, smooth scrolling, and bubble widths; added global `.wc-home` mobile overflow safety rules and media-query guards.

### Testing
- Ran `npm run lint` which completed successfully (exit 0) and reported 4 unrelated `react-hooks/exhaustive-deps` warnings in other files; no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd72c30cc8320bf4aa78abe0c3ab6)