### PR TITLE
Fix Stripe identity verification schema compatibility

### DIFF
--- a/src/app/api/admin/reports/route.ts
+++ b/src/app/api/admin/reports/route.ts
@@ -66,7 +66,7 @@ export async function GET(request: Request) {
     const { count: completedVerifications } = await adminClient
       .from("identity_verifications")
       .select("id", { count: "exact", head: true })
-      .eq("status", "verified");
+      .eq("status", "approved");
 
     return json({
       ok: true,

--- a/src/app/api/stripe/identity/check-status/route.ts
+++ b/src/app/api/stripe/identity/check-status/route.ts
@@ -30,10 +30,10 @@ function getStripe(request: NextRequest) {
 }
 
 function mapVerificationStatus(status: Stripe.Identity.VerificationSession.Status) {
-  if (status === "verified") return "verified";
-  if (status === "processing") return "processing";
+  if (status === "verified") return "approved";
+  if (status === "processing") return "reviewing";
   if (status === "canceled") return "expired";
-  return "failed";
+  return "rejected";
 }
 
 export async function GET(request: NextRequest) {
@@ -57,10 +57,13 @@ export async function GET(request: NextRequest) {
         .maybeSingle();
 
       if (mockError) {
-        return NextResponse.json({ error: mockError.message }, { status: 500 });
+        const isSchemaCacheColumnError = /schema cache|column .* does not exist/i.test(mockError.message);
+        if (!isSchemaCacheColumnError) {
+          return NextResponse.json({ error: mockError.message }, { status: 500 });
+        }
       }
 
-      const userId = mockRow?.user_id ?? null;
+      const userId = mockRow?.user_id ?? requester.userId;
       if (!userId) {
         return NextResponse.json({ error: "Verification session not found." }, { status: 404 });
       }
@@ -69,7 +72,7 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: "Forbidden." }, { status: 403 });
       }
 
-      const mockStatus = mockRow?.status === "verified" ? "verified" : "processing";
+      const mockStatus = mockRow?.status === "approved" ? "verified" : "processing";
 
       if (mockStatus === "verified") {
         await adminClient
@@ -97,10 +100,19 @@ export async function GET(request: NextRequest) {
     }
     const dbStatus = mapVerificationStatus(stripeSession.status);
 
-    await adminClient
+    const { error: verificationUpdateError } = await adminClient
       .from("identity_verifications")
       .update({ status: dbStatus })
       .eq("stripe_session_id", sessionId);
+
+    if (verificationUpdateError) {
+      const isSchemaCacheColumnError = /schema cache|column .* does not exist/i.test(
+        verificationUpdateError.message,
+      );
+      if (!isSchemaCacheColumnError) {
+        throw new Error(verificationUpdateError.message);
+      }
+    }
 
     if (stripeSession.status === "verified") {
       await adminClient

--- a/src/app/api/stripe/identity/create-session/route.ts
+++ b/src/app/api/stripe/identity/create-session/route.ts
@@ -128,7 +128,17 @@ export async function POST(request: NextRequest) {
       });
 
       if (insertError) {
-        throw new Error(insertError.message);
+        const isLegacySchemaConstraintError =
+          /not-null|null value|violates check constraint|column .* does not exist/i.test(insertError.message);
+
+        if (!isLegacySchemaConstraintError) {
+          throw new Error(insertError.message);
+        }
+
+        console.warn("identity_verifications insert skipped due to schema mismatch", {
+          message: insertError.message,
+          code: insertError.code,
+        });
       }
     }
 

--- a/supabase/migrations/20260428133000_identity_verification_stripe_columns.sql
+++ b/supabase/migrations/20260428133000_identity_verification_stripe_columns.sql
@@ -1,0 +1,9 @@
+-- Ensure Stripe Identity fields exist for API routes
+ALTER TABLE public.identity_verifications
+  ADD COLUMN IF NOT EXISTS stripe_session_id text,
+  ADD COLUMN IF NOT EXISTS stripe_verification_report_id text;
+
+-- Avoid duplicate Stripe sessions per verification row when present
+CREATE UNIQUE INDEX IF NOT EXISTS idx_identity_verifications_stripe_session_id
+  ON public.identity_verifications (stripe_session_id)
+  WHERE stripe_session_id IS NOT NULL;


### PR DESCRIPTION
### Motivation
- Stripe identity verification flows were failing in environments where the `identity_verifications` table was missing Stripe columns, causing errors like "Could not find the 'stripe_session_id' column" and blocking signup verification.
- The change aims to make the verification endpoints tolerant of legacy schemas until migrations are applied across environments.

### Description
- Add a Supabase migration `supabase/migrations/20260428133000_identity_verification_stripe_columns.sql` that adds `stripe_session_id` and `stripe_verification_report_id` with `IF NOT EXISTS` and creates a partial unique index on `stripe_session_id`.
- Harden `/api/stripe/identity/create-session` to avoid failing the whole flow when inserting into `identity_verifications` errors due to legacy schema constraints by detecting schema-related insert errors and continuing while logging a warning.
- Harden `/api/stripe/identity/check-status` to tolerate schema-cache/column-missing errors when selecting or updating by `stripe_session_id`, to fallback to the requester user when appropriate, and to surface Stripe-to-DB status mapping consistent with the table semantics.
- Update admin reporting in `src/app/api/admin/reports/route.ts` to count completed identity verifications using the `approved` status instead of `verified`.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c7c779d88320a09b0294faeab232)