### PR TITLE
fix: consolidate PR 163 and 166 for production deploy

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 /// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited

--- a/src/app/_components/home-seo-landing.tsx
+++ b/src/app/_components/home-seo-landing.tsx
@@ -402,11 +402,6 @@ export function HomeSeoLanding({
                   )}
 
                   <div className="absolute left-4 top-4 flex flex-wrap gap-2">
-                    {therapist._tier ? (
-                      <span className="rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-brand-primary">
-                        {therapist._tier}
-                      </span>
-                    ) : null}
                     {(therapist.is_verified_identity || therapist.is_verified_profile) ? (
                       <span className="rounded-full bg-[rgba(15,118,110,0.88)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white">
                         Verified

--- a/src/app/_components/site-header.tsx
+++ b/src/app/_components/site-header.tsx
@@ -261,7 +261,7 @@ export default function SiteHeader() {
         {/* Right CTAs — desktop + mobile hamburger */}
         <div className="flex items-center gap-3">
           <Link
-            href={user ? "/client/dashboard" : "/login"}
+            href={user ? "/pro/dashboard" : "/login"}
             className={`hidden md:flex px-4 py-2 text-sm font-medium transition-colors ${
               isDarkHero ? 'text-white/80 hover:text-white' : 'text-[#4A4F5C] hover:text-[#0B1F3A]'
             }`}

--- a/src/app/therapists/[slug]/_components/PremiumProfileGallery.tsx
+++ b/src/app/therapists/[slug]/_components/PremiumProfileGallery.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import type { PublicTherapist, ProfilePhoto } from "@/app/_lib/directory";
 import { getPublicProfileName } from "@/app/_lib/public-profile";
-import { galleryLimit } from "./galleryLimit";
 
 interface Props {
   profile: PublicTherapist;
@@ -11,7 +10,6 @@ interface Props {
 }
 
 export function PremiumProfileGallery({ profile, photos }: Props) {
-  const limit = galleryLimit(profile._tier);
   const name = getPublicProfileName(profile);
   const city = profile.city || "the area";
 
@@ -20,9 +18,9 @@ export function PremiumProfileGallery({ profile, photos }: Props) {
     : [];
 
   const images = photos.length > 0
-    ? photos.slice(0, limit).map((p) => p.storage_path)
+    ? photos.slice(0, 24).map((p) => p.storage_path)
     : demoPhotos.length > 0
-      ? demoPhotos.slice(0, limit)
+      ? demoPhotos.slice(0, 24)
       : [profile.avatar_url].filter(Boolean) as string[];
 
   if (images.length === 0) {
@@ -63,19 +61,6 @@ export function PremiumProfileGallery({ profile, photos }: Props) {
           {i === 0 && <span className="pp-gallery-tag">New</span>}
         </div>
       ))}
-      
-      {/* Show tier note */}
-      {profile._tier && (
-        <div className="col-span-full mt-2 rounded-lg border border-[var(--glass-border)] bg-[var(--cream-dim)] px-4 py-3 flex items-center justify-between text-xs text-[var(--text-dim)]">
-          <span>
-            {name} is on the{" "}
-            <strong style={{ color: "var(--orange)" }}>
-              {profile._tier.toUpperCase()} Plan
-            </strong>{" "}
-            · {limit} photos available
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/app/therapists/[slug]/_components/ProfileGallery.tsx
+++ b/src/app/therapists/[slug]/_components/ProfileGallery.tsx
@@ -2,7 +2,6 @@ import Image from "next/image";
 import type { PublicTherapist } from "@/app/_lib/directory";
 import type { ProfilePhoto } from "@/app/_lib/directory";
 import { getPublicProfileName } from "@/app/_lib/public-profile";
-import { galleryLimit } from "./galleryLimit";
 
 interface Props {
   profile: PublicTherapist;
@@ -10,12 +9,11 @@ interface Props {
 }
 
 export function ProfileGallery({ profile, photos }: Props) {
-  const limit = galleryLimit(profile._tier);
   const name = getPublicProfileName(profile);
   const city = profile.city || "US";
 
   const images = photos.length > 0
-    ? photos.slice(0, limit).map((p) => p.storage_path)
+    ? photos.slice(0, 24).map((p) => p.storage_path)
     : [profile.avatar_url].filter(Boolean) as string[];
 
   if (images.length === 0) return null;
@@ -23,9 +21,6 @@ export function ProfileGallery({ profile, photos }: Props) {
   return (
     <section id="gallery" className="profile-panel scroll-mt-24 p-6 md:p-7">
       <h2 className="text-2xl font-semibold text-foreground">Gallery</h2>
-      <p className="mt-1 text-xs text-muted-foreground">
-        {profile._tier === "elite" ? "Up to 12 photos" : profile._tier === "pro" ? "Up to 9 photos" : "Up to 5 photos"}
-      </p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {images.map((src, i) => (
           <div key={`gallery-${i}`} className="profile-panel-soft overflow-hidden rounded-[1.5rem]">

--- a/src/app/therapists/[slug]/_components/ProfileHero.tsx
+++ b/src/app/therapists/[slug]/_components/ProfileHero.tsx
@@ -11,11 +11,9 @@ import {
   Phone,
   Ruler,
   ShieldCheck,
-  Sparkles,
 } from "lucide-react";
 import type { PublicTherapist } from "@/app/_lib/directory";
 import {
-  getDirectoryTierLabel,
   getPublicContactLinks,
   getPublicProfileName,
   getPublicTrustHighlights,
@@ -79,7 +77,6 @@ export function ProfileHero({ profile, cityPath }: Props) {
     profile.years_experience ?? (profile.start_year ? new Date().getFullYear() - profile.start_year : null);
   const startingAt = profile.incall_price ?? profile.outcall_price;
   const trustHighlights = getPublicTrustHighlights(profile).slice(0, 4);
-  const tierLabel = getDirectoryTierLabel(profile);
   const physicalProfile = buildPhysicalProfileSummary({
     heightInches: profile.height_inches,
     weightLb: profile.weight_lb,
@@ -100,10 +97,6 @@ export function ProfileHero({ profile, cityPath }: Props) {
               <ArrowUpRight className="h-4 w-4" />
               Explore {city}
             </Link>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/14 bg-white/8 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-white/84 backdrop-blur">
-              <Sparkles className="h-4 w-4" />
-              {tierLabel} profile
-            </span>
             {isVerifiedDirectoryProfile(profile) ? (
               <span className="inline-flex items-center gap-2 rounded-full border border-white/14 bg-white/8 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-white/84 backdrop-blur">
                 <BadgeCheck className="h-4 w-4" />
@@ -250,10 +243,10 @@ export function ProfileHero({ profile, cityPath }: Props) {
             <ShieldCheck className="h-5 w-5 text-brand-soft" />
             <div>
               <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/50">
-                {yearsExp ? "Experience" : "Profile tier"}
+                Experience
               </p>
               <p className="text-sm font-semibold text-white">
-                {yearsExp ? `${yearsExp}+ years` : `${tierLabel} listing`}
+                {yearsExp ? `${yearsExp}+ years` : "Professional provider"}
               </p>
             </div>
           </div>

--- a/src/app/therapists/[slug]/_components/galleryLimit.ts
+++ b/src/app/therapists/[slug]/_components/galleryLimit.ts
@@ -1,7 +1,0 @@
-import type { TherapistTier } from "@/app/_lib/directory";
-
-export function galleryLimit(tier: TherapistTier | null): number {
-  if (tier === "elite") return 12;
-  if (tier === "pro") return 9;
-  return 5;
-}

--- a/src/app/therapists/[slug]/page.tsx
+++ b/src/app/therapists/[slug]/page.tsx
@@ -16,94 +16,7 @@ import {
   buildProfilePageJsonLd,
   createPageMetadata,
 } from "@/app/_lib/seo";
-import { galleryLimit } from "./_components/galleryLimit";
 import { PremiumProfilePage } from "./_components/PremiumProfilePage";
-
-// Demo/fallback profiles for SEO and testing
-const DEMO_PROFILES: Record<string, any> = {
-  'bruno-dallas-tx': {
-    id: 'bruno-demo-001',
-    slug: 'bruno-dallas-tx',
-    display_name: 'Bruno',
-    full_name: 'Bruno Santos',
-    city: 'Dallas',
-    state: 'Texas',
-    neighborhood_name: 'Oak Lawn',
-    primary_area: 'Uptown Dallas',
-    bio: 'With 14 years of professional experience, I bring a unique blend of Brazilian therapeutic bodywork and diverse massage modalities to every session. My practice is rooted in both Brazilian and American massage traditions, offering techniques ranging from traditional AMMA Therapy and Zero Balancing to Deep Tissue, Shiatsu, Hot Stone, and Lymphatic Drainage. Based in Oak Lawn, I operate from a private studio with full amenities — shower, private restroom, and hot towels included. My practice is proudly LGBTQ+ owned and operated. Whether you prefer an in-studio session or a mobile outcall to your home or hotel throughout Dallas, I customize every session to your specific needs. Member of the National Association of Massage Therapists.',
-    avatar_url: '/photos/bruno/photo-4.jpg',
-    photo_url: '/photos/bruno/photo-4.jpg',
-    gallery_photos: [
-      '/photos/bruno/photo-4.jpg',
-      '/photos/bruno/photo-3.jpg',
-      '/photos/bruno/photo-1.jpg',
-      '/photos/bruno/photo-2.jpg',
-    ],
-    modality: 'Licensed Massage Therapist',
-    specialties: ['AMMA Therapy', 'Deep Tissue', 'Hot Stone', 'Lymphatic Drainage', 'Myofascial Release', 'Shiatsu', 'Swedish', 'Zero Balancing'],
-    languages_spoken: ['English', 'Portuguese'],
-    contact_email: 'bruno@masseurmatch.com',
-    phone: '(762) 334-5300',
-    incall_price: 175,
-    outcall_price: 175,
-    pricing_sessions: [
-      { name: 'Standard Session', duration: 60, incall: 175, outcall: 175 },
-      { name: 'Extended Session', duration: 90, incall: 250, outcall: 250 },
-    ],
-    years_experience: 14,
-    lgbtq_affirming: true,
-    accepts_all_genders: true,
-    available_now: true,
-    is_verified_identity: true,
-    is_verified_profile: true,
-    review_count: 12,
-    _tier: 'pro',
-    areas_served: ['Highland Park', 'University Park', 'Downtown Dallas', 'Turtle Creek', 'Oak Lawn', 'Uptown'],
-    education: 'Degree in Accounting and Business, UFRJ (2000–2003)',
-    training: [
-      { label: 'National Association of Massage Therapists', detail: 'Professional Member' }
-    ],
-    promotions: [
-      { title: 'Monday Special', description: '10% off any session on Mondays' },
-      { title: 'Weekly Offer', description: '$10 off any session – week of April 5' },
-      { title: 'Loyalty & Service Discounts', description: 'Special discounts for military, law enforcement, and repeat clients' },
-    ],
-    add_ons: [
-      { name: 'Cupping Therapy', price: 25 },
-      { name: 'Fitness Training', price: 50 },
-    ],
-    travel_schedule: [
-      { city: 'Pensacola', state: 'FL', start_date: '2026-04-01', end_date: '2026-04-01' },
-      { city: 'Tallahassee', state: 'FL', start_date: '2026-04-02', end_date: '2026-04-02' },
-    ],
-    custom_faq: [
-      {
-        question: 'What massage techniques do you offer?',
-        answer: 'I offer AMMA Therapy, Deep Tissue, Hot Stone, Lymphatic Drainage, Myofascial Release, Shiatsu, Swedish, and Zero Balancing. I also offer cupping therapy and fitness training as add-ons.'
-      },
-      {
-        question: 'What are your rates?',
-        answer: '60-minute sessions start at $175 and 90-minute sessions are $250. I offer a 10% Monday discount and periodic promotional deals. Special pricing available for military, law enforcement, and repeat clients.'
-      },
-      {
-        question: 'Do you offer outcall services?',
-        answer: 'Yes! I offer mobile massage to homes and hotels throughout Dallas, including Highland Park, University Park, Downtown Dallas, Turtle Creek, Oak Lawn, and Uptown.'
-      },
-      {
-        question: 'What are your hours?',
-        answer: 'I am available daily from midnight to 11pm. Contact me via text or call to schedule your session.'
-      },
-      {
-        question: 'What payment methods do you accept?',
-        answer: 'I accept Apple Pay, Cash, Mastercard, Venmo, Visa, and Zelle.'
-      },
-      {
-        question: 'Is your practice LGBTQ+ friendly?',
-        answer: 'Absolutely. My practice is proudly LGBTQ+ owned and operated. I welcome all clients and create a safe, inclusive, and judgment-free environment.'
-      }
-    ]
-  }
-};
 
 type Params = { slug: string };
 
@@ -112,33 +25,15 @@ export const revalidate = 60;
 export async function generateStaticParams() {
   try {
     const res = await getPublicTherapists({ page: 1, pageSize: 200 });
-    const dbParams = res.items.map((item) => ({ slug: item.slug || item.id }));
-    
-    // Always include demo profiles
-    const demoParams = Object.keys(DEMO_PROFILES).map(slug => ({ slug }));
-    
-    // Merge and deduplicate
-    const allParams = [...demoParams, ...dbParams];
-    const seen = new Set<string>();
-    return allParams.filter(p => {
-      if (seen.has(p.slug)) return false;
-      seen.add(p.slug);
-      return true;
-    });
+    return res.items.map((item) => ({ slug: item.slug || item.id }));
   } catch {
-    // If DB fails, return demo profiles
-    return Object.keys(DEMO_PROFILES).map(slug => ({ slug }));
+    return [];
   }
 }
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
   const resolvedParams = await params;
-  let profile = await getPublicTherapistBySlug(resolvedParams.slug);
-
-  // Use demo profile as fallback
-  if (!profile && DEMO_PROFILES[resolvedParams.slug]) {
-    profile = DEMO_PROFILES[resolvedParams.slug];
-  }
+  const profile = await getPublicTherapistBySlug(resolvedParams.slug);
 
   if (!profile) {
     return createPageMetadata({
@@ -198,21 +93,15 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
 
 export default async function TherapistPage({ params }: { params: Promise<Params> }) {
   const resolvedParams = await params;
-  let profile = await getPublicTherapistBySlug(resolvedParams.slug);
-
-  // Use demo profile as fallback
-  if (!profile && DEMO_PROFILES[resolvedParams.slug]) {
-    profile = DEMO_PROFILES[resolvedParams.slug];
-  }
+  const profile = await getPublicTherapistBySlug(resolvedParams.slug);
 
   if (!profile) {
     notFound();
   }
 
-  const photoLimit = galleryLimit(profile._tier);
   const [reviews, photos] = await Promise.all([
     getImportedReviews(profile.id, 5),
-    getProfilePhotos(profile.id, photoLimit),
+    getProfilePhotos(profile.id),
   ]);
 
   const name = getPublicProfileName(profile);


### PR DESCRIPTION
### Motivation
- Reapply only the useful, non-stale fixes from two previous PRs so the repo builds and deploys cleanly without merging old branches.  
- Ensure provider login/redirect, public profile privacy, gallery behavior, and homepage visuals match the intended production behavior.  
- Remove duplicated/stale demo and tier-exposure code that caused conflicts and visual/regression issues.  

### Description
- Kept from PR #166: normalized provider dashboard routing so authenticated header CTA and safe-auth helpers point to `/pro/dashboard`, removed public billing-tier exposure (tier badges and plan callouts) in public profile UI, removed tier-based gallery limit logic, removed fake/demo public-profile fallback content, and preserved provider profile validation fixes to keep dashboard profile saving working.  
- Kept from PR #163: selectively retained only the useful public-profile cleanup changes (tier exposure removal and demo fallback removal) and the provider dashboard redirect consistency, while discarding outdated or duplicate branch code.  
- Already present in main before this PR: the homepage city marquee redesign (premium animated city marquee with English title/subtitle) and core auth redirect hardening for `/pro/dashboard`.  
- Conflicts resolved: removed duplicate/stale gallery helper and tier UI bits, deleted demo fallback code paths, and avoided reintroducing old `pnpm-lock.yaml` changes by preserving the lockfile from main.  
- Key file changes: header CTA (`src/app/_components/site-header.tsx`) now links authenticated users to `/pro/dashboard`; therapist slug page (`src/app/therapists/[slug]/page.tsx`) no longer returns demo fallback or uses tier-based photo limits; gallery components removed tier messaging and use a neutral cap; removed `galleryLimit.ts` helper and cleaned up featured listing tier badges.  

### Testing
- Validation commands executed: `pnpm install`, `pnpm typecheck`, `pnpm lint`, and `pnpm build`.  
- Results: `pnpm install` completed (lockfile up-to-date), `pnpm typecheck` passed, `pnpm lint` completed with one non-blocking existing warning about `react-hooks/exhaustive-deps` in `src/app/signup/verify/page.tsx`, and `pnpm build` completed successfully (Next.js production build and static generation succeeded).  
- `pnpm-lock.yaml` confirmation: the lockfile was kept from the main baseline and is consistent with `package.json` (installation completed without lock conflicts).  
- Deployment confidence: build and validations completed successfully in CI-like local runs, so Vercel should deploy this branch cleanly with no merge-conflict artifacts or stale lockfile reintroductions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22c52477c83208829c255e8fcae76)