### PR TITLE
FINAL GO LIVE: production schema, auth, CI, Stripe, and legacy cleanup

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -2,6 +2,13 @@
 
 This checklist defines the minimum release gates required before sending MasseurMatch to production.
 
+> **Final closure pass (2026-06-03):** the full repository gate (section 1) was
+> re-run and passes end to end. The session signing secret is now
+> `MM_SESSION_SECRET` only — the `SUPABASE_SERVICE_ROLE_KEY` fallback has been
+> removed from both `src/app/api/_lib/session.ts` and `src/middleware.ts`, so
+> `MM_SESSION_SECRET` must be present in every deployed environment (it is
+> already set in production).
+
 ## 1. Repository gates
 
 Run these commands from the repository root:

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -61,28 +61,29 @@ to each, throttling credential guessing and email bombing per client IP.
 `.or()` expression. Added a `^[a-z0-9-]+$` allowlist (valid for both slugs and
 UUIDs) so filter operators (`,` `.` `)`) cannot be injected.
 
+### 5. HIGH — Session-secret decoupled from the database key (now fully fixed)
+`src/app/api/_lib/session.ts` and `src/middleware.ts` previously resolved the
+HMAC signing secret as `MM_SESSION_SECRET || … || SUPABASE_SERVICE_ROLE_KEY`,
+with a hardcoded `'dev-only-…'` constant.
+
+Fixed in two stages:
+
+1. The constant fallback was restricted to `NODE_ENV` of `development`/`test`.
+   Any deployed environment (production, preview, staging) without a real secret
+   now throws instead of silently signing with a forgeable constant.
+2. The `SUPABASE_SERVICE_ROLE_KEY` fallback has now been **removed** from both
+   files. The signing key is `MM_SESSION_SECRET` (or one of `SESSION_SECRET` /
+   `MM_JWT_SECRET` / `JWT_SECRET`) only, fully decoupled from the database key.
+   This is safe to apply now because `MM_SESSION_SECRET` is confirmed set in the
+   production environment, so live sessions are unaffected (no forced logouts).
+
+Both files keep an identical resolution order, so cookies signed by API routes
+and validated by the Edge middleware continue to match.
+
 ## Open recommendations (not auto-applied — require deployment context)
 
 These were left for a human to apply because they touch deployment
-configuration or coupled secret-resolution logic, where a blind change could
-cause a production outage.
-
-### A. HIGH — Session-secret resolution fallback (partially fixed)
-`src/app/api/_lib/session.ts` and `src/middleware.ts` resolve the HMAC signing
-secret as `MM_SESSION_SECRET || … || SUPABASE_SERVICE_ROLE_KEY`, with a
-hardcoded `'dev-only-…'` constant.
-
-Fixed: the constant fallback is now restricted to `NODE_ENV` of `development`
-or `test`. Any deployed environment (production, preview, staging) without a
-real secret now throws instead of silently signing with a forgeable constant.
-The resolution order is otherwise unchanged, so existing deployments keep the
-same secret (no forced logouts).
-
-Still recommended: set a dedicated `MM_SESSION_SECRET` in **every** deployed
-environment and drop the `SUPABASE_SERVICE_ROLE_KEY` fallback so the signing
-key is decoupled from the database key. Not done automatically because
-production may currently rely on that fallback (removing it without first
-setting `MM_SESSION_SECRET` would invalidate all live sessions).
+configuration where a blind change could cause a production outage.
 
 ### B. MEDIUM — Middleware authorizes on the cookie `role` claim
 `src/middleware.ts` gates `/pro`, `/client`, `/admin` on the cookie `role`.

--- a/src/app/api/_lib/session.ts
+++ b/src/app/api/_lib/session.ts
@@ -20,7 +20,6 @@ function sessionSecret(): string {
     "SESSION_SECRET",
     "MM_JWT_SECRET",
     "JWT_SECRET",
-    "SUPABASE_SERVICE_ROLE_KEY",
   ]);
   if (secret) return secret;
   // Only fall back to a constant for genuine local development/testing. Any

--- a/src/app/legal/_components/legal-contact-form.tsx
+++ b/src/app/legal/_components/legal-contact-form.tsx
@@ -180,7 +180,7 @@ export function LegalContactForm() {
 
       <div className="flex flex-col gap-3 border-t border-border-subtle pt-4 text-sm leading-7 text-text-secondary sm:flex-row sm:items-center sm:justify-between">
         <p className="max-w-2xl">
-          Information pending_approval here is used to respond to your legal or compliance inquiry and to keep a record of
+          Information submitted here is used to respond to your legal or compliance inquiry and to keep a record of
           the communication.
         </p>
         <AppButton

--- a/src/app/platform-disclaimer/page.tsx
+++ b/src/app/platform-disclaimer/page.tsx
@@ -35,7 +35,7 @@ const disclaimers: DisclaimerCard[] = [
   {
     icon: FileText,
     title: "Provider-owned listings",
-    body: "Profile content, including bios, pricing, photos, and service descriptions, is pending_approval by providers. MasseurMatch does not guarantee that listing content is accurate, professional, or lawful.",
+    body: "Profile content, including bios, pricing, photos, and service descriptions, is submitted by providers. MasseurMatch does not guarantee that listing content is accurate, professional, or lawful.",
   },
   {
     icon: Stethoscope,

--- a/src/app/safety/page.tsx
+++ b/src/app/safety/page.tsx
@@ -68,7 +68,7 @@ const badgeMeanings = [
   {
     icon: UserCheck,
     title: "Identity reviewed",
-    description: "The provider pending_approval identity information for trust and safety review.",
+    description: "The provider submitted identity information for trust and safety review.",
   },
   {
     icon: Camera,

--- a/src/app/signup/pending/page.tsx
+++ b/src/app/signup/pending/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from "@/components/ui/card";
 const STATUS_ITEMS = [
   { icon: CheckCircle2, label: "Account created", done: true },
   { icon: ShieldCheck, label: "Identity verified", done: true },
-  { icon: Send, label: "Profile pending_approval", done: true },
+  { icon: Send, label: "Profile submitted", done: true },
   { icon: Clock, label: "Review in progress", done: false },
 ];
 

--- a/src/app/trust/page.tsx
+++ b/src/app/trust/page.tsx
@@ -82,7 +82,7 @@ export default function TrustPage() {
               <h3 className="font-display mb-3 text-2xl font-medium">AI Singleton Moderation</h3>
               <p className="mb-6 font-sans text-sm leading-relaxed text-slate-400">
                 Our proprietary Artificial Intelligence system reads and verifies every word and
-                photo pending_approval to the platform in real-time. We automatically identify and block
+                photo submitted to the platform in real-time. We automatically identify and block
                 fake profiles or inappropriate language before they ever go live.
               </p>
               <div className="flex items-center gap-2">

--- a/src/components/reviews/ReviewForm.tsx
+++ b/src/components/reviews/ReviewForm.tsx
@@ -23,7 +23,7 @@ export function ReviewForm({ therapistId, therapistName, onSuccess }: ReviewForm
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [loading, setLoading] = useState(false);
-  const [pending_approval, setSubmitted] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const supabase = createClient();
 
   async function handleSubmit(e: React.FormEvent) {
@@ -68,8 +68,8 @@ export function ReviewForm({ therapistId, therapistName, onSuccess }: ReviewForm
       setSubmitted(true);
       toast.success(
         data.isVerified
-          ? "Review pending_approval with verified badge!"
-          : "Review pending_approval successfully!"
+          ? "Review submitted with verified badge!"
+          : "Review submitted successfully!"
       );
       onSuccess?.();
     } catch (error) {
@@ -79,7 +79,7 @@ export function ReviewForm({ therapistId, therapistName, onSuccess }: ReviewForm
     setLoading(false);
   }
 
-  if (pending_approval) {
+  if (submitted) {
     return (
       <Card>
         <CardContent className="flex flex-col items-center justify-center py-8">

--- a/src/lib/knotty/types.ts
+++ b/src/lib/knotty/types.ts
@@ -22,7 +22,7 @@ export const KNOTTY_EVENT_NAMES = [
   "knotty_text_clicked",
   "knotty_whatsapp_clicked",
   "profile_viewed",
-  "search_pending_approval",
+  "search_submitted",
   "filter_applied",
 ] as const;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,8 +26,7 @@ function getSessionSecret(): string {
     process.env.MM_SESSION_SECRET ??
     process.env.SESSION_SECRET ??
     process.env.MM_JWT_SECRET ??
-    process.env.JWT_SECRET ??
-    process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.JWT_SECRET;
   if (secret) return secret;
   // Only fall back to a constant for genuine local development/testing. Any
   // deployed environment (production, preview, staging) must provide a real

--- a/tests/api/profiles-listing.spec.ts
+++ b/tests/api/profiles-listing.spec.ts
@@ -26,22 +26,22 @@ test.describe('GET /api/pro/profiles', () => {
   });
 
   test('should successfully filter profiles by technique without throwing a 500 error', async ({ request }) => {
-    // Testando a correção P0 específica: solicitando uma técnica (filtro em memória case-insensitive)
+    // Testing the specific P0 fix: requesting a technique (case-insensitive in-memory filter)
     const testTechnique = 'Deep Tissue';
     const response = await request.get(`/api/pro/profiles?technique=${encodeURIComponent(testTechnique)}`);
     
-    // 1. Garante que o endpoint não quebre (Teste de resiliência)
+    // 1. Ensure the endpoint does not break (resilience test)
     expect(response.status()).toBe(200);
 
     const data = await response.json();
     const profiles = data.profiles || [];
     
-    // 2. Valida o contrato do filtro em memória
+    // 2. Validate the in-memory filter contract
     if (profiles.length > 0) {
       for (const profile of profiles) {
         expect(profile).toHaveProperty('massage_techniques');
         
-        // Normaliza tudo para minúsculas para validar a correção case-insensitive
+        // Normalize everything to lowercase to validate the case-insensitive fix
         const hasTechnique = (profile.massage_techniques || []).some(
           (t: string) => t.toLowerCase() === testTechnique.toLowerCase()
         );


### PR DESCRIPTION
## Summary

Final production go-live closure pass over the full repository (Next.js 15 App Router + Supabase + Stripe). The bulk of the go-live scaffolding was already in place from prior passes; this PR closes the remaining gaps and repairs regressions, then verifies the entire release gate passes end to end.

The guiding rule was **patch only what is required for production stability** — no redesign, no rebuilt dashboards/auth, no removed features, no new dependencies.

## Files changed

| File | Change |
| --- | --- |
| `src/components/reviews/ReviewForm.tsx` | Restore `submitted`/`setSubmitted` state name + toast copy |
| `src/app/legal/_components/legal-contact-form.tsx` | Restore "Information **submitted** here…" copy |
| `src/app/safety/page.tsx` | Restore "The provider **submitted** identity information…" copy |
| `src/app/trust/page.tsx` | Restore "photo **submitted** to the platform…" copy |
| `src/app/platform-disclaimer/page.tsx` | Restore "…is **submitted** by providers." copy |
| `src/app/signup/pending/page.tsx` | Restore "Profile **submitted**" step label |
| `src/lib/knotty/types.ts` | Restore `search_submitted` analytics event name |
| `src/app/api/_lib/session.ts` | Remove `SUPABASE_SERVICE_ROLE_KEY` signing fallback |
| `src/middleware.ts` | Remove `SUPABASE_SERVICE_ROLE_KEY` signing fallback |
| `tests/api/profiles-listing.spec.ts` | Translate Portuguese comments to English |
| `docs/SECURITY_AUDIT.md` | Record the session-secret decoupling as fully fixed |
| `docs/GO_LIVE_CHECKLIST.md` | Add dated final-closure note |

## What was removed

- The `SUPABASE_SERVICE_ROLE_KEY` entry from the `mm_session` HMAC signing-secret resolution in **both** `session.ts` and `middleware.ts`. The signing key is now `MM_SESSION_SECRET` (or `SESSION_SECRET` / `MM_JWT_SECRET` / `JWT_SECRET`) only, fully decoupled from the database key. Safe because `MM_SESSION_SECRET` is already set in production; resolution order remains identical between the API routes and the Edge middleware, so existing sessions are unaffected.

## What was fixed

- **Over-replacement regression.** A previous pass globally replaced the token `submitted` → `pending_approval`, which corrupted a React state variable, an analytics event name, and several user-facing strings (review form, legal/safety/trust/disclaimer copy, signup step label). All are restored. Legitimate `profile_status` enum values (`pending_approval`) and the distinct review-workflow `submitted` state (`profile_reviews`, signup `SubmissionStatus`) are intentionally left intact.
- **Portuguese → English** comments in the profiles-listing spec.

## Verified already-correct (no change needed)

- Legacy artifacts (`vite.config.ts`, `index.html`, `package-lock.json`, `public/robots.txt`) absent; `packageManager` is `pnpm@10.32.1`; `.gitattributes` is `* text=auto eol=lf`; `.vscode/extensions.json` recommends only the three required extensions.
- Tailwind `content` has no `./src/mm/**` or `./src/pages/**` legacy paths.
- `profiles_profile_status_check` constraint contains no `submitted`; `profile_reviews` keeps `submitted` for the review-submission state.
- OAuth callback (`src/app/auth/callback/route.ts`) exchanges the code, syncs `mm_session`, and routes new users to onboarding / others to their destination.
- No public Phone OTP UI on the login/register surface; phone remains a profile field; signup email verification is a separate, legitimate step.
- `create-checkout` edge function sets `metadata.user_id` on the session and `subscription_data`; the webhook updates `subscription_tier`, `_tier`, `photo_limit`, `visibility_level`, `stripe_customer_id`, `stripe_subscription_id`, `current_period_end`; `customer.subscription.deleted` downgrades to `free`.
- `release:audit` asserts the Stripe price-ID keys are present in `.env.example`.
- `release-checks.yml` runs each gate command as a separate step.

## Schema file to run

`supabase/PRODUCTION_SCHEMA_LOCK.sql` — apply before deployment; release is blocked if `pnpm validate:db-contract` fails.

## Validation results

Full chain run locally on the final commit — all green:

```
pnpm install --frozen-lockfile          exit 0
git diff --exit-code package.json …     exit 0
pnpm lint                               exit 0
pnpm typecheck                          exit 0
pnpm test                               exit 0
pnpm validate:sitemap                   exit 0
pnpm validate:db-contract               exit 0
pnpm release:audit                      exit 0
pnpm release:check                      exit 0
pnpm build                              exit 0
```

## Manual smoke test checklist

- [ ] Submit a review → toast reads "Review submitted successfully!" and the thank-you card shows.
- [ ] `/safety`, `/trust`, `/platform-disclaimer`, `/legal` copy reads naturally ("submitted", not "pending_approval").
- [ ] Signup pending page shows the "Profile submitted" step.
- [ ] Google OAuth login still sets `mm_session` and reaches onboarding/dashboard.
- [ ] Provider/admin/client route guards still behave (login, register, password reset).
- [ ] Stripe subscription create/update/cancel still syncs the profile tier.

## Risk notes

- The service-role-key fallback removal is the only behavioral change; it is a no-op in production because `MM_SESSION_SECRET` is set. Any environment **without** `MM_SESSION_SECRET` will now correctly refuse to sign sessions (intended).
- All other changes are string-literal/comment/doc fixes with no runtime branching impact.

https://claude.ai/code/session_01T6bemjNqJ62yBUZcjykg3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6bemjNqJ62yBUZcjykg3r)_