### PR TITLE
Fix Stripe ID flow: return users and auto-approve verified profiles

### DIFF
--- a/src/app/api/stripe/identity/check-status/route.ts
+++ b/src/app/api/stripe/identity/check-status/route.ts
@@ -65,8 +65,13 @@ export async function GET(request: NextRequest) {
     if (stripeSession.status === "verified") {
       await adminClient
         .from("profiles")
-        .update({ is_verified_identity: true })
-        .eq("user_id", userId);
+        .update({
+          is_verified_identity: true,
+          verification_status: "verified",
+          status: "approved",
+        })
+        .eq("user_id", userId)
+        .in("status", ["pending", "pending_approval"]);
     }
 
     return NextResponse.json({

--- a/src/app/api/stripe/identity/create-session/route.ts
+++ b/src/app/api/stripe/identity/create-session/route.ts
@@ -53,8 +53,11 @@ export async function POST(request: NextRequest) {
     }
 
     const stripe = getStripe();
+    const origin = request.nextUrl.origin;
+    const returnUrl = `${origin}/signup/verify?identity_return=1`;
     const verificationSession = await stripe.identity.verificationSessions.create({
       type: "document",
+      return_url: returnUrl,
       metadata: {
         userId: targetUserId,
         email: targetEmail,


### PR DESCRIPTION
### Motivation
- Users were not redirected back to the site after completing the Stripe Identity flow, leaving them stuck on Stripe pages. 
- Profiles that completed identity verification on Stripe sometimes stayed in `pending`/`pending_approval` instead of being automatically approved when an ID match occurred.

### Description
- Added a `return_url` to the Stripe verification session in `src/app/api/stripe/identity/create-session/route.ts` so Stripe redirects users back to `/signup/verify?identity_return=1` after completion. 
- Updated `src/app/api/stripe/identity/check-status/route.ts` so when a Stripe session is `verified` the code now sets `is_verified_identity = true`, `verification_status = "verified"`, and promotes `status = "approved"` only for profiles whose current `status` is `pending` or `pending_approval`.
- Preserved and still update the `identity_verifications` record with the mapped status and `last_error` when syncing Stripe session state.

### Testing
- Ran `npm run typecheck`, which failed due to unrelated pre-existing TypeScript errors in other modules and not because of these changes. 
- No other automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f358b37d3c8320b485c72b333eab66)