### PR TITLE
Fix deployment type safety for directory filters

### DIFF
--- a/src/app/_components/search-directory.tsx
+++ b/src/app/_components/search-directory.tsx
@@ -27,6 +27,12 @@ const normalizeText = (value: string | null | undefined) =>
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "");
 
+type SearchItem = PublicTherapist & {
+  available_now?: boolean | null;
+  years_experience?: number | null;
+  lgbtq_affirming?: boolean | null;
+};
+
 const getYearsExperience = (therapist: PublicTherapist) => {
   if (typeof therapist.years_experience === "number" && therapist.years_experience > 0) {
     return therapist.years_experience;
@@ -128,6 +134,7 @@ export function SearchDirectory({
     const objectiveSearchValue = normalizeText(getDirectoryObjectiveSearchValue(goal, modality));
 
     return items.filter((item) => {
+      const row = item as SearchItem;
       const searchable = [
         item.display_name,
         item.full_name,
@@ -170,9 +177,9 @@ export function SearchDirectory({
             Boolean(item.is_verified_profile)
           : true;
       const matchesTier = tier ? item._tier === tier : true;
-      const matchesAvailable = availableToday ? Boolean(item.available_now) : true;
-      const matchesMaster = masterOnly ? Boolean(yearsExperience && yearsExperience >= 10) : true;
-      const matchesLgbtq = lgbtqAffirming ? Boolean(item.lgbtq_affirming) : true;
+      const matchesAvailable = availableToday ? !!row.available_now : true;
+      const matchesMaster = masterOnly ? (row.years_experience ?? yearsExperience ?? 0) >= 10 : true;
+      const matchesLgbtq = lgbtqAffirming ? !!row.lgbtq_affirming : true;
 
       return (
         matchesCity &&


### PR DESCRIPTION
## Summary

Fixes the remaining directory filter type-safety issue discussed in the deployment debugging thread.

### Changes

- Adds a local `SearchItem` type in `src/app/_components/search-directory.tsx`.
- Uses a safe cast for `available_now`, `years_experience`, and `lgbtq_affirming` during client-side filtering.
- Keeps the current `main` architecture intact and avoids reintroducing the older `subscription_plans(code)` join path from the failed deployment branch.

### Why

The failed Vercel deployment logs showed TypeScript failures caused by stale or divergent Supabase inferred types. `main` already uses the newer `profiles` based directory flow, so the safest fix is to harden the remaining client filter without changing the server-side data model.

### Notes

- `src/app/_lib/directory.ts` on `main` already selects and filters `lgbtq_affirming` server side.
- `src/app/api/_lib/supabase-server.ts` on `main` does not use the `withTimeout` wrapper that caused the branch-only error.
- No production merge or deploy was triggered by this PR.