### PR TITLE
Revamp provider profile UX and polish homepage/chat/map

### DIFF
--- a/src/app/_components/home-seo-landing.tsx
+++ b/src/app/_components/home-seo-landing.tsx
@@ -92,8 +92,30 @@ export function HomeSeoLanding({
   guides,
   cityCoverageLine,
 }: HomeSeoLandingProps) {
+  const keywordRibbon = [
+    "Deep Tissue Massage",
+    "Swedish Massage",
+    "Sports Recovery",
+    "Incall Session",
+    "Outcall Massage",
+    "Available Now",
+    "Verified Therapist",
+    "LGBTQ+ Friendly",
+  ];
+
   return (
     <div className="bg-[#f4f6fa] text-text-primary">
+      <section className="overflow-hidden border-b border-white/20 bg-[#06152a] py-2">
+        <div className="whitespace-nowrap [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]">
+          <div className="inline-flex min-w-full animate-[marquee_24s_linear_infinite] gap-6 px-4 text-xs font-semibold uppercase tracking-[0.2em] text-[#b6d7ff]">
+            {[...keywordRibbon, ...keywordRibbon].map((keyword, index) => (
+              <span key={`${keyword}-${index}`} className="rounded-full border border-[#2a588f] bg-[#0c2342] px-4 py-1.5">
+                {keyword}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
       <section className="relative isolate overflow-hidden border-b border-white/40 bg-[linear-gradient(160deg,#08162b_0%,#0b1f3a_40%,#153e79_100%)] text-white">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,179,71,0.22),transparent_26%),radial-gradient(circle_at_85%_10%,rgba(255,255,255,0.12),transparent_24%),linear-gradient(rgba(255,255,255,0.06)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.06)_1px,transparent_1px)] bg-[size:auto,auto,72px_72px,72px_72px] opacity-90" />
         <div className="page-shell relative py-12 sm:py-16 lg:py-20">

--- a/src/app/_components/site-header.tsx
+++ b/src/app/_components/site-header.tsx
@@ -228,7 +228,7 @@ export default function SiteHeader() {
     router.refresh();
   }
 
-  const isDarkHero = isHomepage && !isScrolled;
+  const isDarkHero = false;
 
   return (
     <motion.header

--- a/src/app/pro/profile/ProProfilePageClient.tsx
+++ b/src/app/pro/profile/ProProfilePageClient.tsx
@@ -6,6 +6,7 @@ import { updateProfileMutation, type ProProfileMutationResponse } from "@/app/_l
 import { requestJson } from "@/app/_lib/request";
 import { useToast } from "@/hooks/use-toast";
 import { BODY_TYPE_OPTIONS, normalizeBodyTypeValue } from "@/lib/physical-profile";
+import { US_CITIES } from "@/data/cities";
 
 type ProfileResponse = {
   ok: boolean;
@@ -39,6 +40,13 @@ const EMPTY_FORM: FormState = {
   weightLb: "",
   bodyType: "",
 };
+
+const STATE_OPTIONS = Array.from(new Set(US_CITIES.map((city) => city.stateCode))).sort();
+const SPECIALTY_OPTIONS = [
+  "Deep Tissue", "Swedish", "Sports Massage", "Hot Stone", "Thai Massage", "Trigger Point",
+  "Myofascial Release", "Lymphatic Drainage", "Prenatal", "Reflexology", "Relaxation", "Stretch Therapy",
+  "Incall", "Outcall", "Couples Massage", "Chair Massage",
+];
 
 function mapProfileToForm(profile: ProfileResponse["profile"]): FormState {
   if (!profile) {
@@ -180,21 +188,56 @@ export default function ProProfilePageClient() {
               <AppInput
                 placeholder="City"
                 value={form.city}
-                onChange={(event) => setForm((current) => ({ ...current, city: event.target.value }))}
+                onChange={(event) => {
+                  const selected = US_CITIES.find((city) => `${city.name}, ${city.stateCode}` === event.target.value);
+                  setForm((current) => ({
+                    ...current,
+                    city: selected?.name ?? event.target.value,
+                    state: selected?.stateCode ?? current.state,
+                  }));
+                }}
+                list="city-options"
                 required
               />
-              <AppInput
-                placeholder="State"
+              <datalist id="city-options">
+                {US_CITIES.map((city) => (
+                  <option key={`${city.slug}-${city.stateCode}`} value={`${city.name}, ${city.stateCode}`} />
+                ))}
+              </datalist>
+              <select
                 value={form.state}
                 onChange={(event) => setForm((current) => ({ ...current, state: event.target.value }))}
-              />
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="">State</option>
+                {STATE_OPTIONS.map((stateCode) => (
+                  <option key={stateCode} value={stateCode}>{stateCode}</option>
+                ))}
+              </select>
               <AppInput
                 placeholder="Phone"
                 value={form.phone}
                 onChange={(event) => setForm((current) => ({ ...current, phone: event.target.value }))}
               />
+              <select
+                value=""
+                onChange={(event) => {
+                  const value = event.target.value;
+                  if (!value) return;
+                  const current = form.specialties.split(",").map((v) => v.trim()).filter(Boolean);
+                  if (!current.includes(value)) {
+                    setForm((prev) => ({ ...prev, specialties: [...current, value].join(", ") }));
+                  }
+                }}
+                className="md:col-span-2 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <option value="">Add specialty / service option</option>
+                {SPECIALTY_OPTIONS.map((option) => (
+                  <option key={option} value={option}>{option}</option>
+                ))}
+              </select>
               <AppInput
-                placeholder="Specialties (comma separated)"
+                placeholder="Selected specialties (editable)"
                 value={form.specialties}
                 onChange={(event) => setForm((current) => ({ ...current, specialties: event.target.value }))}
                 className="md:col-span-2"

--- a/src/app/therapists/[slug]/_components/ProfileAreasServed.tsx
+++ b/src/app/therapists/[slug]/_components/ProfileAreasServed.tsx
@@ -32,14 +32,15 @@ export function ProfileAreasServed({ profile }: Props) {
     return null;
   }
 
-  const mapEmbedUrl = mapQuery 
-    ? `https://www.google.com/maps/embed/v1/place?q=${encodeURIComponent(mapQuery)}&key=AIzaSyB41DcZfigtf2v4c0D0iQLQoDjiMEsPJwg`
+  const mapEmbedKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_EMBED_KEY;
+  const mapEmbedUrl = mapQuery && mapEmbedKey
+    ? `https://www.google.com/maps/embed/v1/place?q=${encodeURIComponent(mapQuery)}&key=${mapEmbedKey}`
     : null;
 
   return (
     <div className="pp-location-section">
       {/* Map Card */}
-      {mapEmbedUrl && (
+      {mapEmbedUrl ? (
         <div className="pp-map-card pp-fade-in">
           <div className="pp-map-container">
             <iframe
@@ -59,7 +60,21 @@ export function ProfileAreasServed({ profile }: Props) {
             <span>Map shows approximate service area, not exact private address</span>
           </div>
         </div>
-      )}
+      ) : mapQuery ? (
+        <div className="pp-map-card pp-fade-in">
+          <div className="rounded-[var(--radius-sm)] border border-[var(--glass-border)] bg-[var(--cream-dim)] p-6 text-sm text-[var(--cream-soft)]">
+            Map preview unavailable right now. You can still open this area directly in Google Maps:
+            <a
+              className="ml-1 text-[var(--orange)] underline"
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(mapQuery)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {mapQuery}
+            </a>
+          </div>
+        </div>
+      ) : null}
 
       {/* Base Location */}
       <div className="pp-location-header">

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -191,7 +191,7 @@ export const KnottyChat = ({
   const panel = (
     <div
       className={cn(
-        "relative flex flex-col overflow-hidden rounded-[28px] border border-[#1b4678] bg-[linear-gradient(180deg,#0b2447_0%,#091b37_52%,#07162f_100%)] shadow-[0_32px_96px_rgba(1,10,28,0.62)] backdrop-blur-3xl",
+        "relative flex flex-col overflow-hidden rounded-[28px] border border-[#27527f] bg-[linear-gradient(180deg,#133a63_0%,#102f54_52%,#0a223f_100%)] shadow-[0_32px_96px_rgba(1,10,28,0.48)] backdrop-blur-3xl",
         isEmbedded
           ? "h-[620px] w-full"
           : "w-[396px] max-w-[calc(100vw-2rem)] h-[min(620px,calc(100svh-5rem))]",


### PR DESCRIPTION
### Motivation
- Make the provider profile onboarding and edit flow much faster and more visually clear by exposing choice controls and curated options instead of free-text where useful.
- Ensure the top navigation is visible across the homepage and improve the Knotty chat UI to be more readable and visually premium.
- Fix profile map behavior so a missing or hard-coded Google Maps key no longer prevents users from accessing a map, and add a graceful fallback.
- Add an animated keyword ribbon on the homepage hero to surface important keywords in a moving banner.

### Description
- Updated the pro profile editor to provide assisted choices: added a `datalist` of cities sourced from `US_CITIES`, a `select` for `state`, and a specialty picker with prefilled `SPECIALTY_OPTIONS` while keeping an editable specialties input for manual edits (`src/app/pro/profile/ProProfilePageClient.tsx`).
- Forced the site header into a high-contrast mode by setting `isDarkHero = false` so the home menu is visible above the hero (`src/app/_components/site-header.tsx`).
- Restyled the Knotty chat panel background/gradient and adjusted border/shadow colors to improve contrast and readability (`src/components/ai/KnottyChat.tsx`).
- Reworked therapist profile map embedding to use `NEXT_PUBLIC_GOOGLE_MAPS_EMBED_KEY` and avoid a hard-coded API key, and added a fallback card linking to Google Maps when inline embedding is unavailable (`src/app/therapists/[slug]/_components/ProfileAreasServed.tsx`).
- Added an animated keywords ribbon (marquee-style) above the homepage hero to surface search keywords (`src/app/_components/home-seo-landing.tsx`).

### Testing
- Ran lint on the modified files with `npx eslint src/app/pro/profile/ProProfilePageClient.tsx src/app/_components/site-header.tsx src/components/ai/KnottyChat.tsx src/app/therapists/[slug]/_components/ProfileAreasServed.tsx src/app/_components/home-seo-landing.tsx` and the lint run completed successfully.
- No automated unit or integration tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a146c1fab7c8324aa7c33f017745fbf)