### PR TITLE
fix(build): import Check icon in WhyUsSplit to unblock main build

### DIFF
--- a/src/components/marketing/WhyUsSplit.tsx
+++ b/src/components/marketing/WhyUsSplit.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { ShieldCheck } from "lucide-react";
+import { Check, ShieldCheck } from "lucide-react";
 import FadeUp from "@/components/motion/FadeUp";
 
 const TRUST_POINTS = [


### PR DESCRIPTION
## Summary

Fixes the broken production build on `main`. Commit `e240cb5` (merge of `claude/repo-launch-readiness-KqLDX`) left `WhyUsSplit.tsx` importing only `ShieldCheck` from `lucide-react` while the trust-points list renders a `Check` icon, producing:

```
./src/components/marketing/WhyUsSplit.tsx:70:24
Type error: Cannot find name 'Check'.
```

The Next.js build worker exits on this, so the entire build fails.

## Fix

```diff
-import { ShieldCheck } from "lucide-react";
+import { Check, ShieldCheck } from "lucide-react";
```

Both icons are used in the component (the `Check` icon in the trust list, `ShieldCheck` in the verification badge).

## Validation

Ran on this branch against the full `main` tree:
- `pnpm typecheck` — OK
- `pnpm build` — OK (this was the only error; the rest of `main` compiles clean)

## Notes

- One-line, low-risk; no behavior change beyond making the existing markup compile.
- Independent of the open security (#406) and palette (#407) PRs.
