### PR TITLE
Add placeholder GEMINI_API_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ NEXT_PUBLIC_VAPID_PUBLIC_KEY=             # [OPTIONAL] browser push notification
 VAPID_PRIVATE_KEY=                        # [OPTIONAL] browser push notifications
 
 # ── AI / Content moderation ───────────────────────────────────────────────────
-GEMINI_API_KEY=                           # [OPTIONAL] Gemini AI features
+GEMINI_API_KEY=your_gemini_api_key_here
 GOOGLE_API_KEY=                           # [OPTIONAL] Google APIs
 SIGHTENGINE_API_USER=                     # [OPTIONAL] photo moderation
 SIGHTENGINE_API_SECRET=                   # [OPTIONAL] photo moderation


### PR DESCRIPTION
### Motivation
- Make it obvious to developers that they need to set `GEMINI_API_KEY` by adding a visible placeholder in `.env.example`.

### Description
- Update `.env.example` to set `GEMINI_API_KEY=your_gemini_api_key_here` instead of leaving it blank.

### Testing
- No automated tests were run for this configuration/example file change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a9b4140483208645b8c966203757)