### PR TITLE
Fix client dashboard navigation and logout action

### DIFF
--- a/src/app/client/dashboard/_components/ClientDashboardLayout.tsx
+++ b/src/app/client/dashboard/_components/ClientDashboardLayout.tsx
@@ -1,18 +1,26 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Bell, Heart, Search, Settings, LogOut } from 'lucide-react';
 
 export function ClientDashboardLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    router.push('/login');
+    router.refresh();
+  };
 
   const navItems = [
     { href: '/client/dashboard', label: 'Dashboard', icon: Search },
-    { href: '/client/inquiries', label: 'Inquiries', icon: Bell },
-    { href: '/client/favorites', label: 'Favorites', icon: Heart },
-    { href: '/client/settings', label: 'Settings', icon: Settings },
+    { href: '/client/dashboard/inquiries', label: 'Inquiries', icon: Bell },
+    { href: '/client/dashboard/favorites', label: 'Favorites', icon: Heart },
+    { href: '/client/dashboard/settings', label: 'Settings', icon: Settings },
   ];
 
   return (
@@ -25,14 +33,13 @@ export function ClientDashboardLayout({ children }: { children: React.ReactNode 
               My Dashboard
             </h1>
             <Button
+              type="button"
               variant="ghost"
               size="sm"
               className="text-slate-600 hover:text-slate-900"
-              asChild
+              onClick={handleLogout}
             >
-              <Link href="/auth/logout">
-                <LogOut className="h-4 w-4" />
-              </Link>
+              <LogOut className="h-4 w-4" />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Client dashboard navigation pointed to non-existent top-level routes which made subsections inaccessible. 
- The header logout action was implemented as a link to a non-page URL instead of invoking the API and clearing the session.

### Description
- Updated dashboard tab links in `src/app/client/dashboard/_components/ClientDashboardLayout.tsx` to use the existing nested routes under `/client/dashboard/*` (`/client/dashboard/inquiries`, `/client/dashboard/favorites`, `/client/dashboard/settings`).
- Replaced the logout `<Link>` with a client-side `handleLogout` that sends a `POST` to `/api/auth/logout`, then redirects to `/login` and refreshes the router state using `useRouter` from `next/navigation`.
- Minor UI prop adjustments to the `Button` (removed `asChild` and added `type="button"` and `onClick`) to support the new logout handler.

### Testing
- Ran TypeScript compile check with `pnpm -s exec tsc --noEmit --pretty false`, which failed due to unrelated pre-existing TypeScript errors elsewhere in the repository and not caused by these changes.
- No other automated tests were added or run for this small UI/navigation fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3580f53bc8320a8c2f0913284a3fd)