### PR TITLE
Fix signup submission status type mismatch

### DIFF
--- a/src/app/signup/_lib/signup-context.tsx
+++ b/src/app/signup/_lib/signup-context.tsx
@@ -22,9 +22,9 @@ export type SubmissionStatus =
   | "draft"
   | "submitted"
   | "under_review"
+  | "pending_approval"
   | "approved"
   | "rejected";
-"pending_approval";
 
 
 export type BillingStatus =


### PR DESCRIPTION
### Motivation
- The signup review and resubmit flows set a `pending_approval` status but the `SubmissionStatus` type did not include that value, producing TypeScript errors. 
- A stray standalone string expression (`"pending_approval";`) in the signup context file triggered an ESLint `@typescript-eslint/no-unused-expressions` error.

### Description
- Added `"pending_approval"` to the `SubmissionStatus` union in `src/app/signup/_lib/signup-context.tsx` so the runtime value matches the type. 
- Removed the stray standalone string expression that caused the lint error. 
- Preserved existing signup state shape and provider API; no behavioral changes beyond fixing the type/lint mismatch.

### Testing
- Ran `pnpm run lint` and the lint check completed successfully. 
- Ran `pnpm run typecheck` and TypeScript checks passed with no errors. 
- Ran `pnpm run test` (API smoke tests via `pnpm run test:api`) and all smoke checks passed. 
- Ran `pnpm run build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63bf4d78883208280d23d4844cc7d)