### PR TITLE
seo: add llms.txt, raise noindex threshold, enrich profile schema

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,58 @@
+# MasseurMatch
+
+> MasseurMatch is the United States' primary verified directory for LGBTQ+-affirming male massage therapists. It provides identity-verified provider profiles, real client reviews, direct contact options (phone, WhatsApp, SMS), incall and outcall availability, and hyper-local city pages covering hundreds of markets.
+
+## Platform Overview
+
+- [About MasseurMatch](https://masseurmatch.com/about)
+- [How It Works](https://masseurmatch.com/how-it-works)
+- [Trust & Safety Policy](https://masseurmatch.com/safety)
+- [Verification Standards](https://masseurmatch.com/trust)
+- [For Massage Therapists](https://masseurmatch.com/for-therapists)
+- [Pricing & Plans](https://masseurmatch.com/pricing)
+
+## Browse Therapists
+
+- [All Verified Therapists](https://masseurmatch.com/therapists)
+- [Search by City or Specialty](https://masseurmatch.com/search)
+- [Browse by State](https://masseurmatch.com/states)
+- [Browse by City](https://masseurmatch.com/cities)
+- [Find Therapists Near Me](https://masseurmatch.com/near-me)
+
+## Top City Markets
+
+- [Dallas Male Massage Therapists](https://masseurmatch.com/dallas)
+- [Houston Male Massage Therapists](https://masseurmatch.com/houston)
+- [Austin Male Massage Therapists](https://masseurmatch.com/austin)
+- [Los Angeles Male Massage Therapists](https://masseurmatch.com/los-angeles)
+- [New York Male Massage Therapists](https://masseurmatch.com/new-york)
+- [Chicago Male Massage Therapists](https://masseurmatch.com/chicago)
+- [Miami Male Massage Therapists](https://masseurmatch.com/miami)
+- [Atlanta Male Massage Therapists](https://masseurmatch.com/atlanta)
+- [Seattle Male Massage Therapists](https://masseurmatch.com/seattle)
+- [Denver Male Massage Therapists](https://masseurmatch.com/denver)
+- [Phoenix Male Massage Therapists](https://masseurmatch.com/phoenix)
+- [San Diego Male Massage Therapists](https://masseurmatch.com/san-diego)
+
+## Educational Guides
+
+- [All Massage Guides](https://masseurmatch.com/guides)
+
+## Directory Comparisons
+
+- [MasseurMatch vs MasseurFinder](https://masseurmatch.com/compare/masseurmatch-vs-masseurfinder)
+- [MasseurMatch vs RentMasseur](https://masseurmatch.com/compare/masseurmatch-vs-rentmasseur)
+- [All Comparisons](https://masseurmatch.com/compare)
+
+## Ignore
+
+The following sections contain paginated results, authenticated sessions, or thin auto-generated pages with no unique content — skip them.
+
+- /admin
+- /dashboard
+- /login
+- /register
+- /signup
+- /api
+- /search?*
+- Any URL containing ?page=, ?sort=, ?filter=, ?token=, or ?session=

--- a/src/app/[city]/page.tsx
+++ b/src/app/[city]/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
       `${city.name} sports massage`,
       `mobile massage ${city.name}`,
     ],
-    noIndex: inventoryCount === 0,
+    noIndex: inventoryCount < 3,
   });
 }
 

--- a/src/app/_lib/seo-routes.ts
+++ b/src/app/_lib/seo-routes.ts
@@ -195,7 +195,7 @@ export async function buildCitiesSitemapEntries(now = new Date()): Promise<Metad
       .filter((city) => ROUTABLE_CITY_SLUGS.has(city.slug))
       .filter((city) => {
         const cityName = cityNameBySlug(city.slug);
-        return cityName ? (inventoryMap.get(cityName.toLowerCase()) ?? 0) > 0 : false;
+        return cityName ? (inventoryMap.get(cityName.toLowerCase()) ?? 0) >= 3 : false;
       })
       .map((city) => ({
         url: toSitemapUrl(`/cities/${city.slug}`),
@@ -210,7 +210,7 @@ export async function buildCitiesSitemapEntries(now = new Date()): Promise<Metad
     .filter((path) => {
       const slug = path.split("/").filter(Boolean)[0];
       const cityName = slug ? cityNameBySlug(slug) : null;
-      return cityName ? (inventoryMap.get(cityName.toLowerCase()) ?? 0) > 0 : false;
+      return cityName ? (inventoryMap.get(cityName.toLowerCase()) ?? 0) >= 3 : false;
     })
     .map((path) => buildSitemapEntry(`/cities${path}`, now, "weekly", 0.7));
 }

--- a/src/components/profile/ProfileStructuredData.tsx
+++ b/src/components/profile/ProfileStructuredData.tsx
@@ -1,13 +1,105 @@
 import { JsonLd } from "@/app/_components/JsonLd";
 import type { ProfileViewModel } from "./profile-utils";
 
+function buildCredentials(profile: ProfileViewModel) {
+  const credentials = [];
+  if (profile.licenseOptional) {
+    credentials.push({
+      "@type": "EducationalOccupationalCredential",
+      credentialCategory: "license",
+      name: "Licensed Massage Therapist",
+      description: profile.licenseOptional,
+    });
+  }
+  if (profile.backgroundChecked) {
+    credentials.push({
+      "@type": "EducationalOccupationalCredential",
+      credentialCategory: "certification",
+      name: "Identity & Background Verified",
+      description: "Identity and background verified by MasseurMatch",
+    });
+  }
+  if (profile.isVerified && !profile.backgroundChecked) {
+    credentials.push({
+      "@type": "EducationalOccupationalCredential",
+      credentialCategory: "certification",
+      name: "Platform Verified",
+      description: "Profile verified by MasseurMatch",
+    });
+  }
+  return credentials;
+}
+
+function buildOfferCatalog(profile: ProfileViewModel) {
+  if (!profile.pricing.length && !profile.services.length) return undefined;
+
+  const offers = profile.pricing.length
+    ? profile.pricing.map((session) => ({
+        "@type": "Offer",
+        name: session.name,
+        description: `${session.duration}${session.incall !== "Contact for rates" ? ` — Incall: ${session.incall}` : ""}${session.outcall !== "Contact for rates" ? `, Outcall: ${session.outcall}` : ""}`,
+        priceCurrency: profile.currency || "USD",
+        availability: "https://schema.org/InStock",
+        itemOffered: { "@type": "Service", name: session.name },
+      }))
+    : profile.services.slice(0, 6).map((service) => ({
+        "@type": "Offer",
+        name: service,
+        priceCurrency: profile.currency || "USD",
+        availability: "https://schema.org/InStock",
+        itemOffered: { "@type": "Service", name: service },
+      }));
+
+  return { "@type": "OfferCatalog", name: `${profile.name} massage services`, itemListElement: offers };
+}
+
 export function ProfileStructuredData({ profile }: { profile: ProfileViewModel }) {
   const address = { "@type": "PostalAddress", addressLocality: profile.city, addressRegion: profile.state, addressCountry: profile.country };
   const contactPoint = [profile.phone && { "@type": "ContactPoint", telephone: profile.phone, contactType: "phone" }, profile.email && { "@type": "ContactPoint", email: profile.email, contactType: "email" }].filter(Boolean);
+  const credentials = buildCredentials(profile);
+  const offerCatalog = buildOfferCatalog(profile);
+  const allServices = Array.from(new Set([...profile.services, ...profile.specialties, ...profile.massageTypes]));
+
   const data = [
-    { "@context": "https://schema.org", "@type": "ProfilePage", name: profile.seoTitle, description: profile.seoDescription, url: profile.canonicalUrl, image: profile.ogImage, mainEntity: { "@type": "Person", name: profile.name, image: profile.profilePhotoUrl, address, knowsLanguage: profile.languages } },
-    { "@context": "https://schema.org", "@type": "LocalBusiness", name: profile.name, description: profile.seoDescription, image: profile.ogImage, url: profile.canonicalUrl, address, areaServed: profile.serviceAreas, priceRange: profile.startingPrice, contactPoint },
-    { "@context": "https://schema.org", "@type": "Service", name: `${profile.name} massage services`, description: `${profile.services.join(", ")} in ${profile.city}, ${profile.state}`, provider: { "@type": "Person", name: profile.name }, areaServed: profile.serviceAreas, serviceType: profile.services },
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfilePage",
+      name: profile.seoTitle,
+      description: profile.seoDescription,
+      url: profile.canonicalUrl,
+      image: profile.ogImage,
+      mainEntity: {
+        "@type": "Person",
+        name: profile.name,
+        image: profile.profilePhotoUrl,
+        address,
+        knowsLanguage: profile.languages,
+        knowsAbout: allServices.length ? allServices : undefined,
+        ...(credentials.length ? { hasCredential: credentials } : {}),
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "LocalBusiness",
+      name: profile.name,
+      description: profile.seoDescription,
+      image: profile.ogImage,
+      url: profile.canonicalUrl,
+      address,
+      areaServed: profile.serviceAreas,
+      priceRange: profile.startingPrice,
+      contactPoint,
+      ...(offerCatalog ? { hasOfferCatalog: offerCatalog } : {}),
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: `${profile.name} massage services`,
+      description: `${profile.services.join(", ")} in ${profile.city}, ${profile.state}`,
+      provider: { "@type": "Person", name: profile.name },
+      areaServed: profile.serviceAreas,
+      serviceType: profile.services,
+    },
   ];
   return <>{data.map((item, index) => <JsonLd key={index} data={item} />)}</>;
 }

--- a/src/components/profile/ProfileStructuredData.tsx
+++ b/src/components/profile/ProfileStructuredData.tsx
@@ -1,8 +1,10 @@
 import { JsonLd } from "@/app/_components/JsonLd";
 import type { ProfileViewModel } from "./profile-utils";
 
+type Credential = { "@type": string; credentialCategory: string; name: string; description: string };
+
 function buildCredentials(profile: ProfileViewModel) {
-  const credentials = [];
+  const credentials: Credential[] = [];
   if (profile.licenseOptional) {
     credentials.push({
       "@type": "EducationalOccupationalCredential",


### PR DESCRIPTION
- Add /public/llms.txt routing AI crawlers (GPTBot, PerplexityBot, etc.)
  to authoritative content and away from thin/paginated pages
- Raise city page noindex threshold from 0 to 3 providers so thin
  programmatic pages don't drag down domain-wide quality signals; apply
  the same >=3 gate to the cities sitemap entries
- Extend ProfileStructuredData with hasCredential (license + background
  check) on the Person node and hasOfferCatalog (per-session pricing) on
  the LocalBusiness node to satisfy E-E-A-T and enable rich snippets

https://claude.ai/code/session_012divpRpsFuGVeoc9baF5Zy