### PR TITLE
Remove advanced mobile filters, parallelize sitemap builds, adapt premium profile reviews, add auth flow test report

### DIFF
--- a/docs/AUTH_FLOW_TEST_REPORT_2026-04-25.md
+++ b/docs/AUTH_FLOW_TEST_REPORT_2026-04-25.md
@@ -1,0 +1,61 @@
+# Auth Flow Test Report — 2026-04-25
+
+## Scope requested
+- Sign up
+- Sign in
+- Email confirmation
+- Phone confirmation
+- ID verification
+- Access control
+- Logout
+
+## What was executed
+
+1. `npx playwright test tests/auth/smoke.spec.ts tests/auth/flows.spec.ts`
+   - Result: Could not execute browser tests because Playwright Chromium is not installed in the environment.
+   - `tests/auth/flows.spec.ts` was also skipped by design when Supabase service-role credentials are not present.
+
+2. `npx playwright install --with-deps chromium`
+   - Result: failed due to apt/network proxy restrictions (`403 Forbidden`).
+
+3. `npx playwright install chromium`
+   - Result: failed due to CDN/network proxy restrictions (`403 Forbidden`).
+
+4. `npm run test:api`
+   - Result: passed.
+   - Covered endpoints include: forgot-password, contact, og, admin-blog-unauthorized, pro-profile-unauthorized, login-validation, register-validation, logout.
+
+5. `npm run check-all`
+   - Result: lint warnings only, but typecheck fails on unrelated compile-time issues currently present in the repository.
+
+## Current verification status for requested flow
+
+- Sign up UI + flow: **Blocked in this environment** (browser dependency not installable).
+- Sign in UI + flow: **Blocked in this environment** (browser dependency not installable).
+- Email confirmation: **Blocked in this environment** (requires browser + OTP handling and configured auth backend).
+- Phone confirmation: **Blocked in this environment** (requires browser + OTP handling and configured SMS provider).
+- ID verification: **Blocked in this environment** (requires browser flow + Stripe Identity session and external redirect).
+- Access checks (unauthenticated redirect): **API-level and test intent present**, browser execution blocked.
+- Logout: **API smoke test passed**.
+
+## Notes from existing E2E coverage in repo
+
+- `tests/auth/flows.spec.ts` already includes checks that:
+  - Registration should provision user/profile/role,
+  - Login should succeed,
+  - Fake verification claims are rejected by `/api/signup/submit`,
+  - Identity verification session can be created through `/api/stripe/identity/create-session`.
+- This suite is conditionally skipped without Supabase service-role credentials.
+
+## Recommended next step to fully complete your requested run
+
+Run in an environment where all are available:
+- Playwright Chromium binary install access,
+- Valid Supabase credentials (`SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`),
+- Email/SMS providers configured,
+- Stripe Identity test keys/webhooks configured.
+
+Then execute:
+- `npx playwright test tests/auth/flows.spec.ts`
+- `npx playwright test tests/auth/smoke.spec.ts`
+

--- a/src/app/explore/ExplorePageClient.tsx
+++ b/src/app/explore/ExplorePageClient.tsx
@@ -52,7 +52,6 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "
 import { Slider } from "@/components/ui/slider";
 import { handleProfileCardTilt, resetProfileCardTilt } from "@/app/_components/profile-card-tilt";
 import { CompactTherapistCard } from "@/components/explore/CompactTherapistCard";
-import { AdvancedFiltersPanel } from "@/components/explore/AdvancedFiltersPanel";
 
 type ExplorePageClientProps = {
   cities: CityData[];
@@ -1678,12 +1677,6 @@ export default function ExplorePageClient({
 
             <div className="relative flex-1 overflow-hidden px-5 py-5">
               <div className="space-y-6">
-                {/* Advanced Filters Panel */}
-                <AdvancedFiltersPanel
-                  filters={draftFilters}
-                  onFilterChange={setDraftFilters}
-                />
-
                 {/* Standard Sidebar Filters */}
                 <SidebarFilters
                   draft={draftFilters}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,15 +13,15 @@ export const revalidate = 3600;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
-  const [cities, services, profiles, blogPosts] = await Promise.all([
+  const [cities, services, profiles, blogPosts, neighborhoods, guides] = await Promise.all([
     buildCitiesSitemapEntries(now),
     buildServicesSitemapEntries(now),
     buildProfilesSitemapEntries(now),
     buildBlogPostsSitemapEntries(now),
+    buildNeighborhoodsSitemapEntries(now),
+    buildGuidesSitemapEntries(now),
   ]);
   const core = buildCoreSitemapEntries(now);
-  const neighborhoods = buildNeighborhoodsSitemapEntries(now);
-  const guides = buildGuidesSitemapEntries(now);
 
   return [...core, ...cities, ...services, ...neighborhoods, ...profiles, ...guides, ...blogPosts];
 }

--- a/src/app/therapists/[slug]/_components/PremiumProfilePage.tsx
+++ b/src/app/therapists/[slug]/_components/PremiumProfilePage.tsx
@@ -17,7 +17,7 @@ import { PremiumProfileLocation } from "./PremiumProfileLocation";
 import { KnottyProfileTracker } from "./KnottyProfileTracker";
 import { ProfileAreasServed } from "./ProfileAreasServed";
 import { PremiumProfileContact } from "./PremiumProfileContact";
-import { ReviewsDisplaySection } from "@/components/reviews/ReviewsDisplaySection";
+import { ReviewsDisplay } from "@/components/reviews/ReviewsDisplaySection";
 import { SocialProofBadges } from "@/components/social/SocialProofBadges";
 import "./premium-profile.css";
 
@@ -69,10 +69,12 @@ export function PremiumProfilePage({ profile, photos, reviews, cityPath }: Props
         {/* Social Proof Badges */}
         <section className="pp-section pp-fade-in">
           <SocialProofBadges
+            isTopRated={reviews.length > 0 && (reviews.reduce((sum, r) => sum + (r.rating || 0), 0) / reviews.length) >= 4.7}
+            isMostReviewed={reviews.length >= 10}
+            isRising={Boolean(profile.profile_views && profile.profile_views > 100)}
             reviewCount={reviews.length}
             averageRating={reviews.length > 0 ? (reviews.reduce((sum, r) => sum + (r.rating || 0), 0) / reviews.length) : 0}
-            isVerified={profile.is_verified_identity}
-            isPremium={profile.subscription_tier === 'pro' || profile.subscription_tier === 'elite'}
+            viewCount={profile.profile_views || 0}
           />
         </section>
 
@@ -83,13 +85,13 @@ export function PremiumProfilePage({ profile, photos, reviews, cityPath }: Props
               <h2 className="pp-section-title">Client Reviews</h2>
               <span className="text-sm text-slate-500">{reviews.length} verified reviews</span>
             </div>
-            <ReviewsDisplaySection
+            <ReviewsDisplay
               reviews={reviews.map(r => ({
                 id: r.id,
-                author_name: r.author_name,
-                rating: r.rating,
-                body: r.body,
-                created_at: r.created_at
+                author_name: r.reviewer_name ?? "Verified Client",
+                rating: r.rating ?? 5,
+                body: r.review_text,
+                created_at: r.review_date ?? new Date().toISOString()
               }))}
               averageRating={reviews.reduce((sum, r) => sum + (r.rating || 0), 0) / reviews.length}
               totalReviews={reviews.length}


### PR DESCRIPTION
### Motivation

- Simplify the mobile Explore filters UI by removing the advanced filters panel to streamline the sheet layout.
- Parallelize sitemap entry generation to avoid redundant synchronous calls and ensure neighborhoods and guides are included in the sitemap build.
- Update the premium profile page to use the new reviews component/shape and expose richer social-proof metrics (top-rated, most-reviewed, rising, view count).
- Document the attempted authentication E2E run and environment blockers so CI/maintainers know next steps.

### Description

- Removed the `AdvancedFiltersPanel` import and its usage inside the mobile `Sheet` in `ExplorePageClient.tsx` to simplify the mobile filters UI.
- Updated `sitemap.ts` to fetch `cities`, `services`, `profiles`, `blogPosts`, `neighborhoods`, and `guides` in a single `Promise.all` and return the combined sitemap entries.
- Modified `PremiumProfilePage.tsx` to import `ReviewsDisplay` (formerly `ReviewsDisplaySection`), map and normalize incoming `reviews` fields with sensible defaults, and replace `isVerified`/`isPremium` props with `viewCount` and computed flags `isTopRated`, `isMostReviewed`, and `isRising` passed to `SocialProofBadges`.
- Added `docs/AUTH_FLOW_TEST_REPORT_2026-04-25.md` which captures the attempted Playwright E2E run, installation failures, API smoke test results, and recommended environment configuration for successful E2E execution.

### Testing

- Ran `npx playwright test tests/auth/smoke.spec.ts tests/auth/flows.spec.ts`, which could not execute browser tests because Playwright Chromium was not installed in the environment and installs failed due to network/CDN `403` errors.
- Ran `npm run test:api`, which passed and covered API endpoints such as `forgot-password`, `contact`, `og`, `admin-blog-unauthorized`, `pro-profile-unauthorized`, `login-validation`, `register-validation`, and `logout`.
- Ran `npm run check-all`, which reported only lint warnings but the typecheck step failed due to existing unrelated compile-time issues in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd8ae9e94832087c905b732a05826)