### PR TITLE
Add admin dashboard flow to create users with full profiles

### DIFF
--- a/src/app/admin/_components/AdminUsersManager.tsx
+++ b/src/app/admin/_components/AdminUsersManager.tsx
@@ -33,6 +33,31 @@ export default function AdminUsersManager({
   const { toast } = useToast();
   const [drafts, setDrafts] = useState<Record<string, "admin" | "provider">>(() => buildDrafts(initialUsers));
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    fullName: "",
+    displayName: "",
+    email: "",
+    password: "",
+    phone: "",
+    city: "",
+    state: "",
+    neighborhood: "",
+    tagline: "",
+    bio: "",
+    languages: "",
+    education: "",
+    certifications: "",
+    yearsExperience: "",
+    serviceCategories: "",
+    sessionLengths: "60 min",
+    locationType: "both" as "incall" | "outcall" | "both",
+    startingPrice: "",
+    addOns: "",
+    role: "provider" as "admin" | "provider" | "client",
+    profileStatus: "pending_approval" as "draft" | "pending_approval" | "active",
+    availableNow: false,
+  });
 
   useEffect(() => {
     setDrafts(buildDrafts(initialUsers));
@@ -63,8 +88,144 @@ export default function AdminUsersManager({
     }
   };
 
+  const handleCreateUser = async () => {
+    setCreateBusy(true);
+
+    try {
+      await postJson("/api/admin/users", {
+        fullName: createForm.fullName,
+        displayName: createForm.displayName || undefined,
+        email: createForm.email,
+        password: createForm.password,
+        phone: createForm.phone || undefined,
+        city: createForm.city || undefined,
+        state: createForm.state || undefined,
+        neighborhood: createForm.neighborhood || undefined,
+        tagline: createForm.tagline || undefined,
+        bio: createForm.bio || undefined,
+        languages: createForm.languages
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean),
+        education: createForm.education || undefined,
+        certifications: createForm.certifications || undefined,
+        yearsExperience: createForm.yearsExperience || undefined,
+        serviceCategories: createForm.serviceCategories
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean),
+        sessionLengths: createForm.sessionLengths
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean),
+        locationType: createForm.locationType,
+        startingPrice: createForm.startingPrice || undefined,
+        addOns: createForm.addOns || undefined,
+        role: createForm.role,
+        profileStatus: createForm.profileStatus,
+        availableNow: createForm.availableNow,
+      });
+
+      toast({
+        title: "User profile created",
+        description: `${createForm.fullName} was created with a complete profile.`,
+      });
+      setCreateForm({
+        fullName: "",
+        displayName: "",
+        email: "",
+        password: "",
+        phone: "",
+        city: "",
+        state: "",
+        neighborhood: "",
+        tagline: "",
+        bio: "",
+        languages: "",
+        education: "",
+        certifications: "",
+        yearsExperience: "",
+        serviceCategories: "",
+        sessionLengths: "60 min",
+        locationType: "both",
+        startingPrice: "",
+        addOns: "",
+        role: "provider",
+        profileStatus: "pending_approval",
+        availableNow: false,
+      });
+      router.refresh();
+    } catch (error) {
+      toast({
+        title: "Could not create profile",
+        description: error instanceof Error ? error.message : "Unknown error.",
+        variant: "destructive",
+      });
+    } finally {
+      setCreateBusy(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
+      <article className="rounded-lg border border-border p-4">
+        <h2 className="font-semibold">Create user + full profile</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Create an auth user and prefill complete profile details in one action.
+        </p>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <input placeholder="Full name *" className="rounded-md border px-3 py-2 text-sm" value={createForm.fullName} onChange={(event) => setCreateForm((current) => ({ ...current, fullName: event.target.value }))} />
+          <input placeholder="Display name" className="rounded-md border px-3 py-2 text-sm" value={createForm.displayName} onChange={(event) => setCreateForm((current) => ({ ...current, displayName: event.target.value }))} />
+          <input placeholder="Email *" type="email" className="rounded-md border px-3 py-2 text-sm" value={createForm.email} onChange={(event) => setCreateForm((current) => ({ ...current, email: event.target.value }))} />
+          <input placeholder="Temporary password *" type="password" className="rounded-md border px-3 py-2 text-sm" value={createForm.password} onChange={(event) => setCreateForm((current) => ({ ...current, password: event.target.value }))} />
+          <input placeholder="Phone" className="rounded-md border px-3 py-2 text-sm" value={createForm.phone} onChange={(event) => setCreateForm((current) => ({ ...current, phone: event.target.value }))} />
+          <input placeholder="City" className="rounded-md border px-3 py-2 text-sm" value={createForm.city} onChange={(event) => setCreateForm((current) => ({ ...current, city: event.target.value }))} />
+          <input placeholder="State" className="rounded-md border px-3 py-2 text-sm" value={createForm.state} onChange={(event) => setCreateForm((current) => ({ ...current, state: event.target.value }))} />
+          <input placeholder="Neighborhood" className="rounded-md border px-3 py-2 text-sm" value={createForm.neighborhood} onChange={(event) => setCreateForm((current) => ({ ...current, neighborhood: event.target.value }))} />
+          <input placeholder="Tagline" className="rounded-md border px-3 py-2 text-sm md:col-span-2" value={createForm.tagline} onChange={(event) => setCreateForm((current) => ({ ...current, tagline: event.target.value }))} />
+          <textarea placeholder="Bio" className="min-h-24 rounded-md border px-3 py-2 text-sm md:col-span-2" value={createForm.bio} onChange={(event) => setCreateForm((current) => ({ ...current, bio: event.target.value }))} />
+          <input placeholder="Languages (comma separated)" className="rounded-md border px-3 py-2 text-sm" value={createForm.languages} onChange={(event) => setCreateForm((current) => ({ ...current, languages: event.target.value }))} />
+          <input placeholder="Education" className="rounded-md border px-3 py-2 text-sm" value={createForm.education} onChange={(event) => setCreateForm((current) => ({ ...current, education: event.target.value }))} />
+          <input placeholder="Certifications" className="rounded-md border px-3 py-2 text-sm" value={createForm.certifications} onChange={(event) => setCreateForm((current) => ({ ...current, certifications: event.target.value }))} />
+          <input placeholder="Years experience" className="rounded-md border px-3 py-2 text-sm" value={createForm.yearsExperience} onChange={(event) => setCreateForm((current) => ({ ...current, yearsExperience: event.target.value }))} />
+          <input placeholder="Service categories (comma separated)" className="rounded-md border px-3 py-2 text-sm" value={createForm.serviceCategories} onChange={(event) => setCreateForm((current) => ({ ...current, serviceCategories: event.target.value }))} />
+          <input placeholder="Session lengths (e.g. 60 min, 90 min)" className="rounded-md border px-3 py-2 text-sm" value={createForm.sessionLengths} onChange={(event) => setCreateForm((current) => ({ ...current, sessionLengths: event.target.value }))} />
+          <input placeholder="Starting price (USD)" className="rounded-md border px-3 py-2 text-sm" value={createForm.startingPrice} onChange={(event) => setCreateForm((current) => ({ ...current, startingPrice: event.target.value }))} />
+          <input placeholder="Add-ons (e.g. CBD +$30)" className="rounded-md border px-3 py-2 text-sm" value={createForm.addOns} onChange={(event) => setCreateForm((current) => ({ ...current, addOns: event.target.value }))} />
+
+          <select value={createForm.locationType} onChange={(event) => setCreateForm((current) => ({ ...current, locationType: event.target.value as "incall" | "outcall" | "both" }))} className="rounded-md border px-3 py-2 text-sm">
+            <option value="both">Both incall + outcall</option>
+            <option value="incall">Incall only</option>
+            <option value="outcall">Outcall only</option>
+          </select>
+          <select value={createForm.role} onChange={(event) => setCreateForm((current) => ({ ...current, role: event.target.value as "admin" | "provider" | "client" }))} className="rounded-md border px-3 py-2 text-sm">
+            <option value="provider">Provider</option>
+            <option value="admin">Admin</option>
+            <option value="client">Client</option>
+          </select>
+          <select value={createForm.profileStatus} onChange={(event) => setCreateForm((current) => ({ ...current, profileStatus: event.target.value as "draft" | "pending_approval" | "active" }))} className="rounded-md border px-3 py-2 text-sm">
+            <option value="pending_approval">Pending approval</option>
+            <option value="draft">Draft</option>
+            <option value="active">Active</option>
+          </select>
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <input type="checkbox" checked={createForm.availableNow} onChange={(event) => setCreateForm((current) => ({ ...current, availableNow: event.target.checked }))} />
+            Available now
+          </label>
+        </div>
+
+        <div className="mt-4">
+          <Button
+            type="button"
+            disabled={createBusy || !createForm.fullName || !createForm.email || !createForm.password}
+            onClick={() => void handleCreateUser()}
+          >
+            {createBusy ? "Creating..." : "Create full profile"}
+          </Button>
+        </div>
+      </article>
+
       {initialUsers.length === 0 ? (
         <p className="text-sm text-muted-foreground">No users found.</p>
       ) : null}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import { persistSubmittedProfile } from "@/app/api/signup/_lib/profile-submission";
 import {
+  createTherapistUser,
   createSupabaseAdminClient,
   recordAuditLog,
   requireAdminSession,
@@ -10,6 +12,31 @@ import {
 const adminUserActionSchema = z.object({
   userId: z.string().min(1),
   role: z.enum(["admin", "provider"]),
+});
+
+const createProfileSchema = z.object({
+  fullName: z.string().min(2),
+  displayName: z.string().min(2).optional(),
+  email: z.string().email(),
+  password: z.string().min(8),
+  phone: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  neighborhood: z.string().optional(),
+  tagline: z.string().optional(),
+  bio: z.string().optional(),
+  languages: z.array(z.string()).default([]),
+  education: z.string().optional(),
+  certifications: z.string().optional(),
+  yearsExperience: z.union([z.number(), z.string()]).optional(),
+  serviceCategories: z.array(z.string()).default([]),
+  sessionLengths: z.array(z.string()).default([]),
+  locationType: z.enum(["incall", "outcall", "both", ""]).optional(),
+  startingPrice: z.union([z.number(), z.string()]).optional(),
+  addOns: z.string().optional(),
+  availableNow: z.boolean().default(false),
+  profileStatus: z.enum(["draft", "pending_approval", "active"]).default("pending_approval"),
+  role: z.enum(["admin", "provider", "client"]).default("provider"),
 });
 
 async function updateUserRole(
@@ -43,16 +70,130 @@ async function updateUserRole(
   return data;
 }
 
+async function createUserWithProfile(
+  adminUserId: string,
+  input: z.infer<typeof createProfileSchema>,
+) {
+  const adminClient = createSupabaseAdminClient();
+  const created = await createTherapistUser({
+    fullName: input.fullName,
+    email: input.email,
+    password: input.password,
+  });
+
+  const persistenceError = await persistSubmittedProfile(
+    created.user.id,
+    {
+      fullName: input.fullName,
+      displayName: input.displayName || input.fullName,
+      email: input.email,
+      phone: input.phone,
+      city: input.city,
+      state: input.state,
+      neighborhood: input.neighborhood,
+      tagline: input.tagline,
+      bio: input.bio,
+      languages: input.languages,
+      education: input.education,
+      certifications: input.certifications,
+      yearsExperience: input.yearsExperience,
+      serviceCategories: input.serviceCategories,
+      sessionLengths: input.sessionLengths,
+      locationType: input.locationType,
+      startingPrice: input.startingPrice,
+      addOns: input.addOns,
+      availableNow: input.availableNow,
+      termsAccepted: true,
+      emailVerified: true,
+      phoneVerified: true,
+      identityVerified: false,
+    },
+    "premium",
+  );
+
+  if (persistenceError) {
+    throw new RouteError(500, persistenceError);
+  }
+
+  if (input.profileStatus !== "pending_approval") {
+    const profileStatusUpdate: Record<string, unknown> = {
+      status: input.profileStatus,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (input.profileStatus === "active") {
+      profileStatusUpdate.is_active = true;
+      profileStatusUpdate.is_verified_profile = true;
+    }
+
+    const { error: profileStatusError } = await adminClient
+      .from("profiles")
+      .update(profileStatusUpdate)
+      .eq("user_id", created.user.id);
+
+    if (profileStatusError) {
+      throw new RouteError(500, profileStatusError.message);
+    }
+  }
+
+  if (input.role !== "provider") {
+    const { error: deleteError } = await adminClient
+      .from("user_roles")
+      .delete()
+      .eq("user_id", created.user.id);
+    if (deleteError) {
+      throw new RouteError(500, deleteError.message);
+    }
+
+    const { error: roleError } = await adminClient.from("user_roles").insert({
+      user_id: created.user.id,
+      role: input.role,
+    });
+    if (roleError) {
+      throw new RouteError(500, roleError.message);
+    }
+  }
+
+  await recordAuditLog(adminUserId, "create_user_profile", "user", created.user.id, {
+    email: input.email,
+    fullName: input.fullName,
+    role: input.role,
+    profileStatus: input.profileStatus,
+  });
+
+  return {
+    userId: created.user.id,
+    email: created.user.email,
+    role: input.role,
+  };
+}
+
 export async function POST(request: Request) {
   try {
     const admin = await requireAdminSession(request);
-    const body = await parseJsonBody(request, adminUserActionSchema);
-    const result = await updateUserRole(admin.userId, body);
+    const rawBody = await parseJsonBody(request, z.record(z.string(), z.unknown()));
+    const roleUpdateCandidate = adminUserActionSchema.safeParse(rawBody);
+    const createProfileCandidate = createProfileSchema.safeParse(rawBody);
 
-    return json({
-      ok: true,
-      role: result,
-    });
+    if (roleUpdateCandidate.success) {
+      const result = await updateUserRole(admin.userId, roleUpdateCandidate.data);
+
+      return json({
+        ok: true,
+        role: result,
+      });
+    }
+
+    if (createProfileCandidate.success) {
+      const result = await createUserWithProfile(admin.userId, createProfileCandidate.data);
+
+      return json({
+        ok: true,
+        createdUser: result,
+      });
+    }
+
+    throw new RouteError(400, "Invalid admin user action payload.");
   } catch (error) {
     return errorResponse(error);
   }


### PR DESCRIPTION
### Motivation
- Provide admins an in-dashboard way to create an auth user and fully populate a provider profile in one action so admin can seed complete provider accounts quickly.
- Reuse existing signup persistence logic so created profiles follow the same normalization and guardrails as user-submitted profiles.

### Description
- Added a new creation UI to `AdminUsersManager` with fields for identity, contact, location, bio, services, pricing, role, status, and availability, plus create/reset/loading/toast behavior (`src/app/admin/_components/AdminUsersManager.tsx`).
- Extended `/api/admin/users` to accept two request shapes by schema-detecting payloads and either update roles (`adminUserActionSchema`) or create a full user+profile (`createProfileSchema`) (`src/app/api/admin/users/route.ts`).
- Implemented `createUserWithProfile()` which creates an auth user via `createTherapistUser`, persists profile fields via `persistSubmittedProfile`, optionally adjusts profile `status` and `role`, and records an audit log entry. 
- Kept the existing role-update flow intact so existing "Save role" actions continue to work unchanged.

### Testing
- Ran `npm run typecheck` and the TypeScript checks completed successfully.
- Ran `npm run lint` and ESLint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0daa9427c832086a0c2d457a75d4e)