### PR TITLE
Redesign homepage city SEO links into premium marquee

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,35 +48,27 @@ export const metadata: Metadata = {
   },
 };
 
-const PRIORITY_INDEX_CITY_LINKS = [
-  { slug: "dallas", anchor: "male massage em Dallas com perfis verificados" },
-  { slug: "houston", anchor: "massagistas em Houston com contato direto" },
-  { slug: "austin", anchor: "descubra terapeutas premium em Austin" },
-  { slug: "miami", anchor: "encontre male massage em Miami hoje" },
-  { slug: "chicago", anchor: "guia confiável de massage em Chicago" },
-] as const;
-
-const TOP_20_CITY_SLUGS = [
-  "new-york",
-  "los-angeles",
-  "chicago",
-  "houston",
-  "phoenix",
-  "philadelphia",
-  "san-antonio",
-  "san-diego",
-  "dallas",
-  "austin",
-  "san-jose",
-  "fort-worth",
-  "jacksonville",
-  "columbus",
-  "charlotte",
-  "indianapolis",
-  "seattle",
-  "denver",
-  "washington-dc",
-  "miami",
+const HOMEPAGE_CITY_DISCOVERY = [
+  { slug: "new-york", blurb: "Massage therapists near you" },
+  { slug: "los-angeles", blurb: "Trusted local massage profiles" },
+  { slug: "chicago", blurb: "Direct contact massage listings" },
+  { slug: "miami", blurb: "Massage therapists available locally" },
+  { slug: "dallas", blurb: "Professional massage profiles" },
+  { slug: "houston", blurb: "Browse massage therapists" },
+  { slug: "austin", blurb: "Find local massage providers" },
+  { slug: "atlanta", blurb: "Trusted massage listings" },
+  { slug: "san-francisco", blurb: "Massage therapists nearby" },
+  { slug: "seattle", blurb: "Browse local massage profiles" },
+  { slug: "boston", blurb: "Professional massage listings" },
+  { slug: "washington-dc", blurb: "Find massage therapists" },
+  { slug: "denver", blurb: "Local massage profiles" },
+  { slug: "phoenix", blurb: "Trusted massage providers" },
+  { slug: "las-vegas", blurb: "Browse massage therapists" },
+  { slug: "orlando", blurb: "Local massage listings" },
+  { slug: "san-diego", blurb: "Massage providers nearby" },
+  { slug: "philadelphia", blurb: "Professional massage profiles" },
+  { slug: "portland", blurb: "Trusted massage listings" },
+  { slug: "nashville", blurb: "Browse massage therapists" },
 ] as const;
 
 export default async function HomePage() {
@@ -157,22 +149,14 @@ export default async function HomePage() {
     })
     .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
 
-  const priorityCityLinks = PRIORITY_INDEX_CITY_LINKS.map((entry) => {
+  const cityDiscoveryItems = HOMEPAGE_CITY_DISCOVERY.map((entry) => {
     const city = cities.find((cityItem) => cityItem.slug === entry.slug);
 
     return {
       href: city ? `/${city.slug}` : "/cities",
-      anchor: entry.anchor,
-    };
-  });
-
-  const topCityBannerItems = TOP_20_CITY_SLUGS.map((slug) => {
-    const city = cities.find((entry) => entry.slug === slug);
-    const label = city ? `${city.name}, ${city.stateCode}` : slug.replace(/-/g, " ");
-
-    return {
-      href: city ? `/${city.slug}` : "/cities",
-      label,
+      city: city?.name || entry.slug.replace(/-/g, " "),
+      state: city?.stateCode || "US",
+      blurb: entry.blurb,
     };
   });
 
@@ -235,8 +219,7 @@ export default async function HomePage() {
         featuredTherapists={featuredTherapists}
         totalTherapists={therapistsResult.total}
         cityCount={launchCities.length}
-        priorityCityLinks={priorityCityLinks}
-        topCityBannerItems={topCityBannerItems}
+        cityDiscoveryItems={cityDiscoveryItems}
       />
     </>
   );

--- a/src/components/homepage/CinematicHomepage.tsx
+++ b/src/components/homepage/CinematicHomepage.tsx
@@ -8,8 +8,7 @@ interface CinematicHomepageProps {
   featuredTherapists: Profile[];
   totalTherapists: number;
   cityCount: number;
-  priorityCityLinks: Array<{ href: string; anchor: string }>;
-  topCityBannerItems: Array<{ href: string; label: string }>;
+  cityDiscoveryItems: Array<{ href: string; city: string; state: string; blurb: string }>;
 }
 
 const featureCards = [
@@ -113,47 +112,34 @@ function HeroSection({ totalTherapists, cityCount }: { totalTherapists: number; 
   );
 }
 
-function TopCitySideBanner({ cities }: { cities: Array<{ href: string; label: string }> }) {
-  if (cities.length === 0) return null;
+function CityDiscoveryMarquee({ items }: { items: Array<{ href: string; city: string; state: string; blurb: string }> }) {
+  if (items.length === 0) return null;
 
-  const loopedCities = [...cities, ...cities];
+  const loopedItems = [...items, ...items];
 
   return (
-    <section className="border-y border-[#0B1F3A]/10 bg-[#F5EFE3] px-4 py-5 text-[#0B1F3A]">
-      <div className="mx-auto grid max-w-6xl gap-4 lg:grid-cols-[auto_minmax(0,1fr)] lg:items-center">
-        <p className="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-[#A56B21]">Top 20 Cities</p>
-        <div className="relative h-16 overflow-hidden rounded-2xl border border-[#0B1F3A]/10 bg-white">
-          <div className="animate-[city-side-scroll_28s_linear_infinite]">
-            {loopedCities.map((city, index) => (
+    <section className="bg-[#F5EFE3] px-4 py-14 text-[#0B1F3A] sm:px-6">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 text-center">
+          <h2 className="font-serif text-[clamp(30px,4vw,46px)] leading-tight tracking-[-0.02em]">Explore Massage Therapists by City</h2>
+          <p className="mx-auto mt-3 max-w-2xl font-sans text-sm leading-6 text-[#0B1F3A]/70 sm:text-base">
+            Browse trusted massage therapist profiles in major cities and connect directly.
+          </p>
+        </div>
+
+        <div className="city-marquee-wrap relative overflow-hidden rounded-3xl border border-[#0B1F3A]/10 bg-white/70 p-3 shadow-[0_14px_45px_rgba(11,31,58,0.08)] backdrop-blur-sm sm:p-4">
+          <div className="city-marquee-track flex w-max gap-3 sm:gap-4">
+            {loopedItems.map((item, index) => (
               <Link
-                key={`${city.href}-${index}`}
-                href={city.href}
-                className="block border-b border-[#0B1F3A]/8 px-4 py-2 font-sans text-sm font-medium transition hover:bg-[#FCFBF8]"
+                key={`${item.href}-${index}`}
+                href={item.href}
+                className="city-marquee-card group min-w-[220px] rounded-2xl border border-white/70 bg-white/85 px-5 py-4 text-left shadow-[0_8px_30px_rgba(11,31,58,0.08)] transition duration-300 hover:-translate-y-0.5 hover:border-[#1E4B8F]/20 hover:shadow-[0_14px_35px_rgba(11,31,58,0.14)] sm:min-w-[250px]"
               >
-                {city.label}
+                <p className="font-serif text-xl leading-tight text-[#0B1F3A]">{item.city}, {item.state}</p>
+                <p className="mt-2 font-sans text-sm leading-5 text-[#0B1F3A]/65">{item.blurb}</p>
               </Link>
             ))}
           </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function PriorityCityLinks({ links }: { links: Array<{ href: string; anchor: string }> }) {
-  if (links.length === 0) return null;
-
-  return (
-    <section className="bg-[#FCFBF8] px-6 py-12 text-[#0B1F3A]">
-      <div className="mx-auto max-w-6xl rounded-3xl border border-[#0B1F3A]/10 bg-white p-6 sm:p-8">
-        <p className="font-sans text-[11px] uppercase tracking-[0.2em] text-[#A56B21]">Fast index internal links</p>
-        <h2 className="mt-3 font-serif text-3xl leading-tight tracking-[-0.02em]">Explore our priority city pages</h2>
-        <div className="mt-6 flex flex-wrap gap-2">
-          {links.map((link) => (
-            <Link key={link.href} href={link.href} className="rounded-full border border-[#0B1F3A]/20 px-4 py-2 font-sans text-xs font-semibold uppercase tracking-[0.08em] transition hover:bg-[#0B1F3A] hover:text-[#FCFBF8]">
-              {link.anchor}
-            </Link>
-          ))}
         </div>
       </div>
     </section>
@@ -296,28 +282,16 @@ export function CinematicHomepage({
   featuredTherapists,
   totalTherapists,
   cityCount,
-  priorityCityLinks,
-  topCityBannerItems,
+  cityDiscoveryItems,
 }: CinematicHomepageProps) {
   return (
     <main className="overflow-x-hidden bg-[#FCFBF8]">
       <HeroSection totalTherapists={totalTherapists} cityCount={cityCount} />
-      <TopCitySideBanner cities={topCityBannerItems} />
-      <PriorityCityLinks links={priorityCityLinks} />
+      <CityDiscoveryMarquee items={cityDiscoveryItems} />
       <FeaturedTherapists therapists={featuredTherapists} />
       <BenefitsSection />
       <HowItWorksSection />
       <TherapistCTASection />
-      <style jsx global>{`
-        @keyframes city-side-scroll {
-          from {
-            transform: translateY(0);
-          }
-          to {
-            transform: translateY(-50%);
-          }
-        }
-      `}</style>
     </main>
   );
 }

--- a/src/components/homepage/world-class.css
+++ b/src/components/homepage/world-class.css
@@ -2428,3 +2428,49 @@
     gap: 16px;
   }
 }
+
+.city-marquee-wrap::before,
+.city-marquee-wrap::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 34px;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.city-marquee-wrap::before {
+  left: 0;
+  background: linear-gradient(90deg, #f5efe3 0%, rgba(245, 239, 227, 0) 100%);
+}
+
+.city-marquee-wrap::after {
+  right: 0;
+  background: linear-gradient(270deg, #f5efe3 0%, rgba(245, 239, 227, 0) 100%);
+}
+
+.city-marquee-track {
+  animation: city-marquee-x 38s linear infinite;
+  will-change: transform;
+}
+
+.city-marquee-wrap:hover .city-marquee-track,
+.city-marquee-wrap:active .city-marquee-track,
+.city-marquee-wrap:focus-within .city-marquee-track {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .city-marquee-track {
+    animation: none;
+    transform: none;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+}
+
+@keyframes city-marquee-x {
+  from { transform: translateX(-50%); }
+  to { transform: translateX(0); }
+}


### PR DESCRIPTION
### Motivation
- The existing homepage city blocks showed unfinished internal SEO labels, mixed Portuguese text, and oversized pill UI that looked cheap on mobile.  
- The intent is to replace those fragments with a single intentional, mobile-first, luxury city discovery section aligned with brand colors and typography.  
- The new section should remain crawlable, accessible (`prefers-reduced-motion`) and avoid heavy carousel dependencies.

### Description
- Replaced the old `TopCitySideBanner` and `PriorityCityLinks` with a new `CityDiscoveryMarquee` component in `src/components/homepage/CinematicHomepage.tsx` that renders a title, subtitle and an animated horizontal marquee of glass city cards.  
- Added a curated `HOMEPAGE_CITY_DISCOVERY` list (20 cities with English-only SEO blurbs) in `src/app/page.tsx` and mapped it to `cityDiscoveryItems` so links remain standard crawlable anchors.  
- Implemented seamless infinite marquee by duplicating the items array (`[...items, ...items]`) and using a lightweight CSS `@keyframes` animation in `src/components/homepage/world-class.css`, with pause-on-hover/active/focus and `prefers-reduced-motion` fallback that disables animation and wraps cards.  
- Removed visible labels and headings `Top 20 Cities`, `Fast Index Internal Links`, and `Explore our priority city pages`, eliminated Portuguese anchor text, and kept all other homepage sections unchanged.

### Testing
- Ran `pnpm typecheck` and it completed successfully.  
- Ran `pnpm lint` and it completed successfully with one unrelated pre-existing warning in `src/app/signup/verify/page.tsx`.  
- Ran `pnpm build` and the production build succeeded (non-blocking environment/runtime warnings only).  
- Attempted to capture a mobile screenshot via Playwright but browser binaries are not installed in the environment (`pnpm exec playwright install` required), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f228108e9c8320a544f384bd08bd25)