### PR TITLE
Production stabilization for issue #281

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -80,7 +80,7 @@ function resolveTier(obj: StripeEventObject, subscriptionStatus?: string): Subsc
 
 function getStripeClient() {
   if (!hasStripe || !env.stripeSecretKey) return null;
-  return new Stripe(env.stripeSecretKey, { apiVersion: "2024-11-20.acacia" });
+  return new Stripe(env.stripeSecretKey, { apiVersion: "2025-08-27.basil" });
 }
 
 function getClientIp(request: Request): string {


### PR DESCRIPTION
## Summary

Executes the first production stabilization pass for issue #281 while preserving the existing MasseurMatch colors, page layout structure, routes, dashboards, auth system, and business model.

## Files changed

- `src/app/api/webhooks/stripe/route.ts`

## Errors fixed

- Fixes the current TypeScript production build blocker caused by the Stripe SDK API version mismatch.
- Replaces the reverted API version with the version accepted by the installed Stripe SDK.

## Commands required by issue #281

The repository already has `.github/workflows/release-checks.yml` configured to run the release checks on PRs to `main`, including:

```bash
pnpm install --frozen-lockfile
pnpm lint
pnpm typecheck
pnpm test
pnpm validate:sitemap
pnpm validate:db-contract
pnpm release:audit
pnpm release:check
pnpm build
```

## Build result

Pending GitHub Actions release checks on this PR.

## Typecheck result

Pending GitHub Actions release checks on this PR.

## Sitemap validation result

Pending GitHub Actions release checks on this PR.

## DB contract validation result

Pending GitHub Actions release checks on this PR.

## Remaining blockers

No additional file changes were made beyond the confirmed current blocker. If GitHub Actions reports another failure, it should be fixed in this same stabilization branch before merge.

Closes #281 when all release checks are green.