### PR TITLE
FINAL GO LIVE: production schema, auth, CI, Stripe, and legacy cleanup

### DIFF
--- a/src/app/pro/photos/page.tsx
+++ b/src/app/pro/photos/page.tsx
@@ -194,7 +194,7 @@ export default function PhotoManagerPage() {
     if (remainingSlots <= 0) {
       toast({
         title: "Photo limit reached",
-        description: `Seu plano ${planLabel} permite ate ${maxPhotos} fotos.`,
+        description: `Your ${planLabel} plan allows up to ${maxPhotos} photos.`,
         variant: "destructive",
       });
       event.target.value = "";
@@ -457,10 +457,10 @@ export default function PhotoManagerPage() {
       <div className="grid gap-8 lg:grid-cols-[340px_minmax(0,1fr)]">
         <div className="space-y-6">
           <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h2 className="font-display text-lg font-medium text-slate-900">Nova foto</h2>
+            <h2 className="font-display text-lg font-medium text-slate-900">New photo</h2>
             <p className="mt-2 font-sans text-sm text-slate-500">
-              Plano atual: <span className="font-semibold text-slate-900">{planLabel}</span>. Voce
-              pode manter ate <span className="font-semibold text-slate-900">{maxPhotos}</span> fotos.
+              Current plan: <span className="font-semibold text-slate-900">{planLabel}</span>. You
+              can keep up to <span className="font-semibold text-slate-900">{maxPhotos}</span> photos.
             </p>
 
             <button
@@ -498,8 +498,8 @@ export default function PhotoManagerPage() {
                   className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900"
                 />
                 <span className="leading-relaxed">
-                  Confirmo que estas imagens nao contem nudez explicita, logos, dados de contato,
-                  marcas d agua ou elementos enganosos. Tambem concordo com as regras de imagem do{" "}
+                  I confirm these images contain no explicit nudity, logos, contact details,
+                  watermarks or misleading elements. I also agree to the image rules in the{" "}
                   <Link href="/legal" className="font-semibold text-slate-900 underline underline-offset-4">
                     Legal Center
                   </Link>
@@ -550,33 +550,33 @@ export default function PhotoManagerPage() {
                   >
                     <ShieldAlert className="h-4 w-4 text-sky-300" />
                   </motion.div>
-                  Sightengine lendo {scanLabel}
+                  Sightengine reading {scanLabel}
                 </>
               )}
 
               {uploadState === "uploaded" && (
                 <>
                   <Clock className="h-4 w-4" />
-                  Analise concluida
+                  Analysis complete
                 </>
               )}
             </button>
           </section>
 
           <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h2 className="font-display text-lg font-medium text-slate-900">Padrao visual</h2>
+            <h2 className="font-display text-lg font-medium text-slate-900">Visual standard</h2>
             <ul className="mt-4 space-y-4 font-sans text-sm text-slate-600">
               <li className="flex items-start gap-3">
                 <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
-                Use fotos nitidas, recentes e coerentes com seu atendimento real.
+                Use sharp, recent photos that match your real service.
               </li>
               <li className="flex items-start gap-3">
                 <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
-                Inclua pelo menos uma foto de rosto e imagens do espaco de atendimento.
+                Include at least one face photo and images of the service space.
               </li>
               <li className="flex items-start gap-3">
                 <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-rose-600" />
-                Evite qualquer overlay, QR code, telefone, logo ou marca d agua.
+                Avoid any overlay, QR code, phone number, logo or watermark.
               </li>
             </ul>
           </section>
@@ -640,7 +640,7 @@ export default function PhotoManagerPage() {
               <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-6 py-16 text-center">
                 <Camera className="mx-auto h-10 w-10 text-slate-300" />
                 <p className="mt-4 font-sans text-sm text-slate-500">
-                  Nenhuma foto nesta categoria ainda.
+                  No photos in this category yet.
                 </p>
               </div>
             ) : (
@@ -696,7 +696,7 @@ export default function PhotoManagerPage() {
                         <p className="mt-1 font-sans text-xs leading-relaxed text-slate-500">
                           {photo.moderation_reason
                             ? photo.moderation_reason.split("_").join(" ")
-                            : "Sem observacoes da moderacao ate o momento."}
+                            : "No moderation notes yet."}
                         </p>
                       </div>
 


### PR DESCRIPTION
## Summary

Final production go-live audit. The repository was already in strong shape from the prior "FINAL GO LIVE" work — this PR closes the one remaining defect (Portuguese UI copy) and records the full validation results. The result is build-clean, lint-clean, type-safe, test-clean, schema-safe, CI-safe, and deploy-safe.

## Files changed
- `src/app/pro/photos/page.tsx` — translated remaining Portuguese UI copy to English (14 lines).

## What was removed
- Nothing removed. Legacy artifacts (`vite.config.ts`, `index.html`, `package-lock.json`, `public/robots.txt`) were already absent and stay absent. No features, dashboards, or auth systems removed.

## What was fixed
- **English-only compliance:** the pro photos management page still rendered Portuguese strings for the upload panel ("Nova foto" / "Plano atual"), the image-rules consent checkbox, the Sightengine scan/analysis states, the visual-standard tips, the empty-state message, and the moderation-note fallback. All translated to English. No logic changed.

## Verified already-correct (no changes needed)
- **Config:** `.gitattributes` is exactly `* text=auto eol=lf`; `.vscode/extensions.json` recommends only eslint, prettier, tailwindcss; Tailwind content globs exclude `src/mm` and `src/pages`.
- **Auth/OAuth:** `auth/callback/route.ts` syncs the session cookie and redirects new OAuth users to `/pro/onboard`, others to `/pro/dashboard`.
- **Profile status:** `pending_approval` used throughout; no stray `profile_status: "submitted"`.
- **Phone OTP:** no OTP login UI present; phone kept only as an SMS-notification profile field.
- **Stripe:** checkout sends `metadata.user_id`; webhook syncs `subscription_tier`, `_tier`, `photo_limit`, `visibility_level`, `stripe_customer_id`, `stripe_subscription_id`, `current_period_end`; subscription deletion downgrades to `free`.
- **CI:** `.github/workflows/release-checks.yml` runs each validation command as a separate step.

## Schema file to run
`supabase/PRODUCTION_SCHEMA_LOCK.sql` is the source of truth enforced by `pnpm validate:db-contract` (currently passing). No schema change is introduced by this PR.

## Validation results
All run locally on this branch with Node 22 / pnpm 10.32.1:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ clean |
| `git diff --exit-code package.json pnpm-lock.yaml` | ✅ no drift |
| `pnpm lint` | ✅ pass |
| `pnpm typecheck` | ✅ pass |
| `pnpm test` | ✅ 8 API smoke checks pass |
| `pnpm validate:sitemap` | ✅ pass |
| `pnpm validate:db-contract` | ✅ DB contract OK |
| `pnpm release:audit` | ✅ OK |
| `pnpm release:check` + `pnpm build` | ✅ all routes compile |

## Manual smoke test checklist
- [ ] Email login → providers/admins land on `/pro/dashboard`, clients on `/dashboard`.
- [ ] Google OAuth → new user lands on `/pro/onboard`, returning user on `/pro/dashboard`.
- [ ] Signup flow (`/signup` → account → plan → profile → review) reaches `pending_approval`.
- [ ] Pro photos page (`/pro/photos`) — all copy renders in English; upload + consent + moderation states work.
- [ ] Stripe checkout completes and profile reflects new tier, photo limit, visibility, and Stripe IDs.
- [ ] Cancel subscription → profile downgrades to `free`.
- [ ] Forgot/reset password flow.
- [ ] Sitemap and robots resolve at `/sitemap.xml` and `/robots.txt`.

## Risk notes
- **Low risk.** Single file changed, UI copy only — no logic, schema, or dependency changes.
- `.node-version`/`.nvmrc` pin Node 20 while CI uses Node 24 and the build passes on both; aligning these post-launch is a non-blocking follow-up.
- Vercel project `masseurmatch` auto-deploys from `main`; latest production deploy is READY.

https://claude.ai/code/session_01Y7JEzZocXnBeo8RFa68r3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7JEzZocXnBeo8RFa68r3i)_