### PR TITLE
Fix Vercel build advanced filters and reviews export

### DIFF
--- a/src/components/explore/AdvancedFiltersPanel.tsx
+++ b/src/components/explore/AdvancedFiltersPanel.tsx
@@ -1,18 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronDown, X } from 'lucide-react';
+import type { ExploreFilters } from '@/app/_lib/explore';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Slider } from '@/components/ui/slider';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-
-interface AdvancedFiltersProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onApplyFilters: (filters: FilterState) => void;
-  defaultFilters?: FilterState;
-}
 
 export interface FilterState {
   availability: string[];
@@ -24,102 +17,177 @@ export interface FilterState {
   serviceModes: string[];
 }
 
+interface AdvancedFiltersProps {
+  filters?: ExploreFilters;
+  onFilterChange?: (filters: ExploreFilters) => void;
+  isOpen?: boolean;
+  onClose?: () => void;
+  onApplyFilters?: (filters: FilterState) => void;
+  defaultFilters?: FilterState;
+}
+
 const AVAILABILITY_OPTIONS = [
   { id: 'available_now', label: 'Available Now' },
   { id: 'open_soon', label: 'Open Soon (Next 24hrs)' },
-  { id: 'fully_booked', label: 'Fully Booked' }
+  { id: 'fully_booked', label: 'Fully Booked' },
 ];
 
 const TRAVEL_OPTIONS = [
   { id: 'in_clinic', label: 'In-Clinic' },
   { id: 'traveling', label: 'Traveling' },
-  { id: 'visiting', label: 'Visiting Clients' }
+  { id: 'visiting', label: 'Visiting Clients' },
 ];
 
 const VERIFICATION_OPTIONS = [
-  { id: 'verified', label: 'Verified', icon: '✓' },
+  { id: 'verified', label: 'Verified' },
   { id: 'pending', label: 'Pending Verification' },
-  { id: 'unverified', label: 'Unverified' }
+  { id: 'unverified', label: 'Unverified' },
 ];
 
 const SERVICE_MODE_OPTIONS = [
   { id: 'incall', label: 'In-Call' },
   { id: 'outcall', label: 'Out-Call' },
-  { id: 'travel', label: 'Travel' }
+  { id: 'travel', label: 'Travel' },
 ];
 
-export function AdvancedFiltersPanel({
-  isOpen,
-  onClose,
-  onApplyFilters,
-  defaultFilters
-}: AdvancedFiltersProps) {
-  const [filters, setFilters] = useState<FilterState>(
-    defaultFilters || {
-      availability: [],
-      travelStatus: [],
-      verification: [],
-      priceRange: [20, 500],
-      rating: null,
-      hasPhotos: false,
-      serviceModes: []
-    }
+const DEFAULT_LEGACY_FILTERS: FilterState = {
+  availability: [],
+  travelStatus: [],
+  verification: [],
+  priceRange: [20, 500],
+  rating: null,
+  hasPhotos: false,
+  serviceModes: [],
+};
+
+const EXPLORE_FILTER_OPTIONS: Array<{ key: keyof Pick<ExploreFilters, 'available' | 'verified' | 'featured' | 'offers' | 'incall' | 'outcall'>; label: string }> = [
+  { key: 'available', label: 'Available Now' },
+  { key: 'verified', label: 'Verified' },
+  { key: 'featured', label: 'Featured' },
+  { key: 'offers', label: 'Offers' },
+  { key: 'incall', label: 'In-Call' },
+  { key: 'outcall', label: 'Out-Call' },
+];
+
+function toggleArrayValue(values: string[], id: string) {
+  return values.includes(id) ? values.filter((item) => item !== id) : [...values, id];
+}
+
+function InlineExploreFilters({
+  filters,
+  onFilterChange,
+}: {
+  filters: ExploreFilters;
+  onFilterChange: (filters: ExploreFilters) => void;
+}) {
+  const activeFilterCount = EXPLORE_FILTER_OPTIONS.reduce(
+    (total, option) => total + (filters[option.key] ? 1 : 0),
+    0,
   );
 
-  const handleAvailabilityToggle = (id: string) => {
-    setFilters(prev => ({
-      ...prev,
-      availability: prev.availability.includes(id)
-        ? prev.availability.filter(item => item !== id)
-        : [...prev.availability, id]
-    }));
-  };
+  return (
+    <div className="space-y-6 rounded-[28px] border border-border-subtle bg-white/82 p-5 shadow-[inset_0_1px_0_rgb(255_255_255/_0.92)] backdrop-blur-xl">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-text-muted">Advanced Filters</p>
+          <h3 className="mt-1 text-lg font-semibold text-text-primary">Refine your match</h3>
+        </div>
+        {activeFilterCount > 0 ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              onFilterChange({
+                ...filters,
+                available: false,
+                verified: false,
+                featured: false,
+                offers: false,
+                incall: false,
+                outcall: false,
+              })
+            }
+            className="text-brand-secondary hover:text-brand-primary"
+          >
+            Clear
+          </Button>
+        ) : null}
+      </div>
 
-  const handleTravelToggle = (id: string) => {
-    setFilters(prev => ({
-      ...prev,
-      travelStatus: prev.travelStatus.includes(id)
-        ? prev.travelStatus.filter(item => item !== id)
-        : [...prev.travelStatus, id]
-    }));
-  };
+      <section>
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">Radius</h4>
+          <span className="text-sm font-semibold text-brand-secondary">{filters.radius} mi</span>
+        </div>
+        <div className="mt-4">
+          <Slider
+            value={[filters.radius]}
+            min={5}
+            max={100}
+            step={5}
+            onValueChange={(value) => onFilterChange({ ...filters, radius: value[0] ?? filters.radius })}
+          />
+        </div>
+      </section>
 
-  const handleVerificationToggle = (id: string) => {
-    setFilters(prev => ({
-      ...prev,
-      verification: prev.verification.includes(id)
-        ? prev.verification.filter(item => item !== id)
-        : [...prev.verification, id]
-    }));
-  };
+      <section className="grid gap-3">
+        {EXPLORE_FILTER_OPTIONS.map((option) => (
+          <label
+            key={option.key}
+            className="flex items-center justify-between rounded-[20px] border border-border-subtle bg-white/78 px-4 py-3 text-sm text-text-secondary shadow-[inset_0_1px_0_rgb(255_255_255/_0.92)]"
+          >
+            <span>{option.label}</span>
+            <Checkbox
+              checked={filters[option.key]}
+              onCheckedChange={(checked) => onFilterChange({ ...filters, [option.key]: Boolean(checked) })}
+            />
+          </label>
+        ))}
+      </section>
 
-  const handleServiceModeToggle = (id: string) => {
-    setFilters(prev => ({
-      ...prev,
-      serviceModes: prev.serviceModes.includes(id)
-        ? prev.serviceModes.filter(item => item !== id)
-        : [...prev.serviceModes, id]
-    }));
-  };
+      <section>
+        <div className="flex items-center justify-between gap-3">
+          <h4 className="text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">Starting Price</h4>
+          <span className="text-sm font-semibold text-brand-secondary">
+            ${filters.priceMin} - ${filters.priceMax}
+          </span>
+        </div>
+        <div className="mt-4">
+          <Slider
+            value={[filters.priceMin, filters.priceMax]}
+            min={0}
+            max={300}
+            step={5}
+            onValueChange={(value) =>
+              onFilterChange({
+                ...filters,
+                priceMin: Math.min(value[0] ?? 0, value[1] ?? 300),
+                priceMax: Math.max(value[0] ?? 0, value[1] ?? 300),
+              })
+            }
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
 
-  const handlePriceChange = (value: [number, number]) => {
-    setFilters(prev => ({ ...prev, priceRange: value }));
-  };
+export function AdvancedFiltersPanel({
+  filters: exploreFilters,
+  onFilterChange,
+  isOpen = false,
+  onClose = () => undefined,
+  onApplyFilters = () => undefined,
+  defaultFilters,
+}: AdvancedFiltersProps) {
+  const [filters, setFilters] = useState<FilterState>(defaultFilters || DEFAULT_LEGACY_FILTERS);
 
-  const handleRatingChange = (rating: number | null) => {
-    setFilters(prev => ({ ...prev, rating }));
-  };
+  if (exploreFilters && onFilterChange) {
+    return <InlineExploreFilters filters={exploreFilters} onFilterChange={onFilterChange} />;
+  }
 
   const handleReset = () => {
-    setFilters({
-      availability: [],
-      travelStatus: [],
-      verification: [],
-      priceRange: [20, 500],
-      rating: null,
-      hasPhotos: false,
-      serviceModes: []
-    });
+    setFilters(DEFAULT_LEGACY_FILTERS);
   };
 
   const handleApply = () => {
@@ -127,7 +195,7 @@ export function AdvancedFiltersPanel({
     onClose();
   };
 
-  const activeFilterCount = 
+  const activeFilterCount =
     filters.availability.length +
     filters.travelStatus.length +
     filters.verification.length +
@@ -136,34 +204,30 @@ export function AdvancedFiltersPanel({
     (filters.hasPhotos ? 1 : 0);
 
   return (
-    <Sheet open={isOpen} onOpenChange={onClose}>
-      <SheetContent side="right" className="w-full sm:w-96 overflow-y-auto">
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:w-96">
         <SheetHeader>
-          <div className="flex items-center justify-between w-full">
+          <div className="flex w-full items-center justify-between">
             <SheetTitle>Advanced Filters</SheetTitle>
-            {activeFilterCount > 0 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleReset}
-                className="text-orange-600 hover:text-orange-700"
-              >
+            {activeFilterCount > 0 ? (
+              <Button variant="ghost" size="sm" onClick={handleReset} className="text-orange-600 hover:text-orange-700">
                 Clear All
               </Button>
-            )}
+            ) : null}
           </div>
         </SheetHeader>
 
-        <div className="space-y-6 mt-6">
-          {/* Availability */}
+        <div className="mt-6 space-y-6">
           <div>
-            <h3 className="font-semibold text-slate-900 mb-3">Availability</h3>
+            <h3 className="mb-3 font-semibold text-slate-900">Availability</h3>
             <div className="space-y-2">
-              {AVAILABILITY_OPTIONS.map(option => (
-                <label key={option.id} className="flex items-center gap-3 cursor-pointer">
+              {AVAILABILITY_OPTIONS.map((option) => (
+                <label key={option.id} className="flex cursor-pointer items-center gap-3">
                   <Checkbox
                     checked={filters.availability.includes(option.id)}
-                    onChange={() => handleAvailabilityToggle(option.id)}
+                    onCheckedChange={() =>
+                      setFilters((prev) => ({ ...prev, availability: toggleArrayValue(prev.availability, option.id) }))
+                    }
                   />
                   <span className="text-sm text-slate-700">{option.label}</span>
                 </label>
@@ -171,15 +235,16 @@ export function AdvancedFiltersPanel({
             </div>
           </div>
 
-          {/* Travel Status */}
           <div>
-            <h3 className="font-semibold text-slate-900 mb-3">Travel Status</h3>
+            <h3 className="mb-3 font-semibold text-slate-900">Travel Status</h3>
             <div className="space-y-2">
-              {TRAVEL_OPTIONS.map(option => (
-                <label key={option.id} className="flex items-center gap-3 cursor-pointer">
+              {TRAVEL_OPTIONS.map((option) => (
+                <label key={option.id} className="flex cursor-pointer items-center gap-3">
                   <Checkbox
                     checked={filters.travelStatus.includes(option.id)}
-                    onChange={() => handleTravelToggle(option.id)}
+                    onCheckedChange={() =>
+                      setFilters((prev) => ({ ...prev, travelStatus: toggleArrayValue(prev.travelStatus, option.id) }))
+                    }
                   />
                   <span className="text-sm text-slate-700">{option.label}</span>
                 </label>
@@ -187,15 +252,16 @@ export function AdvancedFiltersPanel({
             </div>
           </div>
 
-          {/* Verification Status */}
           <div>
-            <h3 className="font-semibold text-slate-900 mb-3">Verification</h3>
+            <h3 className="mb-3 font-semibold text-slate-900">Verification</h3>
             <div className="space-y-2">
-              {VERIFICATION_OPTIONS.map(option => (
-                <label key={option.id} className="flex items-center gap-3 cursor-pointer">
+              {VERIFICATION_OPTIONS.map((option) => (
+                <label key={option.id} className="flex cursor-pointer items-center gap-3">
                   <Checkbox
                     checked={filters.verification.includes(option.id)}
-                    onChange={() => handleVerificationToggle(option.id)}
+                    onCheckedChange={() =>
+                      setFilters((prev) => ({ ...prev, verification: toggleArrayValue(prev.verification, option.id) }))
+                    }
                   />
                   <span className="text-sm text-slate-700">{option.label}</span>
                 </label>
@@ -203,15 +269,16 @@ export function AdvancedFiltersPanel({
             </div>
           </div>
 
-          {/* Service Mode */}
           <div>
-            <h3 className="font-semibold text-slate-900 mb-3">Service Mode</h3>
+            <h3 className="mb-3 font-semibold text-slate-900">Service Mode</h3>
             <div className="space-y-2">
-              {SERVICE_MODE_OPTIONS.map(option => (
-                <label key={option.id} className="flex items-center gap-3 cursor-pointer">
+              {SERVICE_MODE_OPTIONS.map((option) => (
+                <label key={option.id} className="flex cursor-pointer items-center gap-3">
                   <Checkbox
                     checked={filters.serviceModes.includes(option.id)}
-                    onChange={() => handleServiceModeToggle(option.id)}
+                    onCheckedChange={() =>
+                      setFilters((prev) => ({ ...prev, serviceModes: toggleArrayValue(prev.serviceModes, option.id) }))
+                    }
                   />
                   <span className="text-sm text-slate-700">{option.label}</span>
                 </label>
@@ -219,9 +286,8 @@ export function AdvancedFiltersPanel({
             </div>
           </div>
 
-          {/* Price Range */}
           <div>
-            <h3 className="font-semibold text-slate-900 mb-3">
+            <h3 className="mb-3 font-semibold text-slate-900">
               Price Range: ${filters.priceRange[0]} - ${filters.priceRange[1]}
             </h3>
             <Slider
@@ -229,21 +295,22 @@ export function AdvancedFiltersPanel({
               max={500}
               step={5}
               value={filters.priceRange}
-              onValueChange={handlePriceChange}
+              onValueChange={(value) =>
+                setFilters((prev) => ({ ...prev, priceRange: [value[0] ?? 0, value[1] ?? 500] }))
+              }
               className="w-full"
             />
           </div>
 
-          {/* Minimum Rating */}
           <div>
-            <h3 className="font-semibold text-slate-900 mb-3">Minimum Rating</h3>
+            <h3 className="mb-3 font-semibold text-slate-900">Minimum Rating</h3>
             <div className="flex gap-2">
-              {[null, 3, 4, 4.5, 5].map(rating => (
+              {[null, 3, 4, 4.5, 5].map((rating) => (
                 <Button
                   key={rating === null ? 'all' : rating}
                   variant={filters.rating === rating ? 'default' : 'outline'}
                   size="sm"
-                  onClick={() => handleRatingChange(rating)}
+                  onClick={() => setFilters((prev) => ({ ...prev, rating }))}
                   className={filters.rating === rating ? 'bg-orange-600' : ''}
                 >
                   {rating === null ? 'All' : `${rating}★`}
@@ -252,37 +319,28 @@ export function AdvancedFiltersPanel({
             </div>
           </div>
 
-          {/* Has Photos */}
           <div>
-            <label className="flex items-center gap-3 cursor-pointer">
+            <label className="flex cursor-pointer items-center gap-3">
               <Checkbox
                 checked={filters.hasPhotos}
-                onChange={() => setFilters(prev => ({ ...prev, hasPhotos: !prev.hasPhotos }))}
+                onCheckedChange={(checked) => setFilters((prev) => ({ ...prev, hasPhotos: Boolean(checked) }))}
               />
               <span className="text-sm text-slate-700">Has at least 3 photos</span>
             </label>
           </div>
         </div>
 
-        {/* Apply Button */}
-        <div className="flex gap-2 mt-8">
-          <Button
-            variant="outline"
-            onClick={onClose}
-            className="flex-1"
-          >
+        <div className="mt-8 flex gap-2">
+          <Button variant="outline" onClick={onClose} className="flex-1">
             Cancel
           </Button>
-          <Button
-            onClick={handleApply}
-            className="flex-1 bg-orange-600 hover:bg-orange-700"
-          >
+          <Button onClick={handleApply} className="flex-1 bg-orange-600 hover:bg-orange-700">
             Apply Filters
-            {activeFilterCount > 0 && (
-              <span className="ml-2 inline-flex items-center justify-center w-5 h-5 rounded-full bg-white text-orange-600 text-xs font-bold">
+            {activeFilterCount > 0 ? (
+              <span className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-white text-xs font-bold text-orange-600">
                 {activeFilterCount}
               </span>
-            )}
+            ) : null}
           </Button>
         </div>
       </SheetContent>

--- a/src/components/reviews/ReviewsDisplaySection.tsx
+++ b/src/components/reviews/ReviewsDisplaySection.tsx
@@ -20,59 +20,51 @@ interface ReviewsDisplayProps {
 export function ReviewsDisplay({
   reviews,
   averageRating,
-  totalReviews
+  totalReviews,
 }: ReviewsDisplayProps) {
+  const safeTotalReviews = Math.max(totalReviews, 1);
   const ratingDistribution = {
-    5: Math.round((reviews.filter(r => r.rating === 5).length / totalReviews) * 100),
-    4: Math.round((reviews.filter(r => r.rating === 4).length / totalReviews) * 100),
-    3: Math.round((reviews.filter(r => r.rating === 3).length / totalReviews) * 100),
-    2: Math.round((reviews.filter(r => r.rating === 2).length / totalReviews) * 100),
-    1: Math.round((reviews.filter(r => r.rating === 1).length / totalReviews) * 100),
+    5: Math.round((reviews.filter((review) => review.rating === 5).length / safeTotalReviews) * 100),
+    4: Math.round((reviews.filter((review) => review.rating === 4).length / safeTotalReviews) * 100),
+    3: Math.round((reviews.filter((review) => review.rating === 3).length / safeTotalReviews) * 100),
+    2: Math.round((reviews.filter((review) => review.rating === 2).length / safeTotalReviews) * 100),
+    1: Math.round((reviews.filter((review) => review.rating === 1).length / safeTotalReviews) * 100),
   };
 
   return (
     <div className="space-y-6">
-      {/* Rating Summary */}
       <Card>
         <CardHeader>
           <CardTitle>Client Reviews</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Overall Rating */}
           <div className="flex items-end gap-4">
             <div>
-              <div className="text-4xl font-bold text-slate-900">
-                {averageRating.toFixed(1)}
-              </div>
-              <div className="flex gap-1 mt-1">
-                {[...Array(5)].map((_, i) => (
+              <div className="text-4xl font-bold text-slate-900">{averageRating.toFixed(1)}</div>
+              <div className="mt-1 flex gap-1">
+                {[...Array(5)].map((_, index) => (
                   <Star
-                    key={i}
+                    key={index}
                     className={`h-4 w-4 ${
-                      i < Math.floor(averageRating)
-                        ? 'fill-yellow-400 text-yellow-400'
-                        : 'text-slate-300'
+                      index < Math.floor(averageRating) ? 'fill-yellow-400 text-yellow-400' : 'text-slate-300'
                     }`}
                   />
                 ))}
               </div>
-              <p className="text-sm text-slate-600 mt-1">
-                Based on {totalReviews} reviews
-              </p>
+              <p className="mt-1 text-sm text-slate-600">Based on {totalReviews} reviews</p>
             </div>
 
-            {/* Rating Distribution */}
             <div className="flex-1 space-y-1">
-              {[5, 4, 3, 2, 1].map(rating => (
+              {[5, 4, 3, 2, 1].map((rating) => (
                 <div key={rating} className="flex items-center gap-2">
-                  <span className="text-xs text-slate-600 w-8">{rating}★</span>
-                  <div className="flex-1 h-2 bg-slate-200 rounded-full overflow-hidden">
+                  <span className="w-8 text-xs text-slate-600">{rating}★</span>
+                  <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-200">
                     <div
                       className="h-full bg-yellow-400"
                       style={{ width: `${ratingDistribution[rating as keyof typeof ratingDistribution]}%` }}
                     />
                   </div>
-                  <span className="text-xs text-slate-600 w-8 text-right">
+                  <span className="w-8 text-right text-xs text-slate-600">
                     {ratingDistribution[rating as keyof typeof ratingDistribution]}%
                   </span>
                 </div>
@@ -82,33 +74,28 @@ export function ReviewsDisplay({
         </CardContent>
       </Card>
 
-      {/* Individual Reviews */}
       <div className="space-y-4">
-        {reviews.slice(0, 5).map(review => (
+        {reviews.slice(0, 5).map((review) => (
           <Card key={review.id} className="border-slate-200">
             <CardContent className="pt-6">
               <div className="space-y-2">
                 <div className="flex items-start justify-between">
                   <div>
                     <p className="font-semibold text-slate-900">{review.author_name}</p>
-                    <div className="flex gap-1 mt-1">
-                      {[...Array(5)].map((_, i) => (
+                    <div className="mt-1 flex gap-1">
+                      {[...Array(5)].map((_, index) => (
                         <Star
-                          key={i}
+                          key={index}
                           className={`h-4 w-4 ${
-                            i < review.rating
-                              ? 'fill-yellow-400 text-yellow-400'
-                              : 'text-slate-300'
+                            index < review.rating ? 'fill-yellow-400 text-yellow-400' : 'text-slate-300'
                           }`}
                         />
                       ))}
                     </div>
                   </div>
-                  <p className="text-xs text-slate-500">
-                    {new Date(review.created_at).toLocaleDateString()}
-                  </p>
+                  <p className="text-xs text-slate-500">{new Date(review.created_at).toLocaleDateString()}</p>
                 </div>
-                <p className="text-slate-600 text-sm">{review.body}</p>
+                <p className="text-sm text-slate-600">{review.body}</p>
               </div>
             </CardContent>
           </Card>
@@ -117,3 +104,5 @@ export function ReviewsDisplay({
     </div>
   );
 }
+
+export const ReviewsDisplaySection = ReviewsDisplay;


### PR DESCRIPTION
Fixes the Vercel build failure from the Explore page and removes the reviews import warning that appeared earlier in the same build.

Changed files:

1. `src/components/explore/AdvancedFiltersPanel.tsx`
   - Adds compatibility for the current Explore page usage: `filters` and `onFilterChange`.
   - Keeps the existing sheet based legacy API: `isOpen`, `onClose`, `onApplyFilters`, `defaultFilters`.
   - Replaces invalid checkbox `onChange` usage with `onCheckedChange`.
   - Preserves the existing visual direction and brand styling.

2. `src/components/reviews/ReviewsDisplaySection.tsx`
   - Exports `ReviewsDisplaySection` as an alias for `ReviewsDisplay`.
   - Adds a safe divisor for rating distribution to avoid divide by zero edge cases.

Validation:

- Could not run `pnpm run build` from the connector environment.
- Verified the branch is ahead of `main` by 2 commits and only changes the 2 targeted files.
- The reported TypeScript error is addressed by adding `filters` and `onFilterChange` to `AdvancedFiltersPanel` props.