### PR TITLE
Fix admin users loading and admin subdomain redirect

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const host = request.headers.get("host") ?? "";
+
+  if (host === "admin.masseurmatch.com") {
+    const url = request.nextUrl.clone();
+    url.hostname = "www.masseurmatch.com";
+    url.pathname = url.pathname === "/" ? "/admin" : url.pathname;
+    return NextResponse.redirect(url, 308);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*",
+};

--- a/src/app/admin/_lib/loaders.ts
+++ b/src/app/admin/_lib/loaders.ts
@@ -144,24 +144,30 @@ async function listAllAuthUsers() {
   const users: Array<{ id: string; email: string | null }> = [];
   let page = 1;
 
-  while (page > 0) {
-    const { data, error } = await adminClient.auth.admin.listUsers({
-      page,
-      perPage: 20,
-    });
-
-    if (error) {
-      throw new Error(error.message);
-    }
-
-    for (const user of data.users) {
-      users.push({
-        id: user.id,
-        email: user.email || null,
+  try {
+    while (page > 0) {
+      const { data, error } = await adminClient.auth.admin.listUsers({
+        page,
+        perPage: 20,
       });
-    }
 
-    page = data.nextPage || 0;
+      if (error) {
+        console.error("Supabase Auth users could not be loaded.", error.message);
+        return users;
+      }
+
+      for (const user of data.users ?? []) {
+        users.push({
+          id: user.id,
+          email: user.email || null,
+        });
+      }
+
+      page = data.nextPage || 0;
+    }
+  } catch (error) {
+    console.error("Supabase Auth users fallback triggered.", error);
+    return users;
   }
 
   return users;
@@ -170,7 +176,7 @@ async function listAllAuthUsers() {
 export async function loadUsers(): Promise<AdminLoadResult<AdminUser>> {
   try {
     const adminClient = createSupabaseAdminClient();
-    const [{ data: profiles, error: profilesError }, { data: roles, error: rolesError }, authUsers] =
+    const [{ data: profiles, error: profilesError }, { data: roles, error: rolesError }] =
       await Promise.all([
         adminClient
           .from("profiles")
@@ -178,7 +184,6 @@ export async function loadUsers(): Promise<AdminLoadResult<AdminUser>> {
           .order("updated_at", { ascending: false })
           .limit(50),
         adminClient.from("user_roles").select("user_id, role, created_at").order("created_at", { ascending: false }),
-        listAllAuthUsers(),
       ]);
 
     if (profilesError) {
@@ -189,6 +194,7 @@ export async function loadUsers(): Promise<AdminLoadResult<AdminUser>> {
       throw new Error(rolesError.message);
     }
 
+    const authUsers = await listAllAuthUsers();
     const roleRows = (roles || []) as UserRoleRow[];
     const roleMap = new Map<string, UserRoleRow["role"]>();
     for (const role of roleRows) {

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -5,12 +5,30 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { AuthForms } from "@/app/_components/auth-forms";
 import { useAuth } from "@/contexts/AuthContext";
 
+function sanitizeRedirectTo(value: string | null) {
+  const fallback = "/pro/dashboard";
+
+  if (!value) {
+    return fallback;
+  }
+
+  if (!value.startsWith("/") || value.startsWith("//")) {
+    return fallback;
+  }
+
+  if (value.includes("admin.masseurmatch.com")) {
+    return fallback;
+  }
+
+  return value;
+}
+
 function LoginPageContent() {
   const router = useRouter();
   const { user, loading } = useAuth();
   const searchParams = useSearchParams();
   const params = new URLSearchParams(searchParams?.toString() ?? "");
-  const redirectTo = params.get("redirect") || "/pro/dashboard";
+  const redirectTo = sanitizeRedirectTo(params.get("redirect"));
 
   useEffect(() => {
     if (loading || !user) {


### PR DESCRIPTION
## Summary

Reopened as a fresh PR after syncing the hotfix branch with the latest `main`.

This PR:

1. Prevents `/admin/users` from failing completely when Supabase Auth Admin `listUsers()` fails.
2. Loads admin users from `profiles` and `user_roles` first, then enriches emails from Supabase Auth only when available.
3. Sanitizes login redirects so invalid or external admin host redirects cannot push users to `admin.masseurmatch.com`.
4. Adds middleware to redirect `admin.masseurmatch.com` to the internal `/admin` route when that domain is attached to this Vercel project.

## Why

The admin dashboard was partially accessible at `/admin`, but `/admin/users` could fail if Supabase Auth Admin user loading fails. The separate `admin.masseurmatch.com` host returned Vercel `DEPLOYMENT_NOT_FOUND`, so the app should avoid sending users there and redirect that host back to the main app once the domain is configured in Vercel.

## Required Vercel follow up

After merge, verify these in Vercel:

- `admin.masseurmatch.com` is attached to the MasseurMatch project or removed.
- `SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_URL`
- `SUPABASE_ANON_KEY`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`

## Validation

Branch is synced with latest `main` and is ahead by 3 commits only.