### PR TITLE
Fix admin therapist action routes

### DIFF
--- a/src/app/api/admin/profile/[id]/feature/route.ts
+++ b/src/app/api/admin/profile/[id]/feature/route.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, recordAuditLog, requireAdminSession } from "@/app/api/_lib/supabase-server";
+
+const schema = z.object({
+  reason: z.string().optional(),
+  days: z.coerce.number().int().positive().max(365).optional(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const admin = await requireAdminSession(request);
+    const { id: profileId } = await params;
+    const body = await parseJsonBody(request, schema);
+    const adminClient = createSupabaseAdminClient();
+
+    const { data: profile, error: fetchError } = await adminClient
+      .from("profiles")
+      .select("id, user_id, city, is_featured")
+      .eq("id", profileId)
+      .maybeSingle();
+
+    if (fetchError) throw new RouteError(500, fetchError.message);
+    if (!profile) throw new RouteError(404, "Profile not found.");
+
+    const now = new Date();
+    const isFeaturing = !profile.is_featured;
+
+    const profileUpdate = isFeaturing
+      ? {
+          is_featured: true,
+          featured_until: new Date(now.getTime() + (body.days ?? 30) * 24 * 60 * 60 * 1000).toISOString(),
+          visibility_status: "featured",
+          updated_at: now.toISOString(),
+        }
+      : {
+          is_featured: false,
+          featured_until: null,
+          visibility_status: "public",
+          updated_at: now.toISOString(),
+        };
+
+    const { error: profileUpdateError } = await adminClient
+      .from("profiles")
+      .update(profileUpdate)
+      .eq("id", profileId);
+
+    if (profileUpdateError) throw new RouteError(500, profileUpdateError.message);
+
+    if (isFeaturing) {
+      const { error: featureError } = await adminClient
+        .from("featured_masters")
+        .upsert(
+          {
+            profile_id: profileId,
+            featured_by: admin.userId,
+            city: profile.city || null,
+            is_active: true,
+          },
+          { onConflict: "profile_id" },
+        );
+
+      if (featureError) throw new RouteError(500, featureError.message);
+    } else {
+      const { error: unfeatureError } = await adminClient
+        .from("featured_masters")
+        .update({ is_active: false })
+        .eq("profile_id", profileId);
+
+      if (unfeatureError) throw new RouteError(500, unfeatureError.message);
+    }
+
+    await adminClient.from("admin_actions").insert({
+      admin_id: admin.userId,
+      action_type: isFeaturing ? "feature_profile" : "unfeature_profile",
+      target_user_id: profile.user_id,
+      target_profile_id: profileId,
+      reason: body.reason || null,
+    });
+
+    await recordAuditLog(
+      admin.userId,
+      isFeaturing ? "feature_profile" : "unfeature_profile",
+      "profile",
+      profileId,
+      { reason: body.reason, days: body.days ?? null },
+    );
+
+    return json({ ok: true, profileId, featured: isFeaturing });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/profile/[id]/verify_identity/route.ts
+++ b/src/app/api/admin/profile/[id]/verify_identity/route.ts
@@ -1,0 +1,47 @@
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, recordAuditLog, requireAdminSession } from "@/app/api/_lib/supabase-server";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const admin = await requireAdminSession(request);
+    const { id: profileId } = await params;
+    const adminClient = createSupabaseAdminClient();
+
+    const { data: profile, error: fetchError } = await adminClient
+      .from("profiles")
+      .select("id, user_id")
+      .eq("id", profileId)
+      .maybeSingle();
+
+    if (fetchError) throw new RouteError(500, fetchError.message);
+    if (!profile) throw new RouteError(404, "Profile not found.");
+
+    const { error: updateError } = await adminClient
+      .from("profiles")
+      .update({
+        is_verified_identity: true,
+        verification_status: "verified",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", profileId);
+
+    if (updateError) throw new RouteError(500, updateError.message);
+
+    await adminClient.from("admin_actions").insert({
+      admin_id: admin.userId,
+      action_type: "verify_identity",
+      target_user_id: profile.user_id,
+      target_profile_id: profileId,
+      reason: null,
+    });
+
+    await recordAuditLog(admin.userId, "verify_identity", "profile", profileId, null);
+
+    return json({ ok: true, profileId, verified: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
### Motivation
- The admin therapist UI referenced missing server endpoints for featuring and identity verification, causing actions to fail; this patch adds the minimal missing API routes to restore functionality. 
- The change follows existing admin API patterns (`requireAdminSession`, `RouteError`/`errorResponse`, `admin_actions`, and `recordAuditLog`) to remain consistent with surrounding code.

### Description
- Added `POST /api/admin/profile/[id]/feature` at `src/app/api/admin/profile/[id]/feature/route.ts` which toggles `profiles.is_featured`, sets/clears `profiles.featured_until`, updates `profiles.visibility_status`, upserts `featured_masters` with `is_active = true` when featuring, and marks `is_active = false` when unfeaturing. 
- Added `POST /api/admin/profile/[id]/verify_identity` at `src/app/api/admin/profile/[id]/verify_identity/route.ts` which sets `profiles.is_verified_identity = true` and `profiles.verification_status = "verified"`. 
- Both routes require an admin session, fetch the profile by `id` and return `404` when not found, insert rows into `admin_actions`, call `recordAuditLog`, and return JSON `{ ok: true }` while reusing `RouteError`/`errorResponse` and the existing Supabase helpers.

### Testing
- Ran `npm run typecheck` which completed successfully. 
- Ran `npm run build` (Next.js build) which completed successfully. 
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36f77e90883209824d667a173a1fa)