### PR TITLE
Fix public therapist status contract

### DIFF
--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -14,7 +14,7 @@ const PUBLIC_PROFILE_SELECT = `
   height_inches, weight_lb, body_type,
   years_experience, languages,
   subscription_tier, verification_status, is_featured,
-  promotions, updated_at, profile_status, visibility_status,
+  promotions, updated_at, status, profile_status, visibility_status,
   is_suspended, is_banned, available_now, available_now_expires,
   lgbtq_affirming, business_hours, custom_faq, pricing_sessions, areas_served,
   outcall_radius_miles, travel_schedule, add_ons, training, education, contact_clicks,
@@ -86,9 +86,9 @@ export interface PublicTherapist {
   massage_techniques: string[] | null;
   specialties: string[] | null;
   subscription_tier: TherapistTier | null;
+  status?: string | null;
   profile_status: string | null;
   visibility_status: string | null;
-  status?: string | null;
   incall_price: number | null;
   outcall_price: number | null;
   starting_price: number | null;

--- a/supabase/migrations/20260514133000_expose_public_therapist_status.sql
+++ b/supabase/migrations/20260514133000_expose_public_therapist_status.sql
@@ -1,0 +1,71 @@
+create or replace view public.public_therapist_profiles as
+select
+  tp.id,
+  tp.slug,
+  tp.display_name,
+  tp.headline,
+  tp.bio,
+  tp.city,
+  tp.state,
+  tp.country,
+  tp.neighborhood,
+  tp.latitude,
+  tp.longitude,
+  tp.service_radius_miles,
+  tp.offers_incall,
+  tp.offers_outcall,
+  tp.availability_note,
+  tp.seo_title,
+  tp.seo_description,
+  tp.canonical_city_slug,
+  tp.profile_completion_score,
+  tp.created_at,
+  tp.updated_at,
+  case
+    when tp.is_published = true and tp.moderation_status = 'approved' then 'active'
+    else coalesce(tp.moderation_status, 'pending')
+  end::text as status,
+  tp.moderation_status::text as profile_status,
+  case
+    when tp.is_published = true and tp.moderation_status = 'approved' then 'visible'
+    else 'hidden'
+  end::text as visibility_status
+from public.therapist_profiles tp
+where tp.is_published = true
+  and tp.moderation_status = 'approved';
+
+create or replace view public.public_therapist_profiles_safe as
+select
+  tp.id,
+  tp.slug,
+  tp.display_name,
+  tp.headline,
+  tp.bio,
+  tp.city,
+  tp.state,
+  tp.country,
+  tp.neighborhood,
+  tp.latitude,
+  tp.longitude,
+  tp.service_radius_miles,
+  tp.offers_incall,
+  tp.offers_outcall,
+  tp.availability_note,
+  tp.seo_title,
+  tp.seo_description,
+  tp.canonical_city_slug,
+  tp.profile_completion_score,
+  tp.created_at,
+  tp.updated_at,
+  case
+    when tp.is_published = true and tp.moderation_status = 'approved' then 'active'
+    else coalesce(tp.moderation_status, 'pending')
+  end::text as status,
+  tp.moderation_status::text as profile_status,
+  case
+    when tp.is_published = true and tp.moderation_status = 'approved' then 'visible'
+    else 'hidden'
+  end::text as visibility_status
+from public.therapist_profiles tp
+where tp.is_published = true
+  and tp.moderation_status = 'approved';


### PR DESCRIPTION
## Summary

Fixes the build/runtime contract around `PublicTherapist.status`.

### Changes

- Adds `status` to the `PUBLIC_PROFILE_SELECT` query in `src/app/_lib/directory.ts` so values used by admin UI are actually selected from Supabase.
- Adds a Supabase migration matching the production fix already applied directly to Supabase:
  - `public_therapist_profiles.status`
  - `public_therapist_profiles.profile_status`
  - `public_therapist_profiles.visibility_status`
  - same fields on `public_therapist_profiles_safe`

## Why

The build failed at `src/app/admin/page.tsx` because the UI reads `t.status`. The local `PublicTherapist` contract must include and select that field consistently.

## Testing

Expected checks:

- `pnpm typecheck`
- `pnpm build`

## Risk

Low. This is a contract alignment patch. It does not remove columns or rewrite base tables.