### PR TITLE
fix: bust TS cache for FadeUp className prop

### DIFF
--- a/src/components/motion/FadeUp.tsx
+++ b/src/components/motion/FadeUp.tsx
@@ -7,6 +7,7 @@ type FadeUpProps = {
   children: React.ReactNode;
   delay?: number;
   y?: number;
+  /** Optional Tailwind / CSS classes forwarded to the wrapper element */
   className?: string;
 };
 


### PR DESCRIPTION
## Problem
Build was failing with:
```
Property 'className' does not exist on type 'IntrinsicAttributes & FadeUpProps'
```
The prop was already typed correctly, but the TypeScript compiler cache had a stale snapshot of the type.

## Fix
Added a JSDoc comment to the `className` prop in `FadeUp.tsx` to force TypeScript to reprocess the file and invalidate the stale cache on the next build.