### PR TITLE
Use ipapi `region_code` as fallback for state code in useGeolocation

### DIFF
--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -17,6 +17,8 @@ type GeolocationStatus = "idle" | "checking" | "ready" | "unsupported" | "denied
 type IpCityResponse = {
   city?: string | null;
   stateCode?: string | null;
+  region_code?: string | null;
+  region?: string | null;
 };
 
 type UseGeolocationOptions = {
@@ -125,7 +127,8 @@ export function useGeolocation(options: UseGeolocationOptions = {}) {
   const resolveCityFromIpFallback = useCallback(async () => {
     try {
       const response = await requestJson<IpCityResponse>("https://ipapi.co/json/", { cache: "no-store" });
-      const matchedCity = matchCity(response.city ?? null, response.stateCode ?? null);
+      const stateCode = response.stateCode ?? response.region_code ?? null;
+      const matchedCity = matchCity(response.city ?? null, stateCode);
 
       if (matchedCity) {
         setCity(matchedCity);


### PR DESCRIPTION
### Motivation
- Ensure the IP-based fallback from `ipapi.co` supplies a state code for city matching when `stateCode` is missing by using the `region_code` field.

### Description
- Add `region_code` and `region` to the `IpCityResponse` type and fall back to `response.region_code` when computing the `stateCode` used by `matchCity` in `useGeolocation`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f357d9cf8c8320bbdfc68951b7eafe)