### PR TITLE
Fix Stripe API version type mismatch

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -80,7 +80,7 @@ function resolveTier(obj: StripeEventObject, subscriptionStatus?: string): Subsc
 
 function getStripeClient() {
   if (!hasStripe || !env.stripeSecretKey) return null;
-  return new Stripe(env.stripeSecretKey, { apiVersion: "2024-11-20.acacia" });
+  return new Stripe(env.stripeSecretKey, { apiVersion: "2025-08-27.basil" });
 }
 
 function getClientIp(request: Request): string {


### PR DESCRIPTION
## Summary

Fixes the production build blocker caused by the Stripe SDK type definition expecting the installed package API version.

## Change

- Updated `src/app/api/webhooks/stripe/route.ts`
- Replaced unsupported `apiVersion: "2024-11-20.acacia"` with `apiVersion: "2025-08-27.basil"`

## Why

The installed Stripe package types only accept `"2025-08-27.basil"`, so TypeScript rejects the older Acacia version and fails `pnpm run build`.

## Validation

Expected result after merge:

```bash
pnpm install --frozen-lockfile
pnpm run build
```

No redesign. No dashboard changes. Single line compatibility patch only.