### PR TITLE
fix(page): import missing constants from home-data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,12 @@ import { siteUrl } from "@/lib/site";
 import { getPublicTherapists, getCities } from "@/app/_lib/directory";
 import { competitorsByTier } from "@/lib/competitors";
 import { GUIDES } from "@/app/guides/data";
+import {
+  PRIORITY_CITY_SLUGS,
+  CITY_ROUTE_COUNTS,
+  CITY_HIGHLIGHTS,
+  LANDING_FAQ,
+} from "@/lib/marketing/home-data";
 import type { CityData } from "@/data/cities";
 
 export const revalidate = 3600;


### PR DESCRIPTION
PRIORITY_CITY_SLUGS, CITY_ROUTE_COUNTS, CITY_HIGHLIGHTS, and LANDING_FAQ
were defined in src/lib/marketing/home-data.ts but never imported in page.tsx,
causing four TS2304 type errors.

https://claude.ai/code/session_01UMS1X6CimAscU8vSZMFPto