### PR TITLE
Revamp Knotty chat UI and switch to deterministic internal replies

### DIFF
--- a/src/app/therapists/[slug]/_components/ProfileAIChat.tsx
+++ b/src/app/therapists/[slug]/_components/ProfileAIChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Sparkles, X, Send, ChevronRight } from "lucide-react";
+import { Sparkles, X, Send, Radio } from "lucide-react";
 import type { PublicTherapist } from "@/app/_lib/directory";
 import { getPublicProfileName } from "@/app/_lib/public-profile";
 
@@ -35,6 +35,7 @@ export function ProfileAIChat({ profile }: Props) {
     `Does ${name} offer outcall?`,
     `What specialties does ${name} have?`,
     `Is ${name} LGBTQ+ affirming?`,
+    `Can you find similar masseurs on the website?`,
   ];
 
   // Generate AI response based on profile data
@@ -77,6 +78,10 @@ export function ProfileAIChat({ profile }: Props) {
     
     if (q.includes("book") || q.includes("schedule") || q.includes("appointment") || q.includes("reserve")) {
       return `To contact ${name}, you can:\n\n1. Send a text message using the "Contact" button\n2. Call directly using the phone button\n3. Message on WhatsApp\n\nReach out to discuss availability and services directly with ${name}.`;
+    }
+
+    if (q.includes("find") || q.includes("search") || q.includes("similar") || q.includes("website")) {
+      return `Yes — I can help you search masseurs inside Masseurfinder. Start with /search?city=${encodeURIComponent(city)} and filter by specialties, verified profiles, and availability. If you tell me your budget and preferred technique, I can suggest what filters to apply.`;
     }
     
     if (q.includes("experience") || q.includes("how long") || q.includes("years")) {
@@ -156,38 +161,39 @@ export function ProfileAIChat({ profile }: Props) {
 
       {/* Chat Panel */}
       {isOpen && (
-        <div className="fixed bottom-6 right-6 z-50 flex flex-col w-[380px] h-[520px] rounded-[24px] border border-white/10 bg-[#0B1F3A]/95 backdrop-blur-xl shadow-2xl overflow-hidden">
+        <div className="fixed bottom-6 right-6 z-50 flex h-[520px] w-[380px] flex-col overflow-hidden rounded-[24px] border border-sky-200 bg-[linear-gradient(180deg,#f8fcff_0%,#eef6ff_55%,#e0f0ff_100%)] shadow-[0_24px_68px_rgba(14,116,144,0.24)] backdrop-blur-xl">
           {/* Header */}
-          <div className="flex items-center justify-between px-5 py-4 border-b border-white/10 bg-gradient-to-r from-[#FF8A1F]/10 to-transparent">
+          <div className="flex items-center justify-between border-b border-sky-100 bg-white/75 px-5 py-4">
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#FF8A1F] to-[#ff6b00] flex items-center justify-center">
-                <Sparkles className="w-5 h-5 text-[#0B1F3A]" />
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-sky-400 to-cyan-300">
+                <Sparkles className="h-5 w-5 text-sky-900" />
               </div>
               <div>
-                <p className="text-sm font-bold text-white">Knotty AI</p>
-                <p className="text-xs text-white/50 flex items-center gap-1.5">
-                  <span className="w-2 h-2 rounded-full bg-[#2ECC8A] animate-pulse" />
+                <p className="text-sm font-bold text-slate-900">Knotty • {name}</p>
+                <p className="flex items-center gap-1.5 text-xs text-sky-700">
+                  <Radio className="h-3.5 w-3.5" />
+                  <span className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
                   Ask about {name}
                 </p>
               </div>
             </div>
             <button
               onClick={() => setIsOpen(false)}
-              className="w-8 h-8 rounded-full flex items-center justify-center hover:bg-white/10 transition"
+              className="flex h-8 w-8 items-center justify-center rounded-full transition hover:bg-sky-100"
             >
-              <X className="w-4 h-4 text-white/60" />
+              <X className="h-4 w-4 text-sky-700" />
             </button>
           </div>
 
           {/* Messages */}
-          <div ref={scrollRef} className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
             {messages.map((msg) => (
               <div
                 key={msg.id}
                 className={`max-w-[85%] rounded-[18px] px-4 py-3 text-sm leading-relaxed whitespace-pre-line ${
                   msg.role === "ai"
-                    ? "mr-auto bg-white/8 text-white/90 border border-white/5"
-                    : "ml-auto bg-gradient-to-r from-[#FF8A1F] to-[#ff6b00] text-white"
+                    ? "mr-auto border border-sky-100 bg-white/95 text-slate-800"
+                    : "ml-auto bg-gradient-to-r from-sky-500 to-cyan-400 text-white"
                 }`}
               >
                 {msg.text}
@@ -195,11 +201,11 @@ export function ProfileAIChat({ profile }: Props) {
             ))}
             
             {isTyping && (
-              <div className="mr-auto max-w-[85%] rounded-[18px] bg-white/8 border border-white/5 px-4 py-3">
+              <div className="mr-auto max-w-[85%] rounded-[18px] border border-sky-100 bg-white/95 px-4 py-3">
                 <div className="flex gap-1.5">
-                  <span className="w-2 h-2 rounded-full bg-white/40 animate-bounce" style={{ animationDelay: "0ms" }} />
-                  <span className="w-2 h-2 rounded-full bg-white/40 animate-bounce" style={{ animationDelay: "150ms" }} />
-                  <span className="w-2 h-2 rounded-full bg-white/40 animate-bounce" style={{ animationDelay: "300ms" }} />
+                  <span className="h-2 w-2 rounded-full bg-sky-400 animate-bounce" style={{ animationDelay: "0ms" }} />
+                  <span className="h-2 w-2 rounded-full bg-sky-400 animate-bounce" style={{ animationDelay: "150ms" }} />
+                  <span className="h-2 w-2 rounded-full bg-sky-400 animate-bounce" style={{ animationDelay: "300ms" }} />
                 </div>
               </div>
             )}
@@ -208,13 +214,13 @@ export function ProfileAIChat({ profile }: Props) {
           {/* Quick Questions */}
           {messages.length <= 1 && (
             <div className="px-5 pb-3 space-y-2">
-              <p className="text-[10px] text-white/40 uppercase tracking-wider">Quick questions</p>
+              <p className="text-[10px] uppercase tracking-wider text-sky-700/70">Quick questions</p>
               <div className="flex flex-wrap gap-2">
                 {QUICK_QUESTIONS.map((q) => (
                   <button
                     key={q}
                     onClick={() => handleQuickQuestion(q)}
-                    className="text-xs px-3 py-1.5 rounded-full border border-white/10 bg-white/5 text-white/70 hover:bg-white/10 hover:text-white transition"
+                    className="rounded-full border border-sky-200 bg-white px-3 py-1.5 text-xs text-sky-700 transition hover:bg-sky-50 hover:text-sky-900"
                   >
                     {q}
                   </button>
@@ -224,7 +230,7 @@ export function ProfileAIChat({ profile }: Props) {
           )}
 
           {/* Input */}
-          <div className="px-4 py-4 border-t border-white/10 bg-white/[0.02]">
+          <div className="border-t border-sky-100 bg-white/70 px-4 py-4">
             <div className="flex items-center gap-3">
               <input
                 type="text"
@@ -232,14 +238,14 @@ export function ProfileAIChat({ profile }: Props) {
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleSend()}
                 placeholder={`Ask about ${name}...`}
-                className="flex-1 bg-white/8 border border-white/10 rounded-full px-4 py-2.5 text-sm text-white placeholder:text-white/40 focus:outline-none focus:border-[#FF8A1F]/50"
+                className="flex-1 rounded-full border border-sky-200 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none"
               />
               <button
                 onClick={handleSend}
                 disabled={!input.trim()}
-                className="w-10 h-10 rounded-full bg-[#FF8A1F] flex items-center justify-center disabled:opacity-40 transition hover:bg-[#ff9d3f]"
+                className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-600 transition hover:bg-sky-700 disabled:opacity-40"
               >
-                <Send className="w-4 h-4 text-[#0B1F3A]" />
+                <Send className="h-4 w-4 text-white" />
               </button>
             </div>
           </div>

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -20,7 +20,7 @@ function TypingDots() {
       {[0, 1, 2].map((index) => (
         <span
           key={index}
-          className="h-2 w-2 animate-pulse rounded-full bg-white/70"
+          className="h-2 w-2 animate-pulse rounded-full bg-sky-500/80"
           style={{ animationDelay: `${index * 120}ms` }}
         />
       ))}
@@ -42,37 +42,37 @@ function RecommendationCard({
       className={cn(
         "rounded-[20px] border px-4 py-4 backdrop-blur-2xl",
         featured
-          ? "border-white/18 bg-white/14 text-white shadow-[0_22px_48px_rgba(0,0,0,0.18)]"
-          : "border-white/12 bg-white/[0.08] text-white/88",
+          ? "border-sky-200 bg-white text-slate-800 shadow-[0_16px_34px_rgba(14,116,144,0.16)]"
+          : "border-sky-100 bg-sky-50/70 text-slate-700",
       )}
     >
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-700/80">
             {featured ? "Top Match" : `Alternative ${recommendation.position}`}
           </p>
           <h3 className="mt-1 text-lg font-semibold">{recommendation.name}</h3>
-          <p className="mt-1 text-sm text-white/72">
+          <p className="mt-1 text-sm text-slate-600">
             {recommendation.neighborhood || recommendation.city || "Local area"} · {recommendation.specialty}
           </p>
         </div>
         {recommendation.verified ? (
-          <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-white/18 bg-white/12 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em]">
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-emerald-700">
             <ShieldCheck className="h-3.5 w-3.5" />
             Verified
           </span>
         ) : null}
       </div>
 
-      <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/72">
+      <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-600">
         {recommendation.availableNow ? (
-          <span className="rounded-full border border-white/14 bg-white/10 px-3 py-1">
+          <span className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1">
             <Clock3 className="mr-1 inline h-3.5 w-3.5" />
             Available now
           </span>
         ) : null}
         {typeof recommendation.distanceMiles === "number" ? (
-          <span className="rounded-full border border-white/14 bg-white/10 px-3 py-1">
+          <span className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1">
             <MapPinned className="mr-1 inline h-3.5 w-3.5" />
             {recommendation.distanceMiles < 10
               ? `${recommendation.distanceMiles.toFixed(1)} mi`
@@ -80,13 +80,13 @@ function RecommendationCard({
           </span>
         ) : null}
         {typeof recommendation.priceFrom === "number" ? (
-          <span className="rounded-full border border-white/14 bg-white/10 px-3 py-1">
+          <span className="rounded-full border border-sky-200 bg-sky-50 px-3 py-1">
             From ${recommendation.priceFrom}
           </span>
         ) : null}
       </div>
 
-      <ul className="mt-3 space-y-2 text-sm leading-6 text-white/78">
+      <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
         {recommendation.why.map((reason) => (
           <li key={`${recommendation.therapistId}-${reason}`}>• {reason}</li>
         ))}
@@ -99,8 +99,8 @@ function RecommendationCard({
           className={cn(
             "inline-flex min-h-11 items-center justify-center rounded-full px-4 text-sm font-semibold uppercase tracking-[0.12em] transition",
             featured
-              ? "bg-white text-slate-900 hover:bg-white/90"
-              : "border border-white/18 bg-white/10 text-white hover:bg-white/16",
+              ? "bg-sky-600 text-white hover:bg-sky-700"
+              : "border border-sky-200 bg-white text-slate-700 hover:bg-sky-50",
           )}
         >
           View profile
@@ -136,7 +136,7 @@ function ChatBubble({
 
   return (
     <div className="flex justify-start">
-      <div className="w-full max-w-[88%] space-y-3 rounded-[24px] rounded-bl-sm border border-white/12 bg-white/[0.08] px-4 py-4 text-sm leading-relaxed text-white/92 shadow-[0_18px_40px_rgba(0,0,0,0.12)] backdrop-blur-2xl">
+      <div className="w-full max-w-[88%] space-y-3 rounded-[24px] rounded-bl-sm border border-sky-100 bg-white/95 px-4 py-4 text-sm leading-relaxed text-slate-800 shadow-[0_12px_28px_rgba(14,116,144,0.15)] backdrop-blur-2xl">
         <p>{message.content}</p>
 
         {recommendations.length > 0 ? (
@@ -182,7 +182,7 @@ export const KnottyChat = ({
       key={action.key}
       type="button"
       onClick={() => void sendMessage({ quickAction: action.key })}
-      className="rounded-full border border-[#2f6098] bg-[#0f315b]/72 px-3.5 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-[#bfdcff] transition hover:border-[#4f85c2] hover:bg-[#174273] hover:text-[#e4f2ff]"
+      className="rounded-full border border-sky-200 bg-white/85 px-3.5 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-sky-700 transition hover:border-sky-300 hover:bg-sky-50 hover:text-sky-800"
     >
       {action.label}
     </button>
@@ -191,31 +191,34 @@ export const KnottyChat = ({
   const panel = (
     <div
       className={cn(
-        "relative flex flex-col overflow-hidden rounded-[28px] border border-[#1b4678] bg-[linear-gradient(180deg,#0b2447_0%,#091b37_52%,#07162f_100%)] shadow-[0_32px_96px_rgba(1,10,28,0.62)] backdrop-blur-3xl",
+        "relative flex flex-col overflow-hidden rounded-[28px] border border-[#bfdbfe] bg-[linear-gradient(180deg,#f8fcff_0%,#edf6ff_45%,#e1efff_100%)] text-slate-900 shadow-[0_28px_80px_rgba(22,78,153,0.22)] backdrop-blur-3xl",
         isEmbedded
           ? "h-[620px] w-full"
           : "w-[396px] max-w-[calc(100vw-2rem)] h-[min(620px,calc(100svh-5rem))]",
         className,
       )}
     >
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(58,126,207,0.26),transparent_38%),radial-gradient(circle_at_bottom_left,rgba(18,52,94,0.5),transparent_56%)]" />
-      <div className="pointer-events-none absolute inset-x-10 top-0 h-32 rounded-full bg-[radial-gradient(circle,rgba(98,166,238,0.22),transparent_70%)] blur-3xl" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(56,189,248,0.26),transparent_38%),radial-gradient(circle_at_bottom_left,rgba(59,130,246,0.18),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-x-10 top-0 h-32 rounded-full bg-[radial-gradient(circle,rgba(14,165,233,0.22),transparent_70%)] blur-3xl" />
 
-      <div className="relative flex items-center justify-between border-b border-[#204e83] bg-[#0d2a4f]/72 px-5 py-4">
+      <div className="relative flex items-center justify-between border-b border-[#bfdbfe] bg-white/70 px-5 py-4">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-[#2a5b95] bg-[#12335d] text-[#8ec2f6]">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-sky-300 bg-sky-100 text-sky-700">
             <Sparkles className="h-4 w-4" />
           </div>
           <div>
-            <p className="text-sm font-semibold text-[#a9d4ff]">Knotty</p>
-            <p className="text-[11px] uppercase tracking-[0.24em] text-[#6f9dcb]">AI concierge closer</p>
+            <p className="text-sm font-semibold text-slate-900">Knotty</p>
+            <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-[0.2em] text-sky-700">
+              <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_0_5px_rgba(16,185,129,0.2)] animate-pulse" />
+              Live concierge
+            </p>
           </div>
         </div>
         {!isEmbedded ? (
           <button
             type="button"
             onClick={() => setIsOpen(false)}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#2a5a93] bg-[#12355f] text-[#94bde7] transition hover:bg-[#174273] hover:text-[#d3e8ff]"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-sky-200 bg-white text-sky-700 transition hover:bg-sky-50 hover:text-sky-800"
             aria-label="Close Knotty chat"
           >
             <X className="h-4 w-4" />
@@ -223,7 +226,7 @@ export const KnottyChat = ({
         ) : null}
       </div>
 
-      <div className="relative border-b border-[#204e83] px-4 py-3">
+      <div className="relative border-b border-[#bfdbfe] px-4 py-3">
         <div className="flex flex-wrap gap-2">
           {quickActionButtons}
           {(promptExamples || []).slice(0, 0).map(() => null)}
@@ -241,7 +244,7 @@ export const KnottyChat = ({
 
         {isTyping ? (
           <div className="flex justify-start">
-            <div className="rounded-[20px] rounded-bl-sm border border-white/12 bg-white/[0.08] px-4 py-3 text-sm text-white/82 backdrop-blur-2xl">
+            <div className="rounded-[20px] rounded-bl-sm border border-sky-100 bg-white/90 px-4 py-3 text-sm text-slate-700 backdrop-blur-2xl">
               <TypingDots />
             </div>
           </div>
@@ -255,20 +258,20 @@ export const KnottyChat = ({
           event.preventDefault();
           void sendMessage({ content: input });
         }}
-        className="relative border-t border-[#204e83] px-4 py-4"
+        className="relative border-t border-[#bfdbfe] px-4 py-4"
       >
-        <div className="flex items-center gap-2 rounded-[22px] border border-[#28568b] bg-[#0c2a4f]/75 px-3 py-2.5 backdrop-blur-2xl">
+        <div className="flex items-center gap-2 rounded-[22px] border border-sky-200 bg-white/90 px-3 py-2.5 backdrop-blur-2xl">
           <input
             type="text"
             value={input}
             onChange={(event) => setInput(event.target.value)}
-            placeholder="Tell Knotty what matters most..."
-            className="flex-1 bg-transparent text-sm text-[#d7e8fa] outline-none placeholder:text-[#b8d4f0]"
+            placeholder="Pergunte e eu busco no diretório em tempo real..."
+            className="flex-1 bg-transparent text-sm text-slate-700 outline-none placeholder:text-slate-400"
           />
           <button
             type="submit"
             disabled={!input.trim() || isTyping}
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-[#3f6ea6] bg-[#194679] text-[#e6f3ff] transition hover:bg-[#245890] disabled:cursor-not-allowed disabled:opacity-35"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-sky-300 bg-sky-600 text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-35"
             aria-label="Send message"
           >
             <Send className="h-4 w-4" />
@@ -297,12 +300,12 @@ export const KnottyChat = ({
               setIsOpen(true);
               trackOpen();
             }}
-            className="group relative h-16 w-16 rounded-full border border-white/18 bg-[linear-gradient(180deg,rgba(9,18,34,0.96),rgba(18,44,73,0.96))] shadow-[0_20px_48px_rgba(0,0,0,0.3)]"
+            className="group relative h-16 w-16 rounded-full border border-sky-300 bg-[linear-gradient(180deg,#e0f2fe,#7dd3fc)] shadow-[0_18px_42px_rgba(14,116,144,0.35)]"
             aria-label="Open Knotty chat"
           >
-            <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_58%)]" />
-            <div className="absolute -inset-2 rounded-full bg-[radial-gradient(circle,rgba(122,198,255,0.22),transparent_65%)] opacity-75 blur-2xl transition group-hover:opacity-100" />
-            <div className="relative flex h-full w-full items-center justify-center text-white">
+            <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.6),transparent_58%)]" />
+            <div className="absolute -inset-2 rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.35),transparent_65%)] opacity-75 blur-2xl transition group-hover:opacity-100" />
+            <div className="relative flex h-full w-full items-center justify-center text-sky-800">
               <Sparkles className="h-6 w-6" />
             </div>
           </motion.button>

--- a/src/hooks/useKnotty.ts
+++ b/src/hooks/useKnotty.ts
@@ -37,7 +37,7 @@ const INITIAL_ASSISTANT_MESSAGE: ConversationMessage = {
   id: "knotty-intro",
   role: "assistant",
   content:
-    "Tell me what matters most right now and I’ll narrow this down into a clear match with the next best backups.",
+    "I use Masseurfinder data from this website to answer common questions and find the best masseur matches for you. Tell me what matters most.",
 };
 
 export function useKnotty() {

--- a/src/lib/knotty/service.ts
+++ b/src/lib/knotty/service.ts
@@ -1,8 +1,3 @@
-import {
-  GoogleGenerativeAI,
-  HarmBlockThreshold,
-  HarmCategory,
-} from "@google/generative-ai";
 import { getPublicTherapists } from "@/app/_lib/directory";
 import { sanitizeText } from "@/app/_lib/security";
 import { getRequestSession } from "@/app/api/_lib/session";
@@ -23,7 +18,7 @@ import type {
   KnottyResponsePayload,
 } from "@/lib/knotty/types";
 
-const GEMINI_MODEL = "gemini-1.5-flash";
+const INTERNAL_KNOWLEDGE_MODEL = "knotty-internal-ranking";
 
 const PROFILE_SELECT = [
   "id",
@@ -327,80 +322,11 @@ async function composeReply(input: {
   city: string | null;
 }) {
   const fallback = buildDeterministicReply(input);
-  const apiKey = envAny(["GEMINI_API_KEY", "GOOGLE_API_KEY"], "");
-
-  if (!apiKey || !input.primary) {
-    return {
-      reply: fallback,
-      model: null,
-      fallbackUsed: true,
-    };
-  }
-
-  try {
-    const client = new GoogleGenerativeAI(apiKey);
-    const model = client.getGenerativeModel(
-      {
-        model: GEMINI_MODEL,
-        safetySettings: [
-          {
-            category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-            threshold: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
-          },
-          {
-            category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-            threshold: HarmBlockThreshold.BLOCK_MEDIUM_AND_ABOVE,
-          },
-        ],
-      },
-      {
-        timeout: 3500,
-      },
-    );
-
-    const candidateSummary = [input.primary, ...input.alternatives]
-      .map(
-        (item, index) =>
-          `${index === 0 ? "Primary" : `Alternative ${index}`}: ${item.name} | ${item.specialty} | ${item.why.join(", ")}`,
-      )
-      .join("\n");
-
-    const prompt = [
-      "You are Knotty, a discreet and welcoming AI concierge for a wellness directory.",
-      "Do not invent facts or change the recommendation order.",
-      "Use only the ranked options provided below.",
-      "Keep the reply under 70 words.",
-      "Sound polished, direct, and reassuring.",
-      `User request: ${input.question}`,
-      `Intent: ${input.intent}`,
-      `City context: ${input.city || "not specified"}`,
-      candidateSummary,
-      "Explain why the primary match stands out and optionally mention one backup.",
-    ].join("\n");
-
-    const result = await model.generateContent(prompt);
-    const text = result.response.text().trim();
-
-    if (!text) {
-      return {
-        reply: fallback,
-        model: GEMINI_MODEL,
-        fallbackUsed: true,
-      };
-    }
-
-    return {
-      reply: text,
-      model: GEMINI_MODEL,
-      fallbackUsed: false,
-    };
-  } catch {
-    return {
-      reply: fallback,
-      model: GEMINI_MODEL,
-      fallbackUsed: true,
-    };
-  }
+  return {
+    reply: fallback,
+    model: INTERNAL_KNOWLEDGE_MODEL,
+    fallbackUsed: false,
+  };
 }
 
 export async function handleKnottyRequest(


### PR DESCRIPTION
### Motivation
- Improve the Knotty chat visual design to be brighter, more engaging and to convey a "live" interactive concierge feel for both the global floating chat and profile-level chat. 
- Make each masseur profile have its own Knotty assistant able to answer FAQs and guide users to site search results. 
- Remove dependency on external generative replies for deterministic/safer responses and ensure replies come from the site directory/ranking and FAQ logic. 

### Description
- Reworked the Knotty UI styling and interactive affordances in `src/components/ai/KnottyChat.tsx` to a lighter, higher-contrast design with updated badges, launcher, typing indicators and pill/button styles. 
- Updated profile-level chat in `src/app/therapists/[slug]/_components/ProfileAIChat.tsx` to match the new visual language, added a "live" presence signal, improved typing dots, and added a quick-question/response to help users search for similar masseurs on the site. 
- Clarified the initial assistant greeting in `src/hooks/useKnotty.ts` to explicitly state Knotty uses the website directory data. 
- Removed the Gemini/Google generative reply path from `src/lib/knotty/service.ts` and replaced `composeReply` with a deterministic internal reply that uses the ranking/FAQ output and tags replies with an internal model identifier. 

### Testing
- Ran linting on the changed files with `npx eslint src/components/ai/KnottyChat.tsx src/app/therapists/[slug]/_components/ProfileAIChat.tsx src/lib/knotty/service.ts src/hooks/useKnotty.ts` and it completed successfully. 
- Ran type checking with `npm run typecheck` and it completed successfully. 
- Attempted a headless UI validation and screenshot via Playwright while starting the dev server, but the environment lacked browser binaries so the Playwright step failed (requires `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d07640208320adacb96e6b19e2c2)