### PR TITLE
Security audit: patch critical auth gaps, vulnerable deps, and rate limiting

### DIFF
--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,0 +1,111 @@
+# Security Audit — masseurmatch
+
+Date: 2026-06-01
+Scope: full repository (Next.js 15 App Router + Supabase + Stripe).
+Method: empirical validation chain (lint, typecheck, test, db-contract,
+release-audit, build) plus a manual code-level review of auth, middleware,
+API routes, Stripe integration, secret handling, input validation, and
+dependencies.
+
+## Baseline (verified, not assumed)
+
+The full validation chain passes on this branch:
+
+| Check | Result |
+| --- | --- |
+| `pnpm install --frozen-lockfile` | OK (lockfile in sync) |
+| `pnpm lint` | OK |
+| `pnpm typecheck` | OK |
+| `pnpm test` | OK (8 API smoke checks) |
+| `pnpm validate:sitemap` | OK |
+| `pnpm validate:db-contract` | OK |
+| `pnpm release:audit` | OK |
+| `pnpm build` | OK |
+| `pnpm audit --prod` | 0 known vulnerabilities (after fixes below) |
+
+## Fixed in this branch
+
+### 1. CRITICAL — Unauthenticated notification/email/SMS sender
+`src/app/api/notifications/send/route.ts` accepted anonymous `POST` requests
+and used the Supabase service-role client plus Resend (email) and Twilio (SMS)
+to send messages to any `userId`. This enabled notification spoofing, email
+bombing, and SMS toll fraud.
+
+Fix: require an authenticated `mm_session`; re-derive admin status from the
+authoritative `user_roles` table; non-admin callers can only target their own
+`userId`.
+
+### 2. HIGH — Vulnerable dependencies
+`pnpm audit --prod` reported HIGH advisories in production dependencies.
+
+- `next@15.5.15` → bumped to `^15.5.18` (fixes SSRF via WebSocket upgrades,
+  multiple Middleware/Proxy bypasses, and DoS advisories; this app uses
+  middleware, so the proxy-bypass issues were directly relevant).
+- `axios` (transitive via `twilio`) → pinned `>=1.16.0` via `pnpm.overrides`
+  (prototype-pollution / credential-injection advisories).
+- `ws` (transitive via `@supabase/realtime-js`) → pinned `>=8.20.1`
+  (uninitialized memory disclosure).
+- `qs` (transitive via `stripe`, `twilio`) → pinned `>=6.15.2` (DoS).
+
+All bumps stay within the same major version. `pnpm audit --prod` now reports
+no known vulnerabilities.
+
+### 3. HIGH — No rate limiting on authentication endpoints
+`login`, `register`, `forgot-password`, and `resend-confirmation` had no rate
+limiting (the middleware limiter explicitly skips `/api`). Added the existing
+in-memory `assertRateLimit` helper (already used by the contact and pro routes)
+to each, throttling credential guessing and email bombing per client IP.
+
+### 4. LOW — PostgREST filter interpolation hardening
+`getPublicTherapistBySlug` interpolated a user-supplied slug into a PostgREST
+`.or()` expression. Added a `^[a-z0-9-]+$` allowlist (valid for both slugs and
+UUIDs) so filter operators (`,` `.` `)`) cannot be injected.
+
+## Open recommendations (not auto-applied — require deployment context)
+
+These were left for a human to apply because they touch deployment
+configuration or coupled secret-resolution logic, where a blind change could
+cause a production outage.
+
+### A. HIGH — Session-secret resolution fallback
+`src/app/api/_lib/session.ts` and `src/middleware.ts` resolve the HMAC signing
+secret as `MM_SESSION_SECRET || … || SUPABASE_SERVICE_ROLE_KEY`, with a
+hardcoded `'dev-only-…'` constant outside production. Two concerns:
+1. Reusing the service-role key as a signing key couples two distinct secrets.
+2. Any non-`production` deployed environment using the constant fallback lets
+   an attacker forge a cookie with `role:"admin"`.
+
+Recommended: set a dedicated `MM_SESSION_SECRET` in **every** deployed
+environment and drop the service-role-key and constant fallbacks. Not changed
+automatically because production may currently rely on the service-role-key
+fallback, and the secret must match between `session.ts` and `middleware.ts`.
+
+### B. MEDIUM — Middleware authorizes on the cookie `role` claim
+`src/middleware.ts` gates `/pro`, `/client`, `/admin` on the cookie `role`.
+This is safe only while the HMAC secret is strong and unique (see A). Admin
+**pages**/server components should re-check `getUserRole` against `user_roles`
+rather than trusting the cookie alone. (Admin **API** routes already do via
+`requireAdminSession`.)
+
+### C. LOW — Dead component with unsanitized HTML
+`src/components/sections/EnhancedBlog.tsx` renders `post.content` via
+`dangerouslySetInnerHTML`. The component is not imported anywhere, so it is not
+currently exploitable. Delete it or sanitize with the existing `dompurify`
+dependency before wiring it to a live route.
+
+### D. LOW — `admin/run-migrations` HTTP endpoint
+`src/app/api/admin/run-migrations/route.ts` is admin-gated but runs arbitrary
+`.sql` files through an `exec_sql` RPC. Consider running migrations from CI
+only and removing this endpoint from the deployed app to shrink blast radius if
+an admin account is compromised.
+
+## Verified correct (no change needed)
+
+- Stripe webhook (`src/app/api/webhooks/stripe/route.ts`) reads the raw body and
+  verifies the signature with `STRIPE_WEBHOOK_SECRET`.
+- Stripe payment-intent/refund/identity routes derive the user from the
+  server-side session and never trust a client-supplied `user_id`.
+- Service-role key is never imported into client components or exposed via
+  `NEXT_PUBLIC_`; no hardcoded secrets in `src`.
+- OAuth callback validates the `next` redirect (`/`-prefixed, not `//`).
+- Security headers and a CSP are configured in `next.config.mjs`.

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -67,18 +67,22 @@ These were left for a human to apply because they touch deployment
 configuration or coupled secret-resolution logic, where a blind change could
 cause a production outage.
 
-### A. HIGH — Session-secret resolution fallback
+### A. HIGH — Session-secret resolution fallback (partially fixed)
 `src/app/api/_lib/session.ts` and `src/middleware.ts` resolve the HMAC signing
 secret as `MM_SESSION_SECRET || … || SUPABASE_SERVICE_ROLE_KEY`, with a
-hardcoded `'dev-only-…'` constant outside production. Two concerns:
-1. Reusing the service-role key as a signing key couples two distinct secrets.
-2. Any non-`production` deployed environment using the constant fallback lets
-   an attacker forge a cookie with `role:"admin"`.
+hardcoded `'dev-only-…'` constant.
 
-Recommended: set a dedicated `MM_SESSION_SECRET` in **every** deployed
-environment and drop the service-role-key and constant fallbacks. Not changed
-automatically because production may currently rely on the service-role-key
-fallback, and the secret must match between `session.ts` and `middleware.ts`.
+Fixed: the constant fallback is now restricted to `NODE_ENV` of `development`
+or `test`. Any deployed environment (production, preview, staging) without a
+real secret now throws instead of silently signing with a forgeable constant.
+The resolution order is otherwise unchanged, so existing deployments keep the
+same secret (no forced logouts).
+
+Still recommended: set a dedicated `MM_SESSION_SECRET` in **every** deployed
+environment and drop the `SUPABASE_SERVICE_ROLE_KEY` fallback so the signing
+key is decoupled from the database key. Not done automatically because
+production may currently rely on that fallback (removing it without first
+setting `MM_SESSION_SECRET` would invalidate all live sessions).
 
 ### B. MEDIUM — Middleware authorizes on the cookie `role` claim
 `src/middleware.ts` gates `/pro`, `/client`, `/admin` on the cookie `role`.

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "jose": "^6.2.1",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.577.0",
-    "next": "^15.5.15",
+    "next": "^15.5.18",
     "next-themes": "^0.3.0",
     "postgres": "^3.4.8",
     "react": "^18.3.1",
@@ -143,7 +143,10 @@
       "picomatch@<2.3.2": "2.3.2",
       "picomatch@>=4.0.0 <4.0.4": "4.0.4",
       "postcss@<8.5.10": "8.5.10",
-      "uuid@<14.0.0": "14.0.0"
+      "uuid@<14.0.0": "14.0.0",
+      "axios@<1.16.0": "1.16.0",
+      "ws@<8.20.1": "8.20.1",
+      "qs@<6.15.2": "6.15.2"
     }
   },
   "description": "MasseurMatch is a directory platform for independent massage therapists. Visitors browse city pages, compare therapist profiles, read editorial content, and contact providers directly. The platform does not process appointments or visitor logins.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   postcss@<8.5.10: 8.5.10
   uuid@<14.0.0: 14.0.0
+  axios@<1.16.0: 1.16.0
+  ws@<8.20.1: 8.20.1
+  qs@<6.15.2: 6.15.2
 
 importers:
 
@@ -131,10 +134,10 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.1(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.0(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -178,8 +181,8 @@ importers:
         specifier: ^0.577.0
         version: 0.577.0(react@18.3.1)
       next:
-        specifier: ^15.5.15
-        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^15.5.18
+        version: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -920,60 +923,60 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.5.15':
-    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+  '@next/env@15.5.18':
+    resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
 
   '@next/eslint-plugin-next@15.5.15':
     resolution: {integrity: sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==}
 
-  '@next/swc-darwin-arm64@15.5.15':
-    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+  '@next/swc-darwin-arm64@15.5.18':
+    resolution: {integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.15':
-    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+  '@next/swc-darwin-x64@15.5.18':
+    resolution: {integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
-    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+  '@next/swc-linux-arm64-gnu@15.5.18':
+    resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.5.15':
-    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+  '@next/swc-linux-arm64-musl@15.5.18':
+    resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.5.15':
-    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+  '@next/swc-linux-x64-gnu@15.5.18':
+    resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.5.15':
-    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+  '@next/swc-linux-x64-musl@15.5.18':
+    resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
-    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+  '@next/swc-win32-arm64-msvc@15.5.18':
+    resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.15':
-    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+  '@next/swc-win32-x64-msvc@15.5.18':
+    resolution: {integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2356,8 +2359,8 @@ packages:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3718,8 +3721,8 @@ packages:
       react: ^16.8 || ^17 || ^18
       react-dom: ^16.8 || ^17 || ^18
 
-  next@15.5.15:
-    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
+  next@15.5.18:
+    resolution: {integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -3991,8 +3994,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -4673,20 +4676,8 @@ packages:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5153,34 +5144,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.15': {}
+  '@next/env@15.5.18': {}
 
   '@next/eslint-plugin-next@15.5.15':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.5.15':
+  '@next/swc-darwin-arm64@15.5.18':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.15':
+  '@next/swc-darwin-x64@15.5.18':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
+  '@next/swc-linux-arm64-gnu@15.5.18':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.15':
+  '@next/swc-linux-arm64-musl@15.5.18':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.15':
+  '@next/swc-linux-x64-gnu@15.5.18':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.15':
+  '@next/swc-linux-x64-musl@15.5.18':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
+  '@next/swc-win32-arm64-msvc@15.5.18':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.15':
+  '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6084,7 +6075,7 @@ snapshots:
       '@supabase/phoenix': 0.4.1
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6372,14 +6363,14 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@2.0.1(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  '@vercel/speed-insights@2.0.0(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/speed-insights@2.0.0(next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   accepts@1.3.8:
@@ -6535,7 +6526,7 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -6925,7 +6916,7 @@ snapshots:
       cors: 2.8.6
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7377,7 +7368,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
@@ -8174,9 +8165,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 15.5.15
+      '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001791
       postcss: 8.5.10
@@ -8184,14 +8175,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.15
-      '@next/swc-darwin-x64': 15.5.15
-      '@next/swc-linux-arm64-gnu': 15.5.15
-      '@next/swc-linux-arm64-musl': 15.5.15
-      '@next/swc-linux-x64-gnu': 15.5.15
-      '@next/swc-linux-x64-musl': 15.5.15
-      '@next/swc-win32-arm64-msvc': 15.5.15
-      '@next/swc-win32-x64-msvc': 15.5.15
+      '@next/swc-darwin-arm64': 15.5.18
+      '@next/swc-darwin-x64': 15.5.18
+      '@next/swc-linux-arm64-gnu': 15.5.18
+      '@next/swc-linux-arm64-musl': 15.5.18
+      '@next/swc-linux-x64-gnu': 15.5.18
+      '@next/swc-linux-x64-musl': 15.5.18
+      '@next/swc-win32-arm64-msvc': 15.5.18
+      '@next/swc-win32-x64-msvc': 15.5.18
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.58.2
       sharp: 0.34.5
@@ -8445,7 +8436,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -8825,7 +8816,7 @@ snapshots:
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
-      ws: 8.18.3
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8946,7 +8937,7 @@ snapshots:
 
   stripe@18.5.0(@types/node@22.19.15):
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.2
     optionalDependencies:
       '@types/node': 22.19.15
 
@@ -9106,11 +9097,11 @@ snapshots:
 
   twilio@5.13.1:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       dayjs: 1.11.20
       https-proxy-agent: 5.0.1
       jsonwebtoken: 9.0.3
-      qs: 6.15.0
+      qs: 6.15.2
       scmp: 2.1.0
       xmlbuilder: 13.0.2
     transitivePeerDependencies:
@@ -9369,9 +9360,7 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
-  ws@8.18.3: {}
-
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   xmlbuilder@13.0.2: {}
 

--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -267,6 +267,14 @@ export const getPublicTherapists = async (filters?: {
 
 export const getPublicTherapistBySlug = async (slug: string): Promise<PublicTherapist | null> => {
   const sanitizedSlug = slug.trim();
+
+  // Reject anything that is not a plain slug or UUID before interpolating into
+  // the PostgREST `.or()` filter, so characters like "," "." or ")" cannot
+  // break out of the intended expression and alter the matching logic.
+  if (!/^[a-z0-9-]+$/i.test(sanitizedSlug)) {
+    return null;
+  }
+
   const { data: profile, error } = await buildPublicTherapistsQuery()
     .or(`slug.eq.${sanitizedSlug},id.eq.${sanitizedSlug}`)
     .maybeSingle();

--- a/src/app/api/_lib/session.ts
+++ b/src/app/api/_lib/session.ts
@@ -23,10 +23,15 @@ function sessionSecret(): string {
     "SUPABASE_SERVICE_ROLE_KEY",
   ]);
   if (secret) return secret;
-  if (process.env.NODE_ENV === "production") {
-    throw new Error("MM_SESSION_SECRET is required in production. Set it in your environment variables.");
+  // Only fall back to a constant for genuine local development/testing. Any
+  // deployed environment (production, preview, staging) must provide a real
+  // secret so an attacker cannot forge a signed admin cookie.
+  if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
+    return "dev-only-masseurmatch-session-secret";
   }
-  return "dev-only-masseurmatch-session-secret";
+  throw new Error(
+    "MM_SESSION_SECRET is required outside local development. Set it in your environment variables.",
+  );
 }
 
 function encodeBase64Url(value: string): string {

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,11 +1,14 @@
 import { errorResponse, json, parseJsonBody } from "@/app/api/_lib/http";
 import { createSupabasePublicClient } from "@/app/api/_lib/supabase-server";
+import { assertRateLimit } from "@/app/_lib/security";
 import { forgotPasswordSchema } from "@/app/_lib/validation";
 
 const DEFAULT_RESET_PATH = "/reset-password";
 
 export async function POST(request: Request) {
   try {
+    // Prevent password-reset email bombing per IP.
+    assertRateLimit(request, "auth-forgot-password", { limit: 5, windowMs: 60_000 });
     const body = await parseJsonBody(request, forgotPasswordSchema);
     try {
       const supabase = createSupabasePublicClient();

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { errorResponse, json, parseJsonBody, withSetCookie } from "@/app/api/_lib/http";
 import { setSessionCookie } from "@/app/api/_lib/session";
+import { assertRateLimit } from "@/app/_lib/security";
 import { authLoginSchema } from "@/app/_lib/validation";
 import {
   ensureUserProfileAndRole,
@@ -8,6 +9,8 @@ import {
 
 export async function POST(request: Request) {
   try {
+    // Throttle credential guessing on a per-IP basis.
+    assertRateLimit(request, "auth-login", { limit: 10, windowMs: 60_000 });
     const body = await parseJsonBody(request, authLoginSchema);
     const { user, session } = await verifyPasswordWithRetry(body.email, body.password, 5);
     const { role } = await ensureUserProfileAndRole(user, {

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,7 @@
 import { errorResponse, json, parseJsonBody, withSetCookie } from "@/app/api/_lib/http";
 import { setSessionCookie } from "@/app/api/_lib/session";
 import { RouteError } from "@/app/api/_lib/http";
+import { assertRateLimit } from "@/app/_lib/security";
 import { authRegisterSchema } from "@/app/_lib/validation";
 import {
   createTherapistUser,
@@ -9,6 +10,8 @@ import {
 
 export async function POST(request: Request) {
   try {
+    // Limit automated account creation per IP.
+    assertRateLimit(request, "auth-register", { limit: 5, windowMs: 60_000 });
     const body = await parseJsonBody(request, authRegisterSchema);
     const { origin } = new URL(request.url);
     const result = await createTherapistUser({

--- a/src/app/api/auth/resend-confirmation/route.ts
+++ b/src/app/api/auth/resend-confirmation/route.ts
@@ -1,11 +1,14 @@
 import { errorResponse, json, parseJsonBody } from "@/app/api/_lib/http";
 import { createSupabasePublicClient } from "@/app/api/_lib/supabase-server";
+import { assertRateLimit } from "@/app/_lib/security";
 import { z } from "zod";
 
 const resendSchema = z.object({ email: z.string().email() });
 
 export async function POST(request: Request) {
   try {
+    // Prevent confirmation email bombing per IP.
+    assertRateLimit(request, "auth-resend-confirmation", { limit: 5, windowMs: 60_000 });
     const { email } = await parseJsonBody(request, resendSchema);
     const { origin } = new URL(request.url);
     const client = createSupabasePublicClient();

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+import { createSupabaseAdminClient, getUserRole } from "@/app/api/_lib/supabase-server";
+import { getRequestSession } from "@/app/api/_lib/session";
 import type { Json } from "@/integrations/supabase/types";
 import { Resend } from "resend";
 import twilio from "twilio";
@@ -26,6 +27,29 @@ export async function POST(request: NextRequest) {
 
     if (!body.userId || !body.type || !body.title) {
       return NextResponse.json({ error: "userId, type and title are required" }, { status: 400 });
+    }
+
+    // This route uses the Supabase service-role client plus the Resend and
+    // Twilio senders, so it must never be reachable anonymously. Require an
+    // authenticated session and restrict non-admins to their own account to
+    // prevent notification spoofing, email bombing, and SMS toll fraud.
+    const session = getRequestSession(request);
+    if (!session) {
+      return NextResponse.json({ error: "Authentication required." }, { status: 401 });
+    }
+
+    let isAdmin = session.role === "admin";
+    try {
+      isAdmin = (await getUserRole(session.userId)) === "admin";
+    } catch {
+      // Fall back to the signed cookie role if the authoritative lookup fails.
+    }
+
+    if (!isAdmin && body.userId !== session.userId) {
+      return NextResponse.json(
+        { error: "You can only send notifications to your own account." },
+        { status: 403 },
+      );
     }
 
     const supabase = createSupabaseAdminClient();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,10 +29,13 @@ function getSessionSecret(): string {
     process.env.JWT_SECRET ??
     process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (secret) return secret;
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('MM_SESSION_SECRET is required in production.');
+  // Only fall back to a constant for genuine local development/testing. Any
+  // deployed environment (production, preview, staging) must provide a real
+  // secret so an attacker cannot forge a signed admin cookie.
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+    return 'dev-only-masseurmatch-session-secret';
   }
-  return 'dev-only-masseurmatch-session-secret';
+  throw new Error('MM_SESSION_SECRET is required outside local development.');
 }
 
 function toBase64Url(bytes: Uint8Array): string {


### PR DESCRIPTION
## Summary

A full-repository security audit of the masseurmatch app (Next.js 15 App Router + Supabase + Stripe). The baseline validation chain was already green; this PR fixes the genuine vulnerabilities found, all verified empirically. Full details in `docs/SECURITY_AUDIT.md`.

## What was fixed

| Severity | Fix |
| --- | --- |
| **CRITICAL** | `POST /api/notifications/send` was fully unauthenticated while running the Supabase service-role client + Resend + Twilio — anyone could spoof notifications, bomb emails, or run up SMS charges. Now requires an authenticated session; admin is re-derived from the authoritative `user_roles` table; non-admins may only target their own `userId`. |
| **HIGH** | Patched vulnerable production dependencies: `next 15.5.15 → ^15.5.18` (SSRF via WebSocket upgrades, multiple Middleware/Proxy bypasses, DoS — this app uses middleware), plus `pnpm.overrides` for `axios >=1.16.0`, `ws >=8.20.1`, `qs >=6.15.2`. `pnpm audit --prod` now reports **0 known vulnerabilities** (was 14 high + 15 moderate). All same-major bumps. |
| **HIGH** | Added per-IP rate limiting (`assertRateLimit`) to `login`, `register`, `forgot-password`, and `resend-confirmation`, which previously had none (the middleware limiter skips `/api`). Throttles credential guessing and email bombing. |
| **HIGH** | Restricted the hardcoded `dev-only` session-secret fallback to `NODE_ENV` of `development`/`test`. Deployed environments (production/preview/staging) without a real secret now throw instead of silently signing `mm_session` with a forgeable constant. Resolution order is unchanged, so live deployments keep the same secret (no forced logouts). |
| **LOW** | Hardened `getPublicTherapistBySlug` with a `^[a-z0-9-]+$` allowlist so user input cannot inject PostgREST `.or()` filter operators. |

## Files changed

- `package.json`, `pnpm-lock.yaml` — dependency bumps + overrides (lockfile kept in sync)
- `src/app/api/notifications/send/route.ts` — authentication gate
- `src/app/api/auth/{login,register,forgot-password,resend-confirmation}/route.ts` — rate limiting
- `src/app/api/_lib/session.ts`, `src/middleware.ts` — session-secret fallback hardening
- `src/app/_lib/directory.ts` — slug filter hardening
- `docs/SECURITY_AUDIT.md` — full findings, fixes, and open recommendations

## Validation results

All run locally and passing:

- `pnpm install --frozen-lockfile` — OK (lockfile in sync)
- `pnpm lint` — OK
- `pnpm typecheck` — OK
- `pnpm test` — OK (8 API smoke checks)
- `pnpm validate:db-contract` — OK
- `pnpm release:audit` — OK
- `pnpm build` — OK
- `pnpm audit --prod` — 0 known vulnerabilities

## Open recommendations (not auto-applied — need deployment context)

Documented in `docs/SECURITY_AUDIT.md`:

- **HIGH** — Set a dedicated `MM_SESSION_SECRET` in every deployed environment and drop the `SUPABASE_SERVICE_ROLE_KEY` signing fallback (not removed automatically because prod may currently rely on it; removing it before setting `MM_SESSION_SECRET` would invalidate all live sessions).
- **MEDIUM** — Admin **page** routes should re-check `getUserRole` rather than trusting the cookie `role` (admin API routes already do).
- **LOW** — Remove/sanitize the dead `EnhancedBlog.tsx` (`dangerouslySetInnerHTML`); consider removing the `admin/run-migrations` arbitrary-SQL endpoint from the deployed app.

## Manual smoke test checklist

- [ ] `POST /api/notifications/send` without a session → 401
- [ ] Non-admin session sending to another user's `userId` → 403
- [ ] Admin can still send to any user
- [ ] Login / register / forgot-password / resend still work normally; repeated rapid calls return 429
- [ ] Google OAuth login + email/password login still set `mm_session` and reach `/pro/*`
- [ ] Set `MM_SESSION_SECRET` in deployed env before/with merge if not already present

## Risk notes

- Dependency bumps are all same-major; build + typecheck + tests pass.
- Session-secret change preserves the existing resolution order, so no live sessions are invalidated.
- Rate-limit store is in-memory (per instance) — best-effort under serverless; consider the existing Upstash distributed limiter later for stronger guarantees.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6bemjNqJ62yBUZcjykg3r)_