### PR TITLE
Prevent pnpm lockfile drift from breaking Vercel deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,20 @@ env:
   SITEMAP_SUPABASE_KEY: ${{ secrets.SITEMAP_SUPABASE_KEY }}
 
 jobs:
+
+  vercel-lockfile-guard:
+    name: Vercel lockfile guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm build
   secret-scan:
     name: Secret Scan
     runs-on: ubuntu-latest

--- a/docs/deploy-checklist.md
+++ b/docs/deploy-checklist.md
@@ -1,0 +1,14 @@
+# Deploy Lockfile Checklist
+
+To avoid Vercel deployment failures caused by dependency drift:
+
+1. Always run `pnpm install` after any `package.json` change.
+2. Commit `package.json` and `pnpm-lock.yaml` together.
+3. Never manually edit `pnpm-lock.yaml`.
+4. Before merging, verify with:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm typecheck
+pnpm build
+```


### PR DESCRIPTION
### Motivation
- Vercel builds can fail when `package.json` and `pnpm-lock.yaml` drift, because CI or Vercel runs that enforce a frozen lockfile will error before the build starts.

### Description
- Added a lightweight CI guard job `vercel-lockfile-guard` to `.github/workflows/ci.yml` that runs `pnpm install --frozen-lockfile`, `pnpm typecheck`, and `pnpm build` to catch lockfile drift early.
- Added `docs/deploy-checklist.md` with a short lockfile hygiene checklist that instructs contributors to run `pnpm install` after `package.json` changes, commit `package.json` and `pnpm-lock.yaml` together, never manually edit the lockfile, and verify with `pnpm install --frozen-lockfile` before merging.
- Confirmed `package.json` already pins the package manager to `pnpm@10.32.1` and left internal npm scripts unchanged to preserve compatibility.

### Testing
- Ran `pnpm install --frozen-lockfile` locally and it completed successfully without changing the lockfile.
- Ran `pnpm typecheck` locally and it completed successfully.
- Ran `pnpm build` locally and it completed successfully, producing a successful Next.js production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f363e0caf8832082053bd56f74b097)