### PR TITLE
Sanitize redirect target and preserve redirect query across auth forms

### DIFF
--- a/src/app/_components/auth-forms.tsx
+++ b/src/app/_components/auth-forms.tsx
@@ -290,6 +290,15 @@ export function AuthForms({
   const [rememberMe, setRememberMe] = useState(true);
   const [method, setMethod] = useState<AuthMethod>("email");
 
+  const sanitizedRedirectTo =
+    typeof redirectTo === "string" && redirectTo.startsWith("/") && !redirectTo.startsWith("//")
+      ? redirectTo
+      : "/pro/dashboard";
+
+  const loginHref = `/login?redirect=${encodeURIComponent(sanitizedRedirectTo)}`;
+  const registerHref = `/register?redirect=${encodeURIComponent(sanitizedRedirectTo)}`;
+  const forgotPasswordHref = `/forgot-password?redirect=${encodeURIComponent(sanitizedRedirectTo)}`;
+
   const isLogin = mode === "login";
 
   // Remember user email
@@ -350,7 +359,7 @@ export function AuthForms({
     });
 
     // Use window.location for a full page navigation to ensure cookies are read properly
-    const destination = isLogin ? redirectTo : "/pro/onboard";
+    const destination = isLogin ? sanitizedRedirectTo : "/pro/onboard";
     window.location.href = destination;
   };
 
@@ -359,13 +368,13 @@ export function AuthForms({
       {/* Mode toggle */}
       <div className="inline-flex rounded-full border border-border bg-secondary/60 p-1 text-sm font-semibold">
         <Link
-          href="/login"
+          href={loginHref}
           className={`rounded-full px-4 py-2 transition ${isLogin ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"}`}
         >
           Sign in
         </Link>
         <Link
-          href="/register"
+          href={registerHref}
           className={`rounded-full px-4 py-2 transition ${!isLogin ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"}`}
         >
           Sign up
@@ -391,9 +400,9 @@ export function AuthForms({
 
       <div className="mt-4">
         {method === "phone" ? (
-          <PhoneOtpForm isLogin={isLogin} redirectTo={redirectTo} />
+          <PhoneOtpForm isLogin={isLogin} redirectTo={sanitizedRedirectTo} />
         ) : method === "email-otp" ? (
-          <EmailOtpForm isLogin={isLogin} redirectTo={redirectTo} />
+          <EmailOtpForm isLogin={isLogin} redirectTo={sanitizedRedirectTo} />
         ) : (
           <form onSubmit={onSubmit} className="space-y-3">
             {!isLogin ? (
@@ -438,7 +447,7 @@ export function AuthForms({
                   />
                   Remember me
                 </label>
-                <Link href="/forgot-password" className="text-sm font-semibold text-primary hover:underline">
+                <Link href={forgotPasswordHref} className="text-sm font-semibold text-primary hover:underline">
                   Forgot password?
                 </Link>
               </div>
@@ -457,12 +466,12 @@ export function AuthForms({
         {isLogin ? (
           <>
             Don&apos;t have an account?{" "}
-            <Link href="/register" className="font-semibold text-primary hover:underline">Sign up</Link>
+            <Link href={registerHref} className="font-semibold text-primary hover:underline">Sign up</Link>
           </>
         ) : (
           <>
             Already have an account?{" "}
-            <Link href="/login" className="font-semibold text-primary hover:underline">Sign in</Link>
+            <Link href={loginHref} className="font-semibold text-primary hover:underline">Sign in</Link>
           </>
         )}
       </div>


### PR DESCRIPTION
### Motivation
- Prevent broken or unsafe post-auth navigation by ensuring `AuthForms` only uses safe in-app relative redirect targets and by preserving the user's intended destination when switching between sign in / sign up / forgot-password links.

### Description
- Sanitize the incoming `redirectTo` in `AuthForms` to accept only single-leading-slash relative paths and default to `/pro/dashboard` when invalid.
- Build `loginHref`, `registerHref`, and `forgotPasswordHref` that encode the sanitized redirect and use these links for the mode toggle and forgot-password link so the `redirect` query param is preserved.
- Use the sanitized redirect consistently for email/password and OTP completion flows so post-auth navigation is deterministic.

### Testing
- Ran `npm run -s test -- tests/auth/smoke.spec.ts` and it passed (API smoke tests passed: forgot-password, contact, og, admin-blog-unauthorized, pro-profile-unauthorized, login-validation, register-validation, logout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3572a25448320aa5966731b971a6f)