### PR TITLE
fix: build error + redesign public pages for bold masculine aesthetic

### DIFF
--- a/src/app/_components/PublicTherapistCard.tsx
+++ b/src/app/_components/PublicTherapistCard.tsx
@@ -125,50 +125,50 @@ export function PublicTherapistCard({ therapist }: { therapist: PublicTherapist 
 
   return (
     <article
-      className="group flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:shadow-md hover:border-slate-300"
+      className="group flex h-full flex-col overflow-hidden rounded-2xl border border-[#0B1F3A]/10 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_12px_36px_rgba(11,31,58,0.12)] hover:border-[#0B1F3A]/20"
     >
-      {/* Compact Photo */}
-      <div className="relative aspect-[3/4] overflow-hidden bg-slate-100">
+      {/* Photo */}
+      <div className="relative aspect-[3/4] overflow-hidden bg-[#0B1F3A]/8">
         <Image
           src={profileImage}
           alt={imageAlt}
           fill
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
-          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
           style={{ objectPosition: FACE_FOCUS_OBJECT_POSITION }}
           priority={false}
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent" />
-        
+        <div className="absolute inset-0 bg-gradient-to-t from-[#0B1F3A]/80 via-[#0B1F3A]/15 to-transparent" />
+
         {/* Badges */}
-        <div className="absolute left-2 right-2 top-2 flex items-start justify-between gap-1">
+        <div className="absolute left-2.5 right-2.5 top-2.5 flex items-start justify-between gap-1">
           {isVerified && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/90 text-white px-2 py-0.5 text-[10px] font-semibold backdrop-blur-sm">
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/90 text-white px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.1em] backdrop-blur-sm">
               <CheckCircle2 className="h-3 w-3" />
               Verified
             </span>
           )}
           {therapist.review_count ? (
-            <span className="inline-flex items-center gap-0.5 rounded-full bg-yellow-500/90 text-white px-2 py-0.5 text-[10px] font-semibold ml-auto">
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-[#FF8A1F]/90 text-[#0B1F3A] px-2.5 py-1 text-[10px] font-bold ml-auto backdrop-blur-sm">
               ★ {therapist.review_count}
             </span>
           ) : null}
         </div>
 
-        {/* Name overlay at bottom */}
-        <div className="absolute bottom-2 left-2 right-2">
-          <h3 className="text-sm font-semibold text-white line-clamp-1 drop-shadow-sm">
+        {/* Name overlay */}
+        <div className="absolute bottom-3 left-3 right-3">
+          <h3 className="font-['Georgia','Times_New_Roman',serif] text-base font-semibold text-white line-clamp-1">
             {name}
           </h3>
-          <p className="text-[11px] text-white/80 line-clamp-1">{specialtyLabel}</p>
+          <p className="mt-0.5 text-[11px] text-white/65 line-clamp-1">{specialtyLabel}</p>
         </div>
       </div>
 
-      {/* Compact Content */}
-      <div className="flex flex-1 flex-col gap-2 p-3">
+      {/* Content */}
+      <div className="flex flex-1 flex-col gap-2 p-3.5">
         {/* Location */}
-        <div className="flex items-center gap-1.5 text-xs text-slate-500">
-          <MapPin className="h-3 w-3 text-slate-400 flex-shrink-0" />
+        <div className="flex items-center gap-1.5 text-xs text-[#0B1F3A]/50">
+          <MapPin className="h-3 w-3 text-[#FF8A1F] flex-shrink-0" />
           <span className="line-clamp-1">{locationLabel}</span>
         </div>
 
@@ -176,7 +176,7 @@ export function PublicTherapistCard({ therapist }: { therapist: PublicTherapist 
         {serviceModes.length > 0 && (
           <div className="flex flex-wrap gap-1">
             {serviceModes.map((mode) => (
-              <span key={mode} className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">
+              <span key={mode} className="text-[10px] font-semibold uppercase tracking-[0.1em] px-2 py-0.5 rounded-full bg-[#0B1F3A]/6 text-[#0B1F3A]/70">
                 {mode}
               </span>
             ))}
@@ -186,15 +186,15 @@ export function PublicTherapistCard({ therapist }: { therapist: PublicTherapist 
         <div className="flex-1" />
 
         {/* Price and CTA */}
-        <div className="flex items-center justify-between pt-2 border-t border-slate-100">
+        <div className="flex items-center justify-between pt-2.5 border-t border-[#0B1F3A]/8">
           <div>
-            <p className="text-[10px] text-slate-400">From</p>
-            <p className="text-sm font-bold text-slate-900">{startingValue || "Contact"}</p>
+            <p className="text-[10px] uppercase tracking-[0.12em] text-[#0B1F3A]/40">From</p>
+            <p className="text-sm font-bold text-[#0B1F3A]">{startingValue || "Contact"}</p>
           </div>
           <Link
             href={profilePath}
             onClick={beginRouteTransition}
-            className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-slate-900 text-white text-xs font-medium hover:bg-slate-800 transition-colors"
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-[#0B1F3A] text-white text-xs font-semibold hover:bg-[#FF8A1F] hover:text-[#0B1F3A] transition-all duration-200"
           >
             View <ArrowUpRight className="h-3 w-3" />
           </Link>

--- a/src/app/_components/site-footer.tsx
+++ b/src/app/_components/site-footer.tsx
@@ -5,22 +5,22 @@ export function SiteFooter() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-slate-950 text-slate-400 pt-20 pb-10 border-t border-slate-900">
+    <footer className="bg-[#060E1A] text-slate-400 pt-20 pb-10 border-t border-white/[0.06]">
       <div className="container mx-auto px-4 md:px-6 max-w-7xl">
 
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-12 lg:gap-8 mb-16">
 
           {/* Brand Column */}
           <div className="lg:col-span-2 space-y-6">
-            <Link href="/" className="font-display text-2xl font-bold tracking-tighter text-white inline-block">
-              Masseur<span className="text-slate-500">Match</span>
+            <Link href="/" className="font-['Georgia','Times_New_Roman',serif] text-2xl font-bold tracking-tight text-white inline-block">
+              Masseur<span className="text-[#FF8A1F]">Match</span>
             </Link>
-            <p className="font-sans text-sm leading-relaxed max-w-sm">
-              The world&apos;s leading directory for high-performance massage therapy and elite holistic wellness professionals.
+            <p className="font-sans text-sm leading-relaxed max-w-sm text-slate-400">
+              A privacy-first directory connecting clients with independent LGBTQ+-affirming massage therapists across the United States.
             </p>
             <div className="flex items-center gap-2 mt-4">
-              <ShieldCheck className="w-5 h-5 text-emerald-500" />
-              <span className="font-mono text-[10px] uppercase tracking-widest text-slate-300">Verified Secure Network</span>
+              <ShieldCheck className="w-5 h-5 text-emerald-400" />
+              <span className="font-mono text-[10px] uppercase tracking-widest text-slate-400">Verified Secure Network</span>
             </div>
           </div>
 
@@ -61,15 +61,15 @@ export function SiteFooter() {
         </div>
 
         {/* Bottom Bar: Copyright & Location */}
-        <div className="flex flex-col md:flex-row items-center justify-between pt-8 border-t border-slate-900 gap-4">
-          <p className="font-sans text-xs">
+        <div className="flex flex-col md:flex-row items-center justify-between pt-8 border-t border-white/[0.06] gap-4">
+          <p className="font-sans text-xs text-slate-500">
             &copy; {currentYear} MasseurMatch. All rights reserved.
           </p>
-          <div className="flex items-center gap-6 font-mono text-[10px] uppercase tracking-widest">
+          <div className="flex items-center gap-6 font-mono text-[10px] uppercase tracking-widest text-slate-500">
             <Link href="/cookie-policy" className="hover:text-white transition-colors">Cookies</Link>
             <Link href="/accessibility" className="hover:text-white transition-colors">Accessibility</Link>
             <span className="flex items-center gap-1">
-              Made in <ArrowUpRight className="w-3 h-3 text-slate-600" /> Dallas, TX
+              United States <ArrowUpRight className="w-3 h-3 text-[#FF8A1F]" />
             </span>
           </div>
         </div>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from "next/og";
 
-
 export const alt = "MasseurMatch – LGBTQ+-Inclusive Massage Therapist Directory";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
@@ -18,48 +17,74 @@ export default async function Image() {
           alignItems: "center",
           justifyContent: "center",
           padding: "64px",
-          fontFamily: "Georgia, serif",
         }}
       >
         {/* Logo wordmark */}
         <div
           style={{
             display: "flex",
+            flexDirection: "row",
             alignItems: "baseline",
-            fontSize: 52,
-            fontWeight: 400,
-            color: "#FCFBF8",
-            letterSpacing: "-0.01em",
-            marginBottom: 24,
+            marginBottom: "28px",
           }}
         >
-          <span>Masseur</span><span style={{ color: "#FF8A1F" }}>Match</span>
+          <span
+            style={{
+              fontSize: "54px",
+              fontWeight: 700,
+              color: "#FCFBF8",
+              fontFamily: "Georgia, serif",
+              letterSpacing: "-0.01em",
+            }}
+          >
+            Masseur
+          </span>
+          <span
+            style={{
+              fontSize: "54px",
+              fontWeight: 700,
+              color: "#FF8A1F",
+              fontFamily: "Georgia, serif",
+              letterSpacing: "-0.01em",
+            }}
+          >
+            Match
+          </span>
         </div>
 
         {/* Tagline */}
         <div
           style={{
-            fontSize: 22,
-            color: "rgba(252,251,248,0.6)",
-            fontFamily: "system-ui, sans-serif",
-            fontWeight: 300,
-            letterSpacing: "0.04em",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
           }}
         >
-          LGBTQ+-Inclusive Massage Therapist Directory
+          <span
+            style={{
+              fontSize: "22px",
+              color: "rgba(252,251,248,0.6)",
+              fontFamily: "system-ui, sans-serif",
+              fontWeight: 300,
+              letterSpacing: "0.04em",
+            }}
+          >
+            LGBTQ+-Inclusive Massage Therapist Directory
+          </span>
         </div>
 
         {/* Accent line */}
         <div
           style={{
-            width: 80,
-            height: 3,
+            display: "flex",
+            width: "80px",
+            height: "3px",
             background: "#FF8A1F",
-            marginTop: 36,
+            marginTop: "36px",
           }}
         />
       </div>
     ),
-    { ...size }
+    { ...size },
   );
 }

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -24,6 +24,8 @@ export default async function Image() {
         {/* Logo wordmark */}
         <div
           style={{
+            display: "flex",
+            alignItems: "baseline",
             fontSize: 52,
             fontWeight: 400,
             color: "#FCFBF8",
@@ -31,7 +33,7 @@ export default async function Image() {
             marginBottom: 24,
           }}
         >
-          Masseur<span style={{ color: "#FF8A1F" }}>Match</span>
+          <span>Masseur</span><span style={{ color: "#FF8A1F" }}>Match</span>
         </div>
 
         {/* Tagline */}

--- a/src/components/homepage/EditorialHomepage.tsx
+++ b/src/components/homepage/EditorialHomepage.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowRight, CheckCircle2, Heart, MapPin, Search, Shield, Sparkles, Star, TrendingUp } from "lucide-react";
+import { ArrowRight, CheckCircle2, MapPin, Search, Shield, Sparkles, Star, Heart, TrendingUp } from "lucide-react";
 
 import type { PublicTherapist as Profile } from "@/app/_lib/directory";
 
@@ -38,76 +38,118 @@ export function EditorialHomepage({ featuredTherapists, totalTherapists, cityCou
 
   return (
     <main className="min-h-screen bg-[#FCFBF8] text-[#0B1F3A]">
-      <section className="relative overflow-hidden border-b border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-24 sm:px-6 lg:px-8 lg:py-32">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_14%_12%,rgba(255,138,31,0.16),transparent_32%),radial-gradient(circle_at_84%_20%,rgba(11,31,58,0.08),transparent_30%)]" />
-        <div className="relative mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[1.04fr_0.96fr]">
+
+      {/* ── HERO ── dark navy, bold, masculine */}
+      <section className="relative overflow-hidden bg-[#0B1F3A] px-4 py-28 sm:px-6 lg:px-8 lg:py-36">
+        {/* Atmospheric glows */}
+        <div className="pointer-events-none absolute -right-48 -top-48 h-[640px] w-[640px] rounded-full bg-[#FF8A1F]/[0.07] blur-[120px]" />
+        <div className="pointer-events-none absolute -left-32 bottom-0 h-[480px] w-[480px] rounded-full bg-[#1E4B8F]/50 blur-[90px]" />
+        {/* Subtle diagonal grid */}
+        <div
+          className="pointer-events-none absolute inset-0 opacity-[0.025]"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(255,255,255,0.6) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.6) 1px, transparent 1px)",
+            backgroundSize: "60px 60px",
+          }}
+        />
+
+        <div className="relative mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[1.1fr_0.9fr]">
+          {/* Left: copy */}
           <div>
-            <div className="mb-8 inline-flex items-center gap-3 rounded-full border border-[#0B1F3A]/15 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-[#0B1F3A]/70">
+            <div className="mb-8 inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-white/60">
               <span className="h-2 w-2 rounded-full bg-[#FF8A1F]" />
-              LGBTQ friendly directory
+              LGBTQ+ affirming directory
             </div>
-            <h1 className="font-['Georgia','Times_New_Roman',serif] text-5xl font-semibold leading-[0.98] tracking-[-0.045em] text-[#0B1F3A] sm:text-6xl lg:text-7xl">
-              Find LGBTQ friendly massage therapists near you.
+
+            <h1 className="font-['Georgia','Times_New_Roman',serif] text-5xl font-semibold leading-[1.0] tracking-[-0.04em] text-white sm:text-6xl lg:text-[4.25rem]">
+              Find LGBTQ+&nbsp;affirming massage therapists near&nbsp;you.
             </h1>
-            <p className="mt-7 max-w-2xl text-lg leading-8 text-[#0B1F3A]/72 sm:text-xl">
-              Discover independent massage therapists by city, specialty, profile details, and direct contact options. Built as a privacy first directory, not a booking marketplace.
+
+            <p className="mt-7 max-w-xl text-lg leading-8 text-white/60 sm:text-xl">
+              Discover independent massage therapists by city, specialty, and direct contact. A privacy-first directory — not a booking platform.
             </p>
+
             <div className="mt-10 flex flex-col gap-3 sm:flex-row">
-              <Link href="/explore" className="inline-flex items-center justify-center gap-2 rounded-full bg-[#0B1F3A] px-7 py-4 text-sm font-semibold text-white shadow-[0_18px_42px_rgba(11,31,58,0.22)] transition hover:bg-[#14365F]">
+              <Link
+                href="/explore"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-[#FF8A1F] px-7 py-4 text-sm font-bold text-[#0B1F3A] shadow-[0_8px_32px_rgba(255,138,31,0.38)] transition-all duration-300 hover:bg-[#ff9b42] hover:shadow-[0_14px_40px_rgba(255,138,31,0.50)] hover:scale-[1.02]"
+              >
                 Browse therapists
                 <ArrowRight className="h-4 w-4" />
               </Link>
-              <Link href="/join" className="inline-flex items-center justify-center rounded-full border border-[#0B1F3A]/18 bg-white/70 px-7 py-4 text-sm font-semibold text-[#0B1F3A] transition hover:bg-white">
+              <Link
+                href="/for-therapists"
+                className="inline-flex items-center justify-center rounded-full border border-white/20 px-7 py-4 text-sm font-semibold text-white/80 transition-all duration-300 hover:bg-white/10 hover:text-white hover:border-white/30"
+              >
                 List your profile
               </Link>
             </div>
-            <p className="mt-5 text-sm font-medium text-[#0B1F3A]/58">Directory only. No bookings, no payments, no platform managed sessions.</p>
 
-            <div className="mt-10 grid max-w-xl grid-cols-3 gap-4">
-              <div className="rounded-3xl border border-[#0B1F3A]/10 bg-white/70 p-5">
-                <p className="font-['Georgia','Times_New_Roman',serif] text-3xl font-semibold">{totalTherapists || 500}+</p>
-                <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[#0B1F3A]/55">Profiles</p>
-              </div>
-              <div className="rounded-3xl border border-[#0B1F3A]/10 bg-white/70 p-5">
-                <p className="font-['Georgia','Times_New_Roman',serif] text-3xl font-semibold">{cityCount || 50}+</p>
-                <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[#0B1F3A]/55">Cities</p>
-              </div>
-              <div className="rounded-3xl border border-[#0B1F3A]/10 bg-white/70 p-5">
-                <p className="font-['Georgia','Times_New_Roman',serif] text-3xl font-semibold">0</p>
-                <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[#0B1F3A]/55">Booking fees</p>
-              </div>
+            <p className="mt-5 text-xs font-medium uppercase tracking-[0.18em] text-white/30">
+              No bookings · No payments · No platform fees
+            </p>
+
+            {/* Stats */}
+            <div className="mt-12 grid max-w-sm grid-cols-3 gap-3">
+              {[
+                [totalTherapists || 500, "Profiles"],
+                [cityCount || 50, "Cities"],
+                ["$0", "Booking fees"],
+              ].map(([value, label]) => (
+                <div
+                  key={String(label)}
+                  className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 backdrop-blur-sm"
+                >
+                  <p className="font-['Georgia','Times_New_Roman',serif] text-3xl font-semibold text-white">
+                    {value}+
+                  </p>
+                  <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-white/40">{String(label)}</p>
+                </div>
+              ))}
             </div>
           </div>
 
-          <div className="rounded-[2.25rem] border border-[#0B1F3A]/12 bg-[#0B1F3A] p-5 shadow-[0_28px_90px_rgba(11,31,58,0.28)]">
-            <div className="rounded-[1.75rem] bg-[#FCFBF8] p-5">
-              <div className="rounded-3xl border border-[#0B1F3A]/10 bg-white p-5 shadow-sm">
+          {/* Right: search card */}
+          <div className="rounded-[2rem] border border-white/10 bg-white/[0.03] p-4 shadow-[0_32px_80px_rgba(0,0,0,0.50)] backdrop-blur-sm">
+            <div className="rounded-[1.5rem] bg-[#FCFBF8] p-4">
+              <div className="rounded-2xl border border-[#0B1F3A]/10 bg-white p-5 shadow-sm">
                 <div className="flex items-center gap-3">
                   <Search className="h-5 w-5 text-[#FF8A1F]" />
                   <span className="text-sm font-semibold text-[#0B1F3A]">Search the directory</span>
                 </div>
-                <div className="mt-5 grid gap-3 sm:grid-cols-2">
-                  <div className="rounded-2xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm text-[#0B1F3A]/65">City</div>
-                  <div className="rounded-2xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm text-[#0B1F3A]/65">Massage style</div>
-                  <div className="rounded-2xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm text-[#0B1F3A]/65">Provider type</div>
-                  <Link href="/explore" className="rounded-2xl bg-[#FF8A1F] px-4 py-3 text-center text-sm font-bold text-[#0B1F3A] transition hover:bg-[#ff9b42]">Search</Link>
+                <div className="mt-4 grid gap-2.5 sm:grid-cols-2">
+                  <div className="rounded-xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm text-[#0B1F3A]/50">City</div>
+                  <div className="rounded-xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm text-[#0B1F3A]/50">Massage style</div>
+                  <div className="rounded-xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm text-[#0B1F3A]/50">Provider type</div>
+                  <Link
+                    href="/explore"
+                    className="rounded-xl bg-[#FF8A1F] px-4 py-3 text-center text-sm font-bold text-[#0B1F3A] transition hover:bg-[#ff9b42]"
+                  >
+                    Search
+                  </Link>
                 </div>
               </div>
 
-              <div className="mt-5 grid grid-cols-2 gap-3">
+              <div className="mt-4 grid grid-cols-2 gap-2.5">
                 {popularCities.slice(0, 6).map((city) => (
-                  <Link key={city} href={cityHref(city)} className="rounded-2xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-4 py-3 text-sm font-semibold text-[#0B1F3A] transition hover:border-[#FF8A1F]/70 hover:bg-white">
-                    Massage therapists in {city}
+                  <Link
+                    key={city}
+                    href={cityHref(city)}
+                    className="rounded-xl border border-[#0B1F3A]/10 bg-white px-3 py-2.5 text-xs font-semibold text-[#0B1F3A] transition hover:border-[#FF8A1F]/60 hover:bg-[#FCFBF8]"
+                  >
+                    {city}
                   </Link>
                 ))}
               </div>
-              <div className="mt-6 rounded-3xl bg-[#0B1F3A] p-5 text-white">
-                <div className="flex items-center gap-3 text-sm font-semibold">
-                  <Shield className="h-5 w-5 text-[#FF8A1F]" />
-                  Privacy first browsing
+
+              <div className="mt-4 rounded-2xl bg-[#0B1F3A] p-4 text-white">
+                <div className="flex items-center gap-2.5 text-sm font-semibold">
+                  <Shield className="h-4 w-4 text-[#FF8A1F]" />
+                  Privacy-first browsing
                 </div>
-                <p className="mt-3 text-sm leading-6 text-white/72">
-                  MasseurMatch helps visitors compare profiles and contact therapists directly while keeping the platform focused on discovery, not payment or booking control.
+                <p className="mt-2 text-xs leading-5 text-white/60">
+                  Browse profiles and contact therapists directly. No booking management, no payment control.
                 </p>
               </div>
             </div>
@@ -115,10 +157,17 @@ export function EditorialHomepage({ featuredTherapists, totalTherapists, cityCou
         </div>
       </section>
 
-      <section className="px-4 py-14 sm:px-6 lg:px-8">
+      {/* ── TRUST PILLARS ── */}
+      <section className="border-b border-[#0B1F3A]/8 bg-white px-4 py-12 sm:px-6 lg:px-8">
         <div className="mx-auto grid max-w-7xl gap-4 md:grid-cols-5">
-          {["LGBTQ friendly directory", "Direct therapist contact", "City based discovery", "Transparent profile details", "Privacy first browsing"].map((item) => (
-            <div key={item} className="rounded-3xl border border-[#0B1F3A]/10 bg-white p-5 text-sm font-semibold text-[#0B1F3A] shadow-sm">
+          {[
+            "LGBTQ+ affirming",
+            "Direct therapist contact",
+            "City-based discovery",
+            "Transparent profiles",
+            "Privacy-first browsing",
+          ].map((item) => (
+            <div key={item} className="rounded-2xl border border-[#0B1F3A]/8 bg-[#FCFBF8] p-5 text-sm font-semibold text-[#0B1F3A]">
               <CheckCircle2 className="mb-3 h-5 w-5 text-[#FF8A1F]" />
               {item}
             </div>
@@ -126,101 +175,166 @@ export function EditorialHomepage({ featuredTherapists, totalTherapists, cityCou
         </div>
       </section>
 
+      {/* ── CITIES ── */}
       <section className="px-4 py-20 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-7xl">
           <div className="mb-12 flex flex-col justify-between gap-5 lg:flex-row lg:items-end">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#FF8A1F]">Explore by city</p>
-              <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">Explore massage therapists by city.</h2>
-              <p className="mt-4 max-w-2xl leading-7 text-[#0B1F3A]/66">Browse independent massage therapists in major cities and discover profiles by location, service style, and availability signals.</p>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#FF8A1F]">Explore by city</p>
+              <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">
+                Massage therapists by city.
+              </h2>
+              <p className="mt-4 max-w-2xl leading-7 text-[#0B1F3A]/60">
+                Browse independent massage therapists in major U.S. cities by location, service style, and availability.
+              </p>
             </div>
-            <Link href="/explore" className="inline-flex items-center gap-2 text-sm font-semibold text-[#0B1F3A]">Browse all cities <ArrowRight className="h-4 w-4" /></Link>
+            <Link href="/explore" className="inline-flex items-center gap-2 text-sm font-semibold text-[#0B1F3A] hover:text-[#FF8A1F] transition-colors">
+              Browse all cities <ArrowRight className="h-4 w-4" />
+            </Link>
           </div>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
             {popularCities.map((city) => (
-              <Link key={city} href={cityHref(city)} className="group rounded-[1.5rem] border border-[#0B1F3A]/10 bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:border-[#FF8A1F]/60 hover:shadow-xl">
+              <Link
+                key={city}
+                href={cityHref(city)}
+                className="group rounded-2xl border border-[#0B1F3A]/10 bg-white p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-[#FF8A1F]/50 hover:shadow-[0_12px_40px_rgba(11,31,58,0.12)]"
+              >
                 <MapPin className="h-5 w-5 text-[#FF8A1F]" />
-                <h3 className="mt-4 font-['Georgia','Times_New_Roman',serif] text-2xl font-semibold">{city}</h3>
-                <p className="mt-2 text-sm leading-6 text-[#0B1F3A]/62">Massage therapists in {city}</p>
+                <h3 className="mt-4 font-['Georgia','Times_New_Roman',serif] text-2xl font-semibold text-[#0B1F3A]">{city}</h3>
+                <p className="mt-2 text-xs uppercase tracking-[0.14em] text-[#0B1F3A]/45">View therapists</p>
               </Link>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="bg-[#0B1F3A] px-4 py-20 text-white sm:px-6 lg:px-8">
+      {/* ── HOW IT WORKS ── dark navy */}
+      <section className="bg-[#0B1F3A] px-4 py-24 text-white sm:px-6 lg:px-8">
         <div className="mx-auto max-w-7xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#FF8A1F]">How MasseurMatch works</p>
-          <h2 className="mt-3 max-w-3xl font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] sm:text-5xl">Simple discovery. Clear profiles. Direct contact.</h2>
-          <div className="mt-12 grid gap-8 lg:grid-cols-3">
+          <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#FF8A1F]">How MasseurMatch works</p>
+          <h2 className="mt-3 max-w-3xl font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] sm:text-5xl">
+            Simple discovery. Clear profiles. Direct contact.
+          </h2>
+          <div className="mt-14 grid gap-6 lg:grid-cols-3">
             {[
-              [Sparkles, "Search by city", "Find massage therapists based on location, profile details, and service information."],
+              [Sparkles, "Search by city", "Find massage therapists by location, profile details, and service information."],
               [Star, "Compare profiles", "Review photos, descriptions, specialties, incall or outcall options, and contact preferences."],
-              [Heart, "Contact directly", "Reach out to the therapist outside the platform using their listed contact method."],
+              [Heart, "Contact directly", "Reach the therapist using their listed contact method — no middleman, no booking fees."],
             ].map(([Icon, title, text]) => {
               const Component = Icon as typeof Sparkles;
               return (
-                <div key={String(title)} className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-8 transition hover:-translate-y-1 hover:bg-white/[0.07]">
+                <div
+                  key={String(title)}
+                  className="group rounded-2xl border border-white/10 bg-white/[0.04] p-8 transition-all duration-300 hover:-translate-y-1 hover:bg-white/[0.08] hover:border-white/20"
+                >
                   <Component className="h-7 w-7 text-[#FF8A1F]" />
-                  <h3 className="mt-6 font-['Georgia','Times_New_Roman',serif] text-3xl font-semibold">{title as string}</h3>
-                  <p className="mt-4 leading-7 text-white/68">{text as string}</p>
+                  <h3 className="mt-6 font-['Georgia','Times_New_Roman',serif] text-2xl font-semibold">{title as string}</h3>
+                  <p className="mt-4 text-sm leading-7 text-white/60">{text as string}</p>
                 </div>
               );
             })}
           </div>
-          <Link href="/how-it-works" className="mt-10 inline-flex items-center gap-2 rounded-full bg-[#FF8A1F] px-7 py-4 text-sm font-bold text-[#0B1F3A] transition hover:bg-[#ff9b42]">See How It Works <ArrowRight className="h-4 w-4" /></Link>
+          <Link
+            href="/how-it-works"
+            className="mt-12 inline-flex items-center gap-2 rounded-full bg-[#FF8A1F] px-7 py-4 text-sm font-bold text-[#0B1F3A] transition-all duration-300 hover:bg-[#ff9b42] hover:shadow-[0_8px_28px_rgba(255,138,31,0.40)]"
+          >
+            See how it works <ArrowRight className="h-4 w-4" />
+          </Link>
         </div>
       </section>
 
-      {visibleProfiles.length > 0 ? (
+      {/* ── FEATURED PROFILES ── */}
+      {visibleProfiles.length > 0 && (
         <section className="px-4 py-20 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-7xl">
             <div className="mb-12 flex flex-col justify-between gap-5 lg:flex-row lg:items-end">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#FF8A1F]">Featured profiles</p>
-                <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">Featured massage therapist profiles.</h2>
-                <p className="mt-4 max-w-2xl leading-7 text-[#0B1F3A]/66">Explore selected independent therapists with profile details, location, service style, and direct contact options.</p>
+                <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#FF8A1F]">Featured profiles</p>
+                <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">
+                  Featured massage therapist profiles.
+                </h2>
+                <p className="mt-4 max-w-2xl leading-7 text-[#0B1F3A]/60">
+                  Selected independent therapists with profile details, location, service style, and direct contact options.
+                </p>
               </div>
-              <Link href="/explore" className="inline-flex items-center gap-2 text-sm font-semibold text-[#0B1F3A]">View all profiles <ArrowRight className="h-4 w-4" /></Link>
+              <Link href="/explore" className="inline-flex items-center gap-2 text-sm font-semibold text-[#0B1F3A] hover:text-[#FF8A1F] transition-colors">
+                View all profiles <ArrowRight className="h-4 w-4" />
+              </Link>
             </div>
             <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
               {visibleProfiles.map((therapist) => (
-                <Link key={therapist.id} href={`/therapists/${therapist.slug || therapist.id}`} className="group overflow-hidden rounded-[2rem] border border-[#0B1F3A]/10 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-xl">
+                <Link
+                  key={therapist.id}
+                  href={`/therapists/${therapist.slug || therapist.id}`}
+                  className="group overflow-hidden rounded-2xl border border-[#0B1F3A]/10 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_16px_48px_rgba(11,31,58,0.14)] hover:border-[#0B1F3A]/20"
+                >
                   <div className="relative h-64 bg-[#0B1F3A]/8">
-                    <Image src={therapist.avatar_url || therapist.profile_photo || "/images/placeholder-therapist.jpg"} alt={profileName(therapist)} fill className="object-cover transition duration-700 group-hover:scale-105" />
-                    <div className="absolute inset-0 bg-gradient-to-t from-[#0B1F3A]/82 via-transparent to-transparent" />
+                    <Image
+                      src={therapist.avatar_url || therapist.profile_photo || "/images/placeholder-therapist.jpg"}
+                      alt={profileName(therapist)}
+                      fill
+                      className="object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-[#0B1F3A]/85 via-[#0B1F3A]/20 to-transparent" />
                     <div className="absolute bottom-4 left-4 right-4 text-white">
-                      <p className="font-['Georgia','Times_New_Roman',serif] text-2xl font-semibold">{profileName(therapist)}</p>
-                      <p className="mt-1 flex items-center gap-2 text-sm text-white/78"><MapPin className="h-4 w-4" />{therapist.city || "United States"}</p>
+                      <p className="font-['Georgia','Times_New_Roman',serif] text-xl font-semibold">{profileName(therapist)}</p>
+                      <p className="mt-1 flex items-center gap-1.5 text-xs text-white/70">
+                        <MapPin className="h-3.5 w-3.5" />
+                        {therapist.city || "United States"}
+                      </p>
                     </div>
                   </div>
                   <div className="p-5">
-                    <div className="mb-4 flex flex-wrap gap-2">
-                      {therapist.verification_status === "verified" && <span className="rounded-full bg-[#0B1F3A]/8 px-3 py-1 text-xs font-semibold text-[#0B1F3A]">Verified</span>}
-                      {therapist.lgbtq_affirming && <span className="rounded-full bg-[#FF8A1F]/12 px-3 py-1 text-xs font-semibold text-[#9A4A00]">LGBTQ+ affirming</span>}
-                      {therapist.available_now && <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">Available now</span>}
+                    <div className="mb-3 flex flex-wrap gap-1.5">
+                      {therapist.verification_status === "verified" && (
+                        <span className="rounded-full bg-[#0B1F3A]/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#0B1F3A]">
+                          Verified
+                        </span>
+                      )}
+                      {therapist.lgbtq_affirming && (
+                        <span className="rounded-full bg-[#FF8A1F]/12 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#9A4A00]">
+                          LGBTQ+ affirming
+                        </span>
+                      )}
+                      {therapist.available_now && (
+                        <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-700">
+                          Available
+                        </span>
+                      )}
                     </div>
-                    <p className="line-clamp-2 text-sm leading-6 text-[#0B1F3A]/65">{therapist.headline || therapist.bio || "Review profile details, services, pricing, and contact options directly."}</p>
+                    <p className="line-clamp-2 text-sm leading-6 text-[#0B1F3A]/60">
+                      {therapist.headline || therapist.bio || "Review profile details, services, pricing, and contact options directly."}
+                    </p>
                   </div>
                 </Link>
               ))}
             </div>
           </div>
         </section>
-      ) : null}
+      )}
 
-      <section className="px-4 py-20 sm:px-6 lg:px-8">
+      {/* ── SERVICE STYLES ── */}
+      <section className="border-t border-[#0B1F3A]/8 bg-white px-4 py-20 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-7xl">
-          <div className="grid gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:items-start">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#FF8A1F]">Browse by massage style</p>
-              <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">Service pages built for discovery.</h2>
-              <p className="mt-5 leading-7 text-[#0B1F3A]/66">Category links create a stronger internal SEO map and help visitors discover profiles by actual search intent.</p>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#FF8A1F]">Browse by service</p>
+              <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">
+                Discover by massage style.
+              </h2>
+              <p className="mt-5 leading-7 text-[#0B1F3A]/60">
+                Service category pages help visitors discover profiles by actual search intent — deep tissue, Swedish, sports, mobile, and more.
+              </p>
             </div>
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-3 sm:grid-cols-2">
               {massageStyles.map((style) => (
-                <Link key={style} href={styleHref(style)} className="rounded-3xl border border-[#0B1F3A]/10 bg-white p-5 font-semibold text-[#0B1F3A] shadow-sm transition hover:-translate-y-1 hover:border-[#FF8A1F]/60 hover:shadow-xl">
+                <Link
+                  key={style}
+                  href={styleHref(style)}
+                  className="group flex items-center justify-between rounded-xl border border-[#0B1F3A]/10 bg-[#FCFBF8] px-5 py-4 font-semibold text-[#0B1F3A] transition-all duration-200 hover:border-[#FF8A1F]/50 hover:bg-white hover:shadow-md"
+                >
                   {style}
+                  <ArrowRight className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 text-[#FF8A1F]" />
                 </Link>
               ))}
             </div>
@@ -228,54 +342,80 @@ export function EditorialHomepage({ featuredTherapists, totalTherapists, cityCou
         </div>
       </section>
 
+      {/* ── SEO / EDITORIAL BLOCK ── */}
       <section className="px-4 py-20 sm:px-6 lg:px-8">
-        <div className="mx-auto grid max-w-7xl gap-10 rounded-[2.5rem] border border-[#0B1F3A]/10 bg-white p-8 shadow-sm lg:grid-cols-[1.05fr_0.95fr] lg:p-12">
+        <div className="mx-auto grid max-w-7xl gap-8 rounded-[2rem] border border-[#0B1F3A]/10 bg-white p-8 shadow-sm lg:grid-cols-[1.1fr_0.9fr] lg:p-12">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#FF8A1F]">SEO directory model</p>
-            <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A]">Find massage therapists in your city.</h2>
-            <p className="mt-6 leading-8 text-[#0B1F3A]/68">
-              MasseurMatch helps clients discover independent massage therapists through city based directory pages and detailed therapist profiles. Whether visitors are looking for relaxation massage, deep tissue massage, sports massage, mobile massage, incall, or outcall options, the directory makes it easier to compare profile details and contact therapists directly.
+            <p className="text-xs font-bold uppercase tracking-[0.22em] text-[#FF8A1F]">About MasseurMatch</p>
+            <h2 className="mt-3 font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A]">
+              Find massage therapists in your city.
+            </h2>
+            <p className="mt-6 leading-8 text-[#0B1F3A]/65">
+              MasseurMatch helps clients discover independent massage therapists through city-based directory pages and detailed therapist profiles. Whether visitors are looking for deep tissue, Swedish, sports, mobile, incall, or outcall options, the directory makes it easier to compare profiles and contact therapists directly.
             </p>
-            <p className="mt-5 leading-8 text-[#0B1F3A]/68">
+            <p className="mt-5 leading-8 text-[#0B1F3A]/65">
               Unlike booking platforms, MasseurMatch does not manage appointments, payments, calendars, or therapist schedules. Each profile provides information submitted by the provider, helping clients make informed direct contact outside the platform.
             </p>
           </div>
-          <div className="rounded-[2rem] bg-[#0B1F3A] p-8 text-white">
+          <div className="rounded-2xl bg-[#0B1F3A] p-8 text-white">
             <TrendingUp className="h-8 w-8 text-[#FF8A1F]" />
-            <h3 className="mt-6 font-['Georgia','Times_New_Roman',serif] text-3xl font-semibold">Built for organic growth.</h3>
-            <ul className="mt-6 space-y-4 text-sm leading-6 text-white/72">
-              <li>City based internal links</li>
-              <li>Service category clusters</li>
-              <li>Featured profile pathways</li>
-              <li>FAQ content for long tail search</li>
-              <li>Direct, indexable directory copy</li>
+            <h3 className="mt-6 font-['Georgia','Times_New_Roman',serif] text-2xl font-semibold">Built for organic growth.</h3>
+            <ul className="mt-6 space-y-3 text-sm leading-7 text-white/65">
+              {["City-based internal links", "Service category clusters", "Featured profile pathways", "FAQ content for long-tail search", "Direct, indexable directory copy"].map((item) => (
+                <li key={item} className="flex items-center gap-2.5">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#FF8A1F] flex-shrink-0" />
+                  {item}
+                </li>
+              ))}
             </ul>
           </div>
         </div>
       </section>
 
-      <section className="px-4 py-20 sm:px-6 lg:px-8">
-        <div className="mx-auto max-w-5xl">
-          <p className="text-center text-xs font-semibold uppercase tracking-[0.22em] text-[#FF8A1F]">FAQ</p>
-          <h2 className="mt-3 text-center font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">Frequently asked questions.</h2>
-          <div className="mt-10 divide-y divide-[#0B1F3A]/10 rounded-[2rem] border border-[#0B1F3A]/10 bg-white">
+      {/* ── FAQ ── */}
+      <section className="border-t border-[#0B1F3A]/8 bg-white px-4 py-20 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl">
+          <p className="text-center text-xs font-bold uppercase tracking-[0.22em] text-[#FF8A1F]">FAQ</p>
+          <h2 className="mt-3 text-center font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] text-[#0B1F3A] sm:text-5xl">
+            Frequently asked questions.
+          </h2>
+          <div className="mt-10 divide-y divide-[#0B1F3A]/8 rounded-2xl border border-[#0B1F3A]/10 bg-[#FCFBF8] overflow-hidden">
             {faqs.map(([question, answer]) => (
-              <div key={question} className="p-6">
+              <div key={question} className="p-6 sm:p-8">
                 <h3 className="font-semibold text-[#0B1F3A]">{question}</h3>
-                <p className="mt-3 leading-7 text-[#0B1F3A]/66">{answer}</p>
+                <p className="mt-3 leading-7 text-[#0B1F3A]/60">{answer}</p>
               </div>
             ))}
           </div>
         </div>
       </section>
 
-      <section className="px-4 pb-24 sm:px-6 lg:px-8">
-        <div className="mx-auto max-w-7xl rounded-[2.5rem] bg-[#0B1F3A] p-10 text-center text-white lg:p-16">
-          <h2 className="font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] sm:text-5xl">Start exploring independent massage therapists.</h2>
-          <p className="mx-auto mt-5 max-w-2xl leading-7 text-white/68">Browse city pages, compare profiles, or create a therapist profile to grow visibility in a cleaner directory experience.</p>
-          <div className="mt-9 flex flex-col justify-center gap-3 sm:flex-row">
-            <Link href="/explore" className="inline-flex items-center justify-center gap-2 rounded-full bg-[#FF8A1F] px-7 py-4 text-sm font-bold text-[#0B1F3A] transition hover:bg-[#ff9b42]">Browse therapists <ArrowRight className="h-4 w-4" /></Link>
-            <Link href="/join" className="inline-flex items-center justify-center rounded-full border border-white/15 px-7 py-4 text-sm font-semibold text-white transition hover:bg-white/10">List your profile</Link>
+      {/* ── FINAL CTA ── */}
+      <section className="px-4 pb-24 pt-4 sm:px-6 lg:px-8">
+        <div className="relative mx-auto max-w-7xl overflow-hidden rounded-[2rem] bg-[#0B1F3A] p-10 text-center text-white lg:p-16">
+          <div className="pointer-events-none absolute -right-32 -top-32 h-[400px] w-[400px] rounded-full bg-[#FF8A1F]/[0.08] blur-[80px]" />
+          <div className="pointer-events-none absolute -left-32 bottom-0 h-[300px] w-[300px] rounded-full bg-[#1E4B8F]/40 blur-[60px]" />
+          <div className="relative">
+            <h2 className="font-['Georgia','Times_New_Roman',serif] text-4xl font-semibold tracking-[-0.03em] sm:text-5xl">
+              Start exploring independent massage therapists.
+            </h2>
+            <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-white/55">
+              Browse city pages, compare profiles, or create a therapist profile to grow visibility in a premium directory experience.
+            </p>
+            <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+              <Link
+                href="/explore"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-[#FF8A1F] px-7 py-4 text-sm font-bold text-[#0B1F3A] shadow-[0_8px_28px_rgba(255,138,31,0.40)] transition-all duration-300 hover:bg-[#ff9b42] hover:shadow-[0_14px_40px_rgba(255,138,31,0.55)]"
+              >
+                Browse therapists <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/for-therapists"
+                className="inline-flex items-center justify-center rounded-full border border-white/20 px-7 py-4 text-sm font-semibold text-white/80 transition-all duration-300 hover:bg-white/10 hover:text-white"
+              >
+                List your profile
+              </Link>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
- Fix OG image Satori rendering error (logo wordmark div with mixed text/span children required explicit display:flex per Satori constraint)
- Redesign homepage hero from soft cream to dark navy with atmospheric glows and subtle grid texture — orange CTA with glow shadow, white/dim copy
- Improve hero stats cards to glass treatment on dark background
- Fix footer brand logo: "Match" was slate-500 gray, now brand orange #FF8A1F
- Update footer background to deeper #060E1A and border-t to white/6 opacity
- Update footer copy to accurate privacy-first messaging
- Redesign therapist cards: brand navy border/bg, orange MapPin icon, hover lifts with navy shadow, "View" button transitions navy→orange on hover
- Add orange ArrowRight reveal on service style links
- Improve final CTA section with atmospheric background glows
- All sections: tighten radius, spacing, and typographic hierarchy

Build: ✅  TypeScript: ✅  ESLint: ✅  API tests: ✅  Playwright: 40/40 ✅