### PR TITLE
Fix therapist profile opening and explore API/data-shape regressions

### DIFF
--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -256,8 +256,14 @@ export const getPublicTherapists = async (filters?: {
 };
 
 export const getPublicTherapistBySlug = async (slug: string): Promise<PublicTherapist | null> => {
+  const sanitizedSlug = slug.trim();
+
+  if (!sanitizedSlug) {
+    return null;
+  }
+
   const { data: profile, error } = await buildPublicTherapistsQuery()
-    .eq("slug", slug)
+    .or(`slug.eq.${sanitizedSlug},id.eq.${sanitizedSlug}`)
     .maybeSingle();
 
   if (error || !profile) return null;

--- a/src/app/api/providers/route.ts
+++ b/src/app/api/providers/route.ts
@@ -55,11 +55,11 @@ export async function GET(request: Request) {
 
   return NextResponse.json({
     ok: true,
-    items: result.slice(from, to).map(serializeExploreProvider),
-    total: result.length,
+    items: result.items.slice(from, to).map(serializeExploreProvider),
+    total: result.total,
     page,
     pageSize,
-    hasMore: to < result.length,
+    hasMore: to < result.total,
     filters,
     meta: {
       cache_hit: cacheHit,

--- a/src/app/api/swipe-feed/route.ts
+++ b/src/app/api/swipe-feed/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
     });
   }
 
-  const items = result
+  const items = result.items
     .filter((provider) => !exclude.has(provider.id))
     .slice(0, limit);
 

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -56,7 +56,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
   const filters = parseExploreSearchParams(params);
   const baseFilters = getBaseExploreFilters(filters);
   const baseResult = await loadExploreProviders(baseFilters);
-  const initialItems = applyExploreFilters(baseResult, filters);
+  const initialItems = applyExploreFilters(baseResult.items, filters, baseResult.origin);
   const hasExplicitLocation = Boolean(getFirstParam(params.city) || getFirstParam(params.zip));
 
   return (
@@ -72,9 +72,9 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
       <ExplorePageClient
         cities={getCities()}
         hasExplicitLocation={hasExplicitLocation}
-        initialBaseItems={baseResult}
+        initialBaseItems={baseResult.items}
         initialFilters={filters}
-        initialInvalidProviderCount={0}
+        initialInvalidProviderCount={baseResult.invalidProviderCount}
         initialTotal={initialItems.length}
       />
     </>

--- a/src/app/explore/usa/[city]/page.tsx
+++ b/src/app/explore/usa/[city]/page.tsx
@@ -64,7 +64,7 @@ export default async function ExploreCityPage({ params }: { params: Promise<Para
   };
   const baseFilters = getBaseExploreFilters(filters);
   const baseResult = await loadExploreProviders(baseFilters);
-  const initialItems = applyExploreFilters(baseResult, filters);
+  const initialItems = applyExploreFilters(baseResult.items, filters, baseResult.origin);
 
   return (
     <>
@@ -80,9 +80,9 @@ export default async function ExploreCityPage({ params }: { params: Promise<Para
       <ExplorePageClient
         cities={getCities()}
         hasExplicitLocation
-        initialBaseItems={baseResult}
+        initialBaseItems={baseResult.items}
         initialFilters={filters}
-        initialInvalidProviderCount={0}
+        initialInvalidProviderCount={baseResult.invalidProviderCount}
         initialTotal={initialItems.length}
       />
     </>


### PR DESCRIPTION
### Motivation
- Resolve broken "View profile" behavior where therapist profile pages failed to open when links used an id fallback instead of a slug. 
- Make the explore/provider APIs and pages compatible with the refactored `loadExploreProviders` return shape so pagination, swipe feed, and explore pages work reliably. 
- Remove blocking type/shape mismatches that break production builds in the explore and provider APIs. 

### Description
- Update public profile lookup to sanitize input and query by either `slug` or `id` (`getPublicTherapistBySlug`) so profile routes resolve for slug or id links. 
- Change `/api/providers` to read the refactored result shape (`result.items` / `result.total`) and use `serializeExploreProvider` on the paginated slice. 
- Change `/api/swipe-feed` to read from `result.items` before filtering and slicing so the swipe feed respects exclusions and limits. 
- Update server Explore pages (`/explore` and `/explore/usa/[city]`) to use `baseResult.items` and `baseResult.origin` when applying filters and to pass `initialBaseItems`, `initialInvalidProviderCount`, and other corrected props into `ExplorePageClient`. 

### Testing
- Ran `npm run lint`, which completed successfully. 
- Ran `npm run build` repeatedly during debugging; the build progressed further after these fixes but exposed additional pre-existing type issues elsewhere in the codebase, so a full green production build has not been completed in this PR. 
- Type errors specifically blocking explore/provider API consumers were addressed and the touched explore/API paths now use the consistent `loadExploreProviders` return contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35793f1e48320bc0da304496898d3)