### PR TITLE
Fix typed profile contact click RPC

### DIFF
--- a/src/app/api/public/contact/[id]/route.ts
+++ b/src/app/api/public/contact/[id]/route.ts
@@ -59,11 +59,9 @@ export async function GET(
     return NextResponse.json({ error: "Contact is unavailable." }, { status: 404 });
   }
 
-  await (adminClient as any)
-    .rpc("increment_profile_contact_clicks", {
-      p_profile_id: profile.id,
-    })
-    .catch(() => null);
+  await adminClient.rpc("increment_profile_contact_clicks", {
+    p_profile_id: profile.id,
+  });
 
   return NextResponse.redirect(redirectUrl, { status: 302 });
 }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -44,7 +44,29 @@ export interface Database {
       [key: string]: GenericTable;
     };
     Views: Record<string, never>;
-    Functions: Record<string, never>;
+    Functions: {
+      exec_sql: {
+        Args: { sql: string };
+        Returns: Json;
+      };
+      get_nearby_therapists: {
+        Args: {
+          p_lat: number;
+          p_lng: number;
+          p_radius_miles?: number;
+          p_limit?: number;
+        };
+        Returns: GenericRow[];
+      };
+      get_ranking_event_counts: {
+        Args: Record<PropertyKey, never>;
+        Returns: Record<string, number>;
+      };
+      increment_profile_contact_clicks: {
+        Args: { p_profile_id: string };
+        Returns: undefined;
+      };
+    };
     Enums: {
       app_role: "admin" | "provider" | "client";
       [key: string]: "admin" | "provider" | "client";

--- a/supabase/migrations/20260511000000_increment_profile_contact_clicks_rpc.sql
+++ b/supabase/migrations/20260511000000_increment_profile_contact_clicks_rpc.sql
@@ -1,0 +1,15 @@
+-- Atomically increment a public profile contact-click counter from server routes.
+
+create or replace function public.increment_profile_contact_clicks(p_profile_id uuid)
+returns void
+language sql
+security definer
+set search_path = public
+as $$
+  update public.profiles
+  set contact_clicks = coalesce(contact_clicks, 0) + 1
+  where id = p_profile_id;
+$$;
+
+revoke all on function public.increment_profile_contact_clicks(uuid) from public;
+grant execute on function public.increment_profile_contact_clicks(uuid) to service_role;


### PR DESCRIPTION
### Motivation
- Eliminate a TypeScript type error when calling a Supabase RPC from the public contact redirect route. 
- Ensure RPCs used across the codebase are present in the shared Supabase `Database` typings so typed `.rpc()` calls compile. 
- Provide a safe, atomic server-side increment for profile `contact_clicks` to be executed by the service role. 

### Description
- Remove the local `any` cast and call `rpc("increment_profile_contact_clicks", { p_profile_id: profile.id })` directly in `src/app/api/public/contact/[id]/route.ts`.
- Add `increment_profile_contact_clicks` (and several other existing RPC signatures) to `src/integrations/supabase/types.ts` so RPC call shapes are typed and TypeScript-aware.
- Add a migration `supabase/migrations/20260511000000_increment_profile_contact_clicks_rpc.sql` that creates a `public.increment_profile_contact_clicks(uuid)` SQL function which atomically increments `profiles.contact_clicks` and grants execute to `service_role`.
- Preserve other existing RPC typings (`exec_sql`, `get_nearby_therapists`, `get_ranking_event_counts`) to avoid introducing new type errors. 

### Testing
- Ran `pnpm run typecheck` and the TypeScript checks passed. 
- Ran `pnpm run lint` and ESLint completed with no failures. 
- Ran `pnpm run test:api` and the API smoke tests passed. 
- Ran `pnpm run build` which failed in this environment due to Google Fonts fetch errors (network/font fetch), not the RPC typing; the original TypeScript RPC error is resolved by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02602cb33c832485cfb7b630871497)