### PR TITLE
FINAL GO LIVE: Stripe webhook period sync + CI build fix

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -32,8 +32,15 @@ const VISIBILITY_LEVELS: Record<string, number> = {
   elite: 4,
 }
 
+// Resolve the current billing period end. Under the Stripe "Basil" API version
+// this lives on the subscription items, not on the subscription itself.
+function getCurrentPeriodEnd(sub: Stripe.Subscription): string | null {
+  const periodEnd = sub.items?.data?.[0]?.current_period_end
+  return typeof periodEnd === 'number' ? new Date(periodEnd * 1000).toISOString() : null
+}
+
 // Build the profile update payload for a subscription sync.
-function buildTierUpdate(tier: string, sub: { id: string; customer?: string | Stripe.Customer | Stripe.DeletedCustomer | null }) {
+function buildTierUpdate(tier: string, sub: Stripe.Subscription) {
   const customerId =
     typeof sub.customer === 'string' ? sub.customer : (sub.customer as Stripe.Customer | null)?.id ?? null
 
@@ -44,6 +51,7 @@ function buildTierUpdate(tier: string, sub: { id: string; customer?: string | St
     visibility_level: VISIBILITY_LEVELS[tier] ?? 1,
     stripe_customer_id: customerId,
     stripe_subscription_id: sub.id,
+    current_period_end: getCurrentPeriodEnd(sub),
     updated_at: new Date().toISOString(),
   }
 }
@@ -121,21 +129,11 @@ export async function POST(request: NextRequest) {
       if (!subscriptionId || !userId) break
 
       const tier = planKeyToTier(planKey)
-      const customerId =
-        typeof session.customer === 'string' ? session.customer : (session.customer as Stripe.Customer | null)?.id ?? null
+      // Retrieve the subscription so we capture the billing period end alongside
+      // the tier on the initial purchase.
+      const sub = await stripe.subscriptions.retrieve(subscriptionId)
 
-      await supabase
-        .from('profiles')
-        .update({
-          subscription_tier: tier,
-          _tier: tier,
-          photo_limit: PHOTO_LIMITS[tier] ?? 2,
-          visibility_level: VISIBILITY_LEVELS[tier] ?? 1,
-          stripe_customer_id: customerId,
-          stripe_subscription_id: subscriptionId,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('user_id', userId)
+      await supabase.from('profiles').update(buildTierUpdate(tier, sub)).eq('user_id', userId)
 
       break
     }


### PR DESCRIPTION
## Summary

Final production go-live audit across Stripe end-to-end, auth/onboarding, DB schema lock, and env/secrets + CI. Most launch-readiness work was already present on this branch, so each area was **verified** rather than re-applied. Two concrete defects were fixed.

## Files changed
- `src/app/api/webhooks/stripe/route.ts` — write `current_period_end` on subscription sync.
- `src/components/marketing/WhyUsSplit.tsx` — import the missing `Check` icon.

## What was fixed
- **Stripe webhook `current_period_end`** — the field was never persisted. Under the Stripe Basil API version (`2025-08-27.basil`) it moved from the subscription to its items, which is why it had been dropped. Added a `getCurrentPeriodEnd()` helper reading `sub.items.data[0].current_period_end`, folded it into `buildTierUpdate`, and refactored `checkout.session.completed` to retrieve the subscription so the period end is also captured on the initial purchase. The profile billing period now stays in sync across purchase, plan change, and cancellation downgrade.
- **Typecheck/CI build break** — `WhyUsSplit.tsx` used `<Check>` without importing it (`TS2304`), which would fail `pnpm typecheck` / `pnpm build` in the release workflow. Imported it from `lucide-react`.

## What was verified (no change needed)
- **Stripe checkout** (`supabase/functions/create-checkout/index.ts`) sets `session.metadata.user_id`/`plan_key` and `subscription_data.metadata.{masseurmatch_plan,user_id}`.
- **Webhook** writes `subscription_tier`, `_tier`, `photo_limit`, `visibility_level`, `stripe_customer_id`, `stripe_subscription_id` (and now `current_period_end`); `customer.subscription.deleted` downgrades to `free`.
- **Missing price IDs fail the release audit** — `release-audit.mjs` requires `STRIPE_PRICE_STANDARD/PRO/ELITE` in `.env.example`.
- **Auth/onboarding** — Google OAuth → `/auth/callback?next=…` → syncs the `mm_session` cookie → redirects new profiles to `/pro/onboard`, returning users to `/pro/dashboard`.
- **`submitted`** remains only as a `SubmissionStatus` review-workflow union member, not a `profile_status` literal.
- **DB schema lock** — `validate:db-contract` passes; `profiles.current_period_end` is already in `PRODUCTION_SCHEMA_LOCK.sql` and the required-columns list, so the new write is covered.
- **CI** — `.github/workflows/release-checks.yml` gates PRs to `main` and runs install / lockfile diff / lint / typecheck / test / validate:sitemap / validate:db-contract / release:audit / release:check / build as separate steps.

## Schema file to run
No schema migration required — `supabase/PRODUCTION_SCHEMA_LOCK.sql` already defines `profiles.current_period_end timestamptz`.

## Validation results (local)
- `pnpm validate:db-contract` ✓ (`DB contract OK`)
- `pnpm validate:sitemap` ✓
- `pnpm release:audit` ✓ (`[release-audit] OK`)
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (8 API smoke checks)
- `pnpm build` ✓
- `git diff --exit-code package.json pnpm-lock.yaml` ✓ (clean — no dependency changes)

## Manual smoke test checklist
- [ ] Google OAuth sign-up → lands on `/pro/onboard`; `mm_session` cookie set.
- [ ] Google OAuth sign-in (existing profile) → lands on `/pro/dashboard`.
- [ ] Complete a paid checkout → profile shows correct `subscription_tier`, `photo_limit`, `visibility_level`, and a non-null `current_period_end`.
- [ ] Change plan in Stripe → tier and `current_period_end` re-sync.
- [ ] Cancel subscription → profile downgrades to `free`.
- [ ] Confirm `MM_SESSION_SECRET` and `STRIPE_PRICE_*` are set in the Vercel production environment.

## Risk notes
- Low risk: changes are confined to the Stripe webhook tier-sync path and one missing icon import; no schema, dependency, lockfile, or auth-flow changes.
- `checkout.session.completed` now makes one extra Stripe API call (`subscriptions.retrieve`) to capture the period end. The `customer.subscription.created/updated` events already carry the full subscription, so they incur no extra call.

https://claude.ai/code/session_01HYVaMsv8H91o5yKLdRhSxD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYVaMsv8H91o5yKLdRhSxD)_