### PR TITLE
feat: align Pro dashboard with Admin UI and improve Admin Users manager (mobile + create-user)

### DIFF
--- a/src/app/admin/_components/AdminUsersManager.tsx
+++ b/src/app/admin/_components/AdminUsersManager.tsx
@@ -168,18 +168,18 @@ export default function AdminUsersManager({
 
   return (
     <div className="space-y-4">
-      <article className="rounded-lg border border-border p-4">
+      <article className="rounded-xl border border-border bg-background p-4 md:p-5">
         <h2 className="font-semibold">Create user + full profile</h2>
         <p className="mt-1 text-sm text-muted-foreground">
           Create an auth user and prefill complete profile details in one action.
         </p>
 
         <div className="mt-4 grid gap-3 md:grid-cols-2">
-          <input placeholder="Full name *" className="rounded-md border px-3 py-2 text-sm" value={createForm.fullName} onChange={(event) => setCreateForm((current) => ({ ...current, fullName: event.target.value }))} />
-          <input placeholder="Display name" className="rounded-md border px-3 py-2 text-sm" value={createForm.displayName} onChange={(event) => setCreateForm((current) => ({ ...current, displayName: event.target.value }))} />
-          <input placeholder="Email *" type="email" className="rounded-md border px-3 py-2 text-sm" value={createForm.email} onChange={(event) => setCreateForm((current) => ({ ...current, email: event.target.value }))} />
-          <input placeholder="Temporary password *" type="password" className="rounded-md border px-3 py-2 text-sm" value={createForm.password} onChange={(event) => setCreateForm((current) => ({ ...current, password: event.target.value }))} />
-          <input placeholder="Phone" className="rounded-md border px-3 py-2 text-sm" value={createForm.phone} onChange={(event) => setCreateForm((current) => ({ ...current, phone: event.target.value }))} />
+          <input placeholder="Full name *" className="rounded-md border border-input bg-background px-3 py-2 text-sm" value={createForm.fullName} onChange={(event) => setCreateForm((current) => ({ ...current, fullName: event.target.value }))} />
+          <input placeholder="Display name" className="rounded-md border border-input bg-background px-3 py-2 text-sm" value={createForm.displayName} onChange={(event) => setCreateForm((current) => ({ ...current, displayName: event.target.value }))} />
+          <input placeholder="Email *" type="email" className="rounded-md border border-input bg-background px-3 py-2 text-sm" value={createForm.email} onChange={(event) => setCreateForm((current) => ({ ...current, email: event.target.value }))} />
+          <input placeholder="Temporary password *" type="password" className="rounded-md border border-input bg-background px-3 py-2 text-sm" value={createForm.password} onChange={(event) => setCreateForm((current) => ({ ...current, password: event.target.value }))} />
+          <input placeholder="Phone" className="rounded-md border border-input bg-background px-3 py-2 text-sm" value={createForm.phone} onChange={(event) => setCreateForm((current) => ({ ...current, phone: event.target.value }))} />
           <input placeholder="City" className="rounded-md border px-3 py-2 text-sm" value={createForm.city} onChange={(event) => setCreateForm((current) => ({ ...current, city: event.target.value }))} />
           <input placeholder="State" className="rounded-md border px-3 py-2 text-sm" value={createForm.state} onChange={(event) => setCreateForm((current) => ({ ...current, state: event.target.value }))} />
           <input placeholder="Neighborhood" className="rounded-md border px-3 py-2 text-sm" value={createForm.neighborhood} onChange={(event) => setCreateForm((current) => ({ ...current, neighborhood: event.target.value }))} />
@@ -238,10 +238,10 @@ export default function AdminUsersManager({
                 {user.email || "No email"} · {user.city || "No city"} · {user.status}
               </p>
               <h2 className="mt-1 font-semibold">{user.fullName}</h2>
-              <p className="mt-2 text-sm text-muted-foreground">User ID: {user.userId}</p>
+              <p className="mt-2 break-all text-sm text-muted-foreground">User ID: {user.userId}</p>
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex w-full items-center gap-2 sm:w-auto sm:gap-3">
               <select
                 value={drafts[user.userId] || "provider"}
                 onChange={(event) =>
@@ -250,12 +250,12 @@ export default function AdminUsersManager({
                     [user.userId]: event.target.value as "admin" | "provider",
                   }))
                 }
-                className="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                className="flex h-10 min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm sm:flex-none"
               >
                 <option value="provider">Provider</option>
                 <option value="admin">Admin</option>
               </select>
-              <Button type="button" variant="outline" size="sm" disabled={busyId === user.userId} onClick={() => void handleSave(user.userId)}>
+              <Button type="button" variant="outline" size="sm" className="shrink-0" disabled={busyId === user.userId} onClick={() => void handleSave(user.userId)}>
                 {busyId === user.userId ? "Saving..." : "Save role"}
               </Button>
             </div>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -9,7 +9,7 @@ export default async function AdminUsersPage() {
     <div className="space-y-6">
       <AdminPageHeader
         title="Users"
-        description="Review provider accounts and move them between provider and admin roles."
+        description="Create new auth users with full profiles, then manage provider/admin roles."
       />
 
       {error ? (

--- a/src/app/pro/ProLayoutClient.tsx
+++ b/src/app/pro/ProLayoutClient.tsx
@@ -67,16 +67,18 @@ export default function ProLayoutClient({
 
   const sidebarContent = (
     <>
-      <div className="p-6">
-        <Link href="/" className="font-display text-2xl font-bold tracking-tighter text-white">
-          Masseur<span className="text-slate-500">Match</span>{" "}
-          <span className="ml-1 align-top font-mono text-[10px] uppercase tracking-widest text-indigo-400">
-            PRO
+      <div className="p-4">
+        <Link href="/pro/dashboard" className="flex items-center gap-2">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-accent text-sidebar-accent-foreground">
+            <BookUser className="h-4 w-4" />
+          </div>
+          <span className="text-base font-semibold text-sidebar-foreground">
+            Pro Dashboard
           </span>
         </Link>
       </div>
 
-      <nav className="flex-1 space-y-2 px-4 py-6">
+      <nav className="flex-1 space-y-1 px-3 py-5">
         {navItems.map((item) => {
           const isActive = pathname === item.href;
 
@@ -85,15 +87,15 @@ export default function ProLayoutClient({
               {isActive ? (
                 <motion.div
                   layoutId="activeNav"
-                  className="absolute inset-0 rounded-lg border border-slate-800 bg-slate-900"
+                  className="absolute inset-0 rounded-lg border border-primary/20 bg-primary/10"
                   transition={{ type: "spring", stiffness: 300, damping: 30 }}
                 />
               ) : null}
               <span
-                className={`relative flex items-center gap-3 rounded-lg px-4 py-3 font-sans text-sm transition-colors ${
+                className={`relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors ${
                   isActive
-                    ? "font-medium text-white"
-                    : "text-slate-400 hover:bg-slate-900/50 hover:text-slate-200"
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-secondary/80 hover:text-foreground"
                 }`}
               >
                 <item.icon className="h-4 w-4" />
@@ -104,10 +106,10 @@ export default function ProLayoutClient({
         })}
       </nav>
 
-      <div className="m-4 rounded-xl border border-indigo-500/20 bg-gradient-to-b from-indigo-900/20 to-transparent p-4">
-        <p className="font-sans text-xs text-slate-400">
+      <div className="m-3 rounded-xl border border-border bg-sidebar-accent/30 p-4">
+        <p className="text-xs text-muted-foreground">
           Need help?{" "}
-          <a href="mailto:support@masseurmatch.com" className="text-indigo-300 underline">
+          <a href="mailto:support@masseurmatch.com" className="text-primary underline">
             Contact support
           </a>
         </p>
@@ -116,22 +118,20 @@ export default function ProLayoutClient({
   );
 
   return (
-    <div className="flex h-screen overflow-hidden bg-slate-50">
-      <aside className="z-20 hidden w-64 flex-col border-r border-slate-900 bg-slate-950 text-slate-300 shadow-2xl md:flex">
+    <div className="flex min-h-screen overflow-hidden bg-[hsl(220,33%,97%)]">
+      <aside className="z-20 hidden w-64 flex-col border-r border-border bg-sidebar text-sidebar-foreground md:flex">
         {sidebarContent}
       </aside>
 
-      <div className="fixed inset-x-0 top-0 z-30 flex items-center justify-between border-b border-slate-900 bg-slate-950 px-4 py-3 md:hidden">
-        <Link href="/" className="font-display text-xl font-bold tracking-tighter text-white">
-          Masseur<span className="text-slate-500">Match</span>{" "}
-          <span className="ml-1 align-top font-mono text-[9px] uppercase tracking-widest text-indigo-400">
-            PRO
-          </span>
+      <div className="fixed inset-x-0 top-0 z-30 flex items-center justify-between border-b border-border bg-white/90 px-4 py-3 backdrop-blur-xl md:hidden">
+        <Link href="/pro/dashboard" className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <BookUser className="h-4 w-4 text-primary" />
+          Pro Dashboard
         </Link>
         <button
           onClick={() => setMobileOpen((prev) => !prev)}
           aria-label={mobileOpen ? "Close menu" : "Open menu"}
-          className="rounded-md p-1.5 text-slate-300 transition-colors hover:bg-slate-800"
+          className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-secondary"
         >
           {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </button>
@@ -155,7 +155,7 @@ export default function ProLayoutClient({
               animate={{ x: 0 }}
               exit={{ x: "-100%" }}
               transition={{ type: "spring", stiffness: 300, damping: 35 }}
-              className="fixed inset-y-0 left-0 z-50 flex w-72 flex-col bg-slate-950 text-slate-300 shadow-2xl md:hidden"
+              className="fixed inset-y-0 left-0 z-50 flex w-[86vw] max-w-xs flex-col border-r border-border bg-sidebar text-sidebar-foreground shadow-2xl md:hidden"
             >
               {sidebarContent}
             </motion.aside>
@@ -163,7 +163,7 @@ export default function ProLayoutClient({
         ) : null}
       </AnimatePresence>
 
-      <main className="flex-1 overflow-y-auto bg-slate-50 pt-14 md:pt-0">{children}</main>
+      <main className="flex-1 overflow-y-auto pt-14 md:pt-0">{children}</main>
     </div>
   );
 }

--- a/src/app/pro/dashboard/page.tsx
+++ b/src/app/pro/dashboard/page.tsx
@@ -37,20 +37,20 @@ const statusMessages: Record<AvailabilityStatus, string> = {
 
 const colorMap: Record<string, { active: string; idle: string }> = {
   emerald: {
-    active: "bg-emerald-500/10 border-emerald-500/50 text-emerald-400",
-    idle: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10",
+    active: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700",
+    idle: "border-border bg-background text-muted-foreground hover:bg-secondary",
   },
   indigo: {
-    active: "bg-indigo-500/10 border-indigo-500/50 text-indigo-400",
-    idle: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10",
+    active: "border-indigo-500/40 bg-indigo-500/10 text-indigo-700",
+    idle: "border-border bg-background text-muted-foreground hover:bg-secondary",
   },
   amber: {
-    active: "bg-amber-500/10 border-amber-500/50 text-amber-400",
-    idle: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10",
+    active: "border-amber-500/40 bg-amber-500/10 text-amber-700",
+    idle: "border-border bg-background text-muted-foreground hover:bg-secondary",
   },
   rose: {
-    active: "bg-rose-500/10 border-rose-500/50 text-rose-400",
-    idle: "bg-white/5 border-white/10 text-slate-400 hover:bg-white/10",
+    active: "border-rose-500/40 bg-rose-500/10 text-rose-700",
+    idle: "border-border bg-background text-muted-foreground hover:bg-secondary",
   },
 };
 
@@ -149,26 +149,26 @@ export default function DashboardHome() {
   const profileStatus = profile?.status ?? "draft";
 
   return (
-    <div className="mx-auto max-w-7xl space-y-8 p-6 md:p-10">
+    <div className="mx-auto max-w-7xl space-y-6 p-4 md:space-y-8 md:p-6 lg:p-8">
       <header className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
         <div>
-          <h1 className="font-display text-3xl font-semibold tracking-tight text-slate-900">
+          <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground">
             Dashboard
           </h1>
-          <p className="mt-1 font-sans text-sm text-slate-500">
+          <p className="mt-1 text-sm text-muted-foreground">
             Track your profile performance and manage availability.
           </p>
         </div>
-        <div className="flex gap-3">
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:gap-3">
           <Link
             href="/pro/listing"
-            className="border border-slate-200 bg-white px-4 py-2 font-mono text-xs uppercase tracking-wider text-slate-600 shadow-sm transition-colors hover:bg-slate-50"
+            className="rounded-lg border border-border bg-white px-4 py-2 text-center font-mono text-[11px] uppercase tracking-wider text-muted-foreground shadow-sm transition-colors hover:bg-secondary"
           >
             Edit Profile
           </Link>
           <Link
             href="/pro/settings"
-            className="border border-slate-200 bg-white px-4 py-2 font-mono text-xs uppercase tracking-wider text-slate-600 shadow-sm transition-colors hover:bg-slate-50"
+            className="rounded-lg border border-border bg-white px-4 py-2 text-center font-mono text-[11px] uppercase tracking-wider text-muted-foreground shadow-sm transition-colors hover:bg-secondary"
           >
             <Settings className="inline h-3.5 w-3.5" />
           </Link>
@@ -183,19 +183,19 @@ export default function DashboardHome() {
             variants={fadeUp}
             initial="hidden"
             animate="show"
-            className="relative overflow-hidden border border-slate-200/60 bg-white p-6 shadow-sm"
+            className="relative overflow-hidden rounded-2xl border border-border bg-white p-5 shadow-sm md:p-6"
           >
             <div className="flex items-center gap-4">
               <div className="relative flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-tr from-emerald-400 to-emerald-600">
                 <UserCircle className="relative h-10 w-10 text-white" />
               </div>
               <div>
-                <h2 className="font-display text-xl font-medium text-slate-900">
+                <h2 className="font-display text-xl font-medium text-foreground">
                   {displayName}
                 </h2>
                 <div className="mt-0.5 flex items-center gap-1">
                   <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />
-                  <span className="font-mono text-[10px] uppercase tracking-widest text-slate-500">
+                  <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
                     Pro Member
                   </span>
                 </div>
@@ -204,26 +204,26 @@ export default function DashboardHome() {
 
             <div className="mt-6">
               <div className="mb-2 flex justify-between text-xs">
-                <span className="font-mono uppercase tracking-wider text-slate-500">
+                <span className="font-mono uppercase tracking-wider text-muted-foreground">
                   Profile Completion
                 </span>
-                <span className="font-mono font-semibold text-slate-900">
+                <span className="font-mono font-semibold text-foreground">
                   {profileLoading ? "…" : `${completion}%`}
                 </span>
               </div>
-              <div className="h-1.5 w-full overflow-hidden bg-slate-100">
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-secondary">
                 {!profileLoading && (
                   <motion.div
                     initial={{ width: 0 }}
                     animate={{ width: `${completion}%` }}
                     transition={{ duration: 0.8, delay: 0.3 }}
-                    className="h-full bg-slate-900"
+                    className="h-full bg-primary"
                   />
                 )}
               </div>
               {!profileLoading && completion < 100 && (
-                <p className="mt-2 text-[11px] text-slate-500">
-                  <Link href="/pro/listing" className="text-indigo-600 underline">
+                <p className="mt-2 text-[11px] text-muted-foreground">
+                  <Link href="/pro/listing" className="text-primary underline">
                     Complete your profile
                   </Link>{" "}
                   to appear in more searches.
@@ -237,9 +237,9 @@ export default function DashboardHome() {
             initial="hidden"
             animate="show"
             transition={{ delay: 0.1 }}
-            className="border border-slate-800 bg-slate-950 p-6 text-white shadow-xl"
+            className="rounded-2xl border border-border bg-white p-5 shadow-sm md:p-6"
           >
-            <h3 className="mb-4 font-mono text-xs uppercase tracking-widest text-slate-400">
+            <h3 className="mb-4 font-mono text-xs uppercase tracking-widest text-muted-foreground">
               Availability
             </h3>
 
@@ -263,9 +263,9 @@ export default function DashboardHome() {
               })}
             </div>
 
-            <div className="mt-4 border border-white/10 bg-white/5 p-3 font-sans text-xs leading-relaxed text-slate-300">
-              {statusMessages[activeStatus]}
-            </div>
+              <div className="mt-4 rounded-xl border border-border bg-secondary/50 p-3 text-xs leading-relaxed text-muted-foreground">
+                {statusMessages[activeStatus]}
+              </div>
           </motion.div>
         </div>
 
@@ -281,25 +281,25 @@ export default function DashboardHome() {
                 variants={fadeUp}
                 initial="hidden"
                 animate="show"
-                className="flex flex-col gap-2 border border-slate-200/60 bg-white p-4 shadow-sm"
+                className="flex flex-col gap-2 rounded-xl border border-border bg-white p-4 shadow-sm"
               >
-                <item.icon className="h-4 w-4 text-slate-400" />
+                <item.icon className="h-4 w-4 text-muted-foreground" />
                 <div>
-                  <div className="font-display text-lg font-medium text-slate-400">—</div>
-                  <div className="mt-0.5 font-mono text-[10px] uppercase tracking-wider text-slate-500">
+                  <div className="font-display text-lg font-medium text-muted-foreground">—</div>
+                  <div className="mt-0.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
                     {item.label}
                   </div>
-                  <div className="mt-1 text-[10px] text-slate-400 italic">{item.note}</div>
+                  <div className="mt-1 text-[10px] italic text-muted-foreground">{item.note}</div>
                 </div>
               </motion.div>
             ))}
           </div>
 
-          <div className="border border-slate-200/60 bg-white shadow-sm">
-            <div className="flex items-center justify-between border-b border-slate-100 p-5">
-              <h3 className="font-sans font-semibold text-slate-900">Quick Links</h3>
+          <div className="rounded-2xl border border-border bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-border/50 p-5">
+              <h3 className="font-sans font-semibold text-foreground">Quick Links</h3>
             </div>
-            <div className="grid grid-cols-1 gap-0 divide-y divide-slate-100 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
+            <div className="grid grid-cols-1 gap-0 divide-y divide-border/50 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
               {[
                 { href: "/pro/listing", label: "Edit Profile", desc: "Update bio, photos, and services" },
                 { href: "/pro/photos", label: "Manage Photos", desc: "Upload and reorder gallery photos" },
@@ -311,19 +311,19 @@ export default function DashboardHome() {
                 <Link
                   key={link.href}
                   href={link.href}
-                  className="flex flex-col gap-0.5 p-5 transition hover:bg-slate-50"
+                  className="flex flex-col gap-0.5 p-5 transition hover:bg-secondary/60"
                 >
-                  <span className="font-sans text-sm font-semibold text-slate-800">{link.label}</span>
-                  <span className="font-sans text-xs text-slate-500">{link.desc}</span>
+                  <span className="font-sans text-sm font-semibold text-foreground">{link.label}</span>
+                  <span className="font-sans text-xs text-muted-foreground">{link.desc}</span>
                 </Link>
               ))}
             </div>
           </div>
 
-          <div className="border border-slate-200/60 bg-white p-5 shadow-sm">
+          <div className="rounded-2xl border border-border bg-white p-5 shadow-sm">
             <div className="mb-4 flex items-center justify-between">
-              <h3 className="font-sans font-semibold text-slate-900">Ads Activation (Compact)</h3>
-              <span className="text-xs text-slate-500">Pay instantly in Stripe</span>
+              <h3 className="font-sans font-semibold text-foreground">Ads Activation (Compact)</h3>
+              <span className="text-xs text-muted-foreground">Pay instantly in Stripe</span>
             </div>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               {[
@@ -335,14 +335,14 @@ export default function DashboardHome() {
                 <Link
                   key={ad.slug}
                   href={`/pro/billing?addon=${encodeURIComponent(ad.slug)}`}
-                  className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2 text-sm transition hover:border-slate-300 hover:bg-slate-50"
+                  className="flex items-center justify-between rounded-lg border border-border px-3 py-2 text-sm transition hover:border-primary/30 hover:bg-secondary/60"
                 >
-                  <span className="font-medium text-slate-700">{ad.name}</span>
-                  <span className="font-mono text-xs text-slate-500">{ad.price}</span>
+                  <span className="font-medium text-foreground">{ad.name}</span>
+                  <span className="font-mono text-xs text-muted-foreground">{ad.price}</span>
                 </Link>
               ))}
             </div>
-            <p className="mt-3 text-xs text-slate-500">
+            <p className="mt-3 text-xs text-muted-foreground">
               No activation email is needed. Checkout opens directly and activates via Stripe.
             </p>
             {subscription.plan_key === "free" && (
@@ -351,8 +351,8 @@ export default function DashboardHome() {
           </div>
 
           {profileStatus === "pending_approval" && (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-5 text-sm text-slate-600">
-              <p className="font-semibold text-slate-800 mb-1">What happens next?</p>
+            <div className="rounded-lg border border-border bg-secondary/40 p-5 text-sm text-muted-foreground">
+              <p className="mb-1 font-semibold text-foreground">What happens next?</p>
               <ol className="list-decimal list-inside space-y-1 text-xs">
                 <li>Our team reviews your profile and photos — usually within 1–2 business days.</li>
                 <li>You'll receive an email once approved.</li>


### PR DESCRIPTION
### Motivation
- Align the Pro (masseur) dashboard visual language with the Admin console so both dashboards share the same layout, tokens, and mobile-friendly behaviour.
- Improve the Admin Users area to make creating auth users + full profiles clearer and to make the user-management controls more usable on small screens.

### Description
- Updated the Pro layout shell to use the admin-style sidebar/header palette, tokenized colors, typography and a polished mobile drawer/header experience (`src/app/pro/ProLayoutClient.tsx`).
- Restyled the Pro dashboard page (cards, actions, spacings, progress bar, and availability widgets) to match admin fonts/colors and improve responsiveness (`src/app/pro/dashboard/page.tsx`).
- Clarified admin copy to highlight the ability to create new auth users with full profiles (`src/app/admin/users/page.tsx`).
- Improved `AdminUsersManager` input styling and responsive layout, added long `userId` wrapping, and tightened select/button behaviour for better mobile ergonomics while preserving the existing create-user + full-profile flow (`src/app/admin/_components/AdminUsersManager.tsx`).
- Note: I attempted a lockfile sync (`pnpm install`) and to push the branch, but `pnpm install` failed here due to a `403` fetching `@vercel/analytics` and `git push` could not run because this clone has no configured `origin` remote in the environment.

### Testing
- Ran `pnpm exec eslint` against the modified files and it passed for the changed files (`src/app/pro/ProLayoutClient.tsx`, `src/app/pro/dashboard/page.tsx`, `src/app/admin/users/page.tsx`, `src/app/admin/_components/AdminUsersManager.tsx`).
- Ran `pnpm exec tsc --noEmit` and it failed due to a pre-existing, unrelated TypeScript error in `src/app/pro/profile/ProProfilePageClient.tsx` (object literal contains unknown property `headline`).
- Note: `pnpm install` could not complete in this environment due to an external `ERR_PNPM_FETCH_403` for `@vercel/analytics`, so lockfile/installation validation was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e76336488320adf6337cd9f5b755)