### PR TITLE
Route admins to /admin on login and sync verification state

### DIFF
--- a/src/app/_components/auth-forms.tsx
+++ b/src/app/_components/auth-forms.tsx
@@ -215,10 +215,33 @@ export function AuthForms({
       }
     }
 
-    const result = isLogin
-      ? await signIn(email.trim(), password)
-      : await signUp(email.trim(), password, fullName.trim());
+    if (isLogin) {
+      const result = await signIn(email.trim(), password);
+      setLoading(false);
 
+      if (result.error) {
+        const errorMsg = result.error.message || "";
+        toast({
+          title: "Login failed",
+          description: errorMsg,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      toast({ title: "Welcome back" });
+      const destination = (!redirectTo || redirectTo === "/client/dashboard" || redirectTo === "/pro/dashboard")
+        ? result.role === "admin"
+          ? "/admin"
+          : redirectTo === "/client/dashboard"
+            ? "/client/dashboard"
+            : "/pro/dashboard"
+        : redirectTo;
+      window.location.href = destination;
+      return;
+    }
+
+    const result = await signUp(email.trim(), password, fullName.trim());
     setLoading(false);
 
     if (result.error) {
@@ -229,7 +252,7 @@ export function AuthForms({
         ((typeof (result.error as any)?.code === "string" && (result.error as any).code) === "USER_EXISTS");
 
       toast({
-        title: isLogin ? "Login failed" : "Could not register",
+        title: "Could not register",
         description: isUserExists
           ? "An account with this email already exists. Please sign in instead."
           : errorMsg,
@@ -242,13 +265,8 @@ export function AuthForms({
       return;
     }
 
-    toast({
-      title: isLogin ? "Welcome back" : "Account created",
-      description: isLogin ? undefined : "You can continue into onboarding now.",
-    });
-
-    const destination = isLogin ? redirectTo : "/signup/plan";
-    window.location.href = destination;
+    toast({ title: "Account created", description: "You can continue into onboarding now." });
+    window.location.href = "/signup/plan";
   };
 
   return (

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -29,7 +29,7 @@ function getServiceRoleKey() {
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") || "/pro/dashboard";
+  const requestedNext = searchParams.get("next");
 
   if (!code) {
     return NextResponse.redirect(new URL("/login?error=no_code", origin));
@@ -100,6 +100,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  const next = requestedNext || (role === "admin" ? "/admin" : "/pro/dashboard");
   const response = NextResponse.redirect(new URL(next, origin));
   response.headers.append(
     "Set-Cookie",

--- a/src/app/signup/verify/page.tsx
+++ b/src/app/signup/verify/page.tsx
@@ -78,6 +78,10 @@ export default function SignupVerifyPage() {
       phone: state.phone || user.phone?.trim() || "",
     });
 
+    if (user.email_confirmed_at) {
+      markEmailVerified();
+    }
+
     if (user.phone_confirmed_at) {
       markPhoneVerified();
     }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -25,7 +25,7 @@ interface AuthContextType {
   subscription: SubscriptionState;
   refreshSubscription: () => Promise<void>;
   signUp: (email: string, password: string, fullName: string) => Promise<{ error: Error | null }>;
-  signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
+  signIn: (email: string, password: string) => Promise<{ error: Error | null; role: "admin" | "provider" | "client" | null }>;
   signOut: () => Promise<void>;
 }
 
@@ -223,9 +223,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         console.warn("Client session sync failed after login.", sessionError);
       });
 
-      return { error: null };
+      return { error: null, role: result.role };
     } catch (error) {
-      return { error: error as Error };
+      return { error: error as Error, role: null };
     }
   };
 


### PR DESCRIPTION
### Motivation
- Admins signing in were not routed to the admin dashboard when no explicit redirect was provided, causing confusion after login.
- Verification steps (email/phone/Stripe identity) could appear stuck when Supabase already reported a verified email but the UI state was not synchronized.
- OAuth callback always defaulted to `/pro/dashboard` which prevented admin users from landing on the admin console after OAuth flows.

### Description
- Return the authenticated user's `role` from the client `signIn` flow by adjusting `AuthContext.signIn` to include `role` so the frontend can choose the proper post-login route (`src/contexts/AuthContext.tsx`).
- Update the login form logic to route admins to `/admin` when `redirectTo` is the default (or not provided), while preserving existing client/provider destinations (`src/app/_components/auth-forms.tsx`).
- Change the OAuth callback to use the requested `next` URL when present or fall back to `/admin` for admin users and `/pro/dashboard` for non-admins (`src/app/api/auth/callback/route.ts`).
- Sync email verification state on the signup verification page by marking email verified when Supabase already reports `email_confirmed_at` to avoid blocking the verification step (`src/app/signup/verify/page.tsx`).

### Testing
- Ran a TypeScript build check with `pnpm -s exec tsc --noEmit` and the run failed due to an existing unrelated type error in `src/app/pro/profile/ProProfilePageClient.tsx` about a `headline` property, and not due to the auth/redirect changes.
- No other automated test runs were performed in this PR; changes were committed and validated locally against the TypeScript typechecker (above) prior to creating the PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21e41e6048320825561b32dbc4b0f)