### PR TITLE
Improve auth responsiveness and middleware HMAC caching

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -41,7 +41,6 @@ const defaultSubscription: SubscriptionState = {
   loading: true,
   config_error: null,
 };
-const CLIENT_SESSION_SYNC_TIMEOUT_MS = 8000;
 
 type SubscriptionResponse = {
   ok: boolean;
@@ -202,11 +201,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       const result = await registerMutation({ email, password, fullName });
 
       // Registration API already sets the server session cookie.
-      // Try to establish the browser Supabase session, but do not block signup flow on it.
-      await Promise.race([
-        establishClientSession(email, password, result.session),
-        wait(8000),
-      ]).catch(() => null);
+      // Try to establish the browser Supabase session in the background.
+      void establishClientSession(email, password, result.session).catch((sessionError) => {
+        console.warn("Client session sync failed after signup.", sessionError);
+      });
 
       return { error: null };
     } catch (error) {
@@ -221,13 +219,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       // Login API already sets the server session cookie.
       // Mirror the Supabase browser session so client auth state hydrates immediately,
       // but don't block login when this sync fails (server cookie is already valid).
-      const sessionSyncPromise = establishClientSession(email, password, result.session).catch((sessionError) => {
+      void establishClientSession(email, password, result.session).catch((sessionError) => {
         console.warn("Client session sync failed after login.", sessionError);
       });
-      await Promise.race([
-        sessionSyncPromise,
-        wait(CLIENT_SESSION_SYNC_TIMEOUT_MS),
-      ]);
 
       return { error: null };
     } catch (error) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,7 @@ import { containsLangParam, removeLangSearchParam } from "@/app/_lib/route-norma
 const SESSION_COOKIE_NAME = "mm_session";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+let sessionHmacKeyPromise: Promise<CryptoKey> | null = null;
 
 type MiddlewareSession = {
   userId: string;
@@ -55,13 +56,16 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 async function signPayload(payload: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(getSessionSecret()),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
+  if (!sessionHmacKeyPromise) {
+    sessionHmacKeyPromise = crypto.subtle.importKey(
+      "raw",
+      encoder.encode(getSessionSecret()),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+  }
+  const key = await sessionHmacKeyPromise;
   const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
   return toBase64Url(new Uint8Array(signature));
 }
@@ -151,7 +155,6 @@ function exploreCityToSlug(rawCity: string): string {
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const { pathname, searchParams } = request.nextUrl;
-  const session = await readSessionCookie(request);
 
   // ── 1. Removed routes → 301 redirects ───────────────────────────────────
   if (pathname === "/wireframes" || pathname.startsWith("/wireframes/")) {
@@ -293,6 +296,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // Unauthenticated → /login (with redirect param)
   // Authenticated but wrong role → / (home, no redirect param)
   if (pathname === "/pro" || pathname.startsWith("/pro/")) {
+    const session = await readSessionCookie(request);
     if (!session) {
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("redirect", pathname);
@@ -304,6 +308,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   }
 
   if (pathname === "/admin" || pathname.startsWith("/admin/")) {
+    const session = await readSessionCookie(request);
     if (!session) {
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("redirect", pathname);


### PR DESCRIPTION
### Motivation
- Users experienced slow behavior around login/signup because the client Supabase session sync could block the form action for several seconds.
- The middleware performed expensive per-request work (importing an HMAC key and validating the session cookie) on every matched route, adding unnecessary overhead.
- The intent is to remove blocking work from the auth critical path and reduce middleware CPU/latency cost for common requests.

### Description
- Updated `src/contexts/AuthContext.tsx` so `signIn` and `signUp` no longer wait for `establishClientSession`; the client session sync now runs as a best-effort background task via `void ... .catch(...)` and logs on failure.
- Removed the blocking timeout/race wait used to hold the login/signup flow while the client session synchronized.
- Optimized `src/middleware.ts` by caching the imported HMAC `CryptoKey` in `sessionHmacKeyPromise` to avoid repeated `crypto.subtle.importKey` calls.
- Reduced middleware work by deferring `readSessionCookie`/signature verification so it is only invoked for the protected `/pro` and `/admin` guards instead of every matched request.

### Testing
- Ran `npm run typecheck`, which completed successfully.
- Ran `npx eslint src/contexts/AuthContext.tsx src/middleware.ts`, which reported no lint errors for the changed files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0da3d03cc8320986e3ab7054b2f4e)