### PR TITLE
Handle missing profiles.profile_status in legacy DBs

### DIFF
--- a/src/app/_lib/store.ts
+++ b/src/app/_lib/store.ts
@@ -28,6 +28,26 @@ const PROFILE_SELECT = `
 
 const AVAILABLE_NOW_SELECT = "id, subscription_tier, _tier, available_now, available_now_expires";
 
+
+const LEGACY_PROFILE_SELECT = `
+  id, user_id, slug, display_name, full_name, headline, bio, city, state, neighborhood, 
+  phone, whatsapp_number, email_address, website,
+  service_categories, massage_techniques, specialties,
+  incall_price, outcall_price, starting_price,
+  height_inches, weight_lb, body_type,
+  offers_incall, offers_outcall, outcall_radius,
+  years_experience, languages,
+  subscription_tier, is_featured, is_suspended, is_banned,
+  stripe_customer_id, stripe_subscription_id, current_period_end,
+  photo_limit, visibility_level, featured_until,
+  promotions, seo_title, seo_description, seo_keywords,
+  updated_at, created_at
+`;
+
+function isMissingProfileStatus(errorMessage: string): boolean {
+  return /column\s+profiles\.profile_status\s+does not exist/i.test(errorMessage);
+}
+
 export type AvailableNowProfile = {
   id: string;
   subscription_tier: string | null;
@@ -40,17 +60,25 @@ export { createSupabaseAdminClient, createSupabasePublicClient, getUserRole, rec
 
 export async function getProfileByUserId(userId: string) {
   const adminClient = createSupabaseAdminClient();
-  const { data, error } = await adminClient
+  let query = await adminClient
     .from("profiles")
     .select(PROFILE_SELECT)
     .eq("user_id", userId)
     .maybeSingle();
 
-  if (error) {
-    throw new RouteError(500, error.message);
+  if (query.error && isMissingProfileStatus(query.error.message)) {
+    query = await adminClient
+      .from("profiles")
+      .select(LEGACY_PROFILE_SELECT)
+      .eq("user_id", userId)
+      .maybeSingle();
   }
 
-  return data;
+  if (query.error) {
+    throw new RouteError(500, query.error.message);
+  }
+
+  return query.data;
 }
 
 export async function getAvailableNowProfile(userId: string): Promise<AvailableNowProfile | null> {
@@ -88,7 +116,7 @@ export async function setAvailableNow(
 
 export async function updateProfileByUserId(userId: string, updates: ProfileUpdate) {
   const adminClient = createSupabaseAdminClient();
-  const { data, error } = await adminClient
+  let query = await adminClient
     .from("profiles")
     .update({
       ...updates,
@@ -98,11 +126,23 @@ export async function updateProfileByUserId(userId: string, updates: ProfileUpda
     .select(PROFILE_SELECT)
     .maybeSingle();
 
-  if (error) {
-    throw new RouteError(500, error.message);
+  if (query.error && isMissingProfileStatus(query.error.message)) {
+    query = await adminClient
+      .from("profiles")
+      .update({
+        ...updates,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId)
+      .select(LEGACY_PROFILE_SELECT)
+      .maybeSingle();
   }
 
-  return data;
+  if (query.error) {
+    throw new RouteError(500, query.error.message);
+  }
+
+  return query.data;
 }
 
 export async function getSiteSettings() {


### PR DESCRIPTION
### Motivation
- Prevent hard failures when querying `profiles` on older databases that lack the new `profile_status` column. 
- Keep read and update flows backward-compatible so deployments that haven't run the migration continue to work. 

### Description
- Added a `LEGACY_PROFILE_SELECT` field list in `src/app/_lib/store.ts` that omits `profile_status` and related moderation columns. 
- Implemented `isMissingProfileStatus(errorMessage: string)` to detect the Postgres error `column profiles.profile_status does not exist`. 
- Updated `getProfileByUserId` to retry the query with `LEGACY_PROFILE_SELECT` when that error occurs and to surface other errors normally. 
- Updated `updateProfileByUserId` to retry the post-update `.select(...)` with `LEGACY_PROFILE_SELECT` when the missing-column error is detected. 

### Testing
- No automated tests were executed in this environment; recommend running unit and integration tests against both migrated and legacy schemas after merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365e70e888320a2992b6ccf94021d)