### PR TITLE
Use `keyword` for internal search links and remove inline reviews block

### DIFF
--- a/src/app/therapists/[slug]/_components/PremiumProfilePage.tsx
+++ b/src/app/therapists/[slug]/_components/PremiumProfilePage.tsx
@@ -13,7 +13,6 @@ import { PremiumProfileGallery } from "./PremiumProfileGallery";
 import { PremiumProfileAvailability } from "./PremiumProfileAvailability";
 import { PremiumProfileFaq } from "./PremiumProfileFaq";
 import { ProfileTravel } from "./ProfileTravel";
-import { PremiumProfileLocation } from "./PremiumProfileLocation";
 import { KnottyProfileTracker } from "./KnottyProfileTracker";
 import { ProfileAreasServed } from "./ProfileAreasServed";
 import { PremiumProfileContact } from "./PremiumProfileContact";
@@ -30,8 +29,7 @@ interface Props {
 
 export function PremiumProfilePage({ profile, photos, reviews, cityPath }: Props) {
   useFadeInOnScroll();
-  
-  const FALLBACK_REVIEW_DATE = "1970-01-01T00:00:00.000Z";
+
   const city = profile.city || "United States";
   const neighborhood = profile.neighborhood_name || profile.primary_area;
   const avgRating = reviews.length > 0
@@ -159,27 +157,27 @@ export function PremiumProfilePage({ profile, photos, reviews, cityPath }: Props
             <h2 className="pp-section-title">Browse More in {city}</h2>
           </div>
           <div className="pp-internal-links">
-            <Link href={`/search?city=${encodeURIComponent(city)}&q=gay+massage`} className="pp-int-link">
+            <Link href={`/search?city=${encodeURIComponent(city)}&keyword=gay+massage`} className="pp-int-link">
               Gay Massage {city}
             </Link>
             <Link href={`/search?city=${encodeURIComponent(city)}`} className="pp-int-link">
               All {city} Therapists
             </Link>
             {neighborhood && (
-              <Link href={`/search?city=${encodeURIComponent(city)}&q=${encodeURIComponent(neighborhood)}`} className="pp-int-link">
+              <Link href={`/search?city=${encodeURIComponent(city)}&keyword=${encodeURIComponent(neighborhood)}`} className="pp-int-link">
                 {neighborhood} Massage
               </Link>
             )}
-            <Link href={`/search?city=${encodeURIComponent(city)}&q=outcall`} className="pp-int-link">
+            <Link href={`/search?city=${encodeURIComponent(city)}&keyword=outcall`} className="pp-int-link">
               Outcall {city}
             </Link>
-            <Link href={`/search?city=${encodeURIComponent(city)}&q=deep+tissue`} className="pp-int-link">
+            <Link href={`/search?city=${encodeURIComponent(city)}&keyword=deep+tissue`} className="pp-int-link">
               Deep Tissue {city}
             </Link>
-            <Link href={`/search?city=${encodeURIComponent(city)}&q=swedish`} className="pp-int-link">
+            <Link href={`/search?city=${encodeURIComponent(city)}&keyword=swedish`} className="pp-int-link">
               Swedish Massage {city}
             </Link>
-            <Link href={`/search?city=${encodeURIComponent(city)}&q=lgbtq`} className="pp-int-link">
+            <Link href={`/search?city=${encodeURIComponent(city)}&keyword=lgbtq`} className="pp-int-link">
               LGBTQ+ Massage {city}
             </Link>
           </div>
@@ -188,33 +186,6 @@ export function PremiumProfilePage({ profile, photos, reviews, cityPath }: Props
         {/* Final CTA */}
         <PremiumProfileCTA profile={profile} />
 
-        {/* Reviews */}
-        {reviews.length > 0 && (
-          <section className="pp-section pp-fade-in" id="reviews">
-            <div className="pp-section-header">
-              <h2 className="pp-section-title">Reviews</h2>
-            </div>
-            <div className="space-y-4">
-              {reviews.map((review) => (
-                <article
-                  key={review.id}
-                  className="rounded-lg border border-[var(--glass-border)] bg-[var(--cream-dim)] p-5"
-                >
-                  <div className="flex items-center gap-2 mb-3">
-                    <div className="text-[var(--orange)]">
-                      {"★".repeat(review.rating || 5)}
-                      {"☆".repeat(5 - (review.rating || 5))}
-                    </div>
-                    {(review.author_name || review.reviewer_name) && (
-                      <span className="text-xs text-[var(--text-muted)]">by {review.author_name || review.reviewer_name}</span>
-                    )}
-                  </div>
-                  <p className="text-sm leading-relaxed text-[var(--cream-soft)]">{review.content || review.review_text}</p>
-                </article>
-              ))}
-            </div>
-          </section>
-        )}
       </div>
 
       {/* AI Chat Widget */}


### PR DESCRIPTION
### Motivation

- Align internal search links with the updated search parameter expected by the app by replacing legacy `q` usage with `keyword`.
- Remove the inline reviews rendering to centralize reviews display and avoid duplicated UI logic.
- Clean up unused code and imports to reduce noise in `PremiumProfilePage.tsx`.

### Description

- Updated all internal `Link` hrefs in the "Browse More" section to use the `keyword` query parameter instead of `q`.
- Removed the manual reviews section that rendered each `review` item inline from `PremiumProfilePage.tsx`.
- Deleted the unused `FALLBACK_REVIEW_DATE` constant and removed the unused `PremiumProfileLocation` import.
- Performed minor whitespace and formatting cleanup in `PremiumProfilePage.tsx`.

### Testing

- Ran TypeScript build (`npm run build`) to verify type correctness and the Next.js compilation, which succeeded.
- Executed unit tests (`npm test`) against the changed files and they passed.
- Ran linter (`npm run lint`) and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35b40a2048320a80f4c6f06fb62ae)