### PR TITLE
Fix AdminTherapistsManager prop typing to resolve build error

### DIFF
--- a/src/app/admin/_components/AdminTherapistsManager.tsx
+++ b/src/app/admin/_components/AdminTherapistsManager.tsx
@@ -7,7 +7,17 @@ import { postJson } from "@/app/_lib/client-api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import type { AdminTherapist } from "@/app/admin/_lib/loaders";
+
+type AdminTherapistListItem = {
+  id: string;
+  display_name: string | null;
+  full_name: string | null;
+  city: string | null;
+  status: string | null;
+  is_verified_identity: boolean | null;
+  tier: string | null;
+  featured: { is_active: boolean | null } | null;
+};
 
 type TherapistAction =
   | "approve"
@@ -33,7 +43,7 @@ const DEFAULT_ACTION: ActionDraft = {
   displayOrder: "",
 };
 
-function buildDrafts(therapists: AdminTherapist[]) {
+function buildDrafts(therapists: AdminTherapistListItem[]) {
   return therapists.reduce<Record<string, ActionDraft>>((accumulator, therapist) => {
     accumulator[therapist.id] = {
       ...DEFAULT_ACTION,
@@ -46,7 +56,7 @@ function buildDrafts(therapists: AdminTherapist[]) {
 export default function AdminTherapistsManager({
   initialTherapists,
 }: {
-  initialTherapists: AdminTherapist[];
+  initialTherapists: AdminTherapistListItem[];
 }) {
   const router = useRouter();
   const { toast } = useToast();


### PR DESCRIPTION
### Motivation
- A TypeScript build error occurred because the component expected a cross-module `AdminTherapist` type that was not assignable to the data returned by `loadTherapists()` due to differing fields and type identity issues.
- The UI only needs a small subset of therapist fields, so a component-local shape avoids the cross-boundary type mismatch while keeping strict typing for the client component.

### Description
- Removed the `AdminTherapist` import from the client component and added a local `AdminTherapistListItem` type that contains only the fields used by the UI.
- Updated `buildDrafts` and the `initialTherapists` prop signature to use `AdminTherapistListItem[]` instead of the server type.
- Modified `src/app/admin/_components/AdminTherapistsManager.tsx` to use the new local type throughout the component.

### Testing
- Ran `pnpm run build` and the build completed successfully, resolving the previous type error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f362993d308320b67f483bd6e1c229)