### PR TITLE
Restore missing legacy scripts with safe replacements

### DIFF
--- a/scripts/_diagnose-auth.mjs
+++ b/scripts/_diagnose-auth.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('[deprecated] scripts/_diagnose-auth.mjs was removed during cleanup.');
+console.log('Use: node scripts/test-api-routes.mjs');

--- a/scripts/_fix-admin.mjs
+++ b/scripts/_fix-admin.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('[deprecated] scripts/_fix-admin.mjs is no longer needed.');
+console.log('Use: node scripts/check-supabase-admin-connection.mjs');

--- a/scripts/_test-login.mjs
+++ b/scripts/_test-login.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('[deprecated] scripts/_test-login.mjs was consolidated.');
+console.log('Use: node scripts/test-api-routes.mjs');

--- a/scripts/_test-login2.mjs
+++ b/scripts/_test-login2.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log('[deprecated] scripts/_test-login2.mjs was consolidated.');
+console.log('Use: node scripts/test-api-routes.mjs');

--- a/scripts/_test-supabase-connection.mjs
+++ b/scripts/_test-supabase-connection.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import './check-supabase-admin-connection.mjs';


### PR DESCRIPTION
### Motivation
- Prevent runtime errors from missing script entrypoints by restoring the legacy `scripts/*` paths that were referenced elsewhere in the repo. 

### Description
- Added lightweight deprecation-safe entrypoint files: `scripts/_diagnose-auth.mjs`, `scripts/_fix-admin.mjs`, `scripts/_test-login.mjs`, `scripts/_test-login2.mjs` (which print guidance) and `scripts/_test-supabase-connection.mjs` (which delegates to `check-supabase-admin-connection.mjs`).

### Testing
- Executed each restored script with `node` and confirmed the four deprecation stubs print guidance successfully, while `node scripts/_test-supabase-connection.mjs` runs but reports a missing environment file (`.env.production.local`) so the underlying Supabase check cannot complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61058dd608320a9babc81caed6660)