### PR TITLE
Redesign therapist card (compact + SEO) and add per-profile map, Q&A, and inline Knotty

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -79,7 +79,7 @@ const CONTENT_SECURITY_POLICY = [
   "style-src 'self' 'unsafe-inline' https:",
   `script-src 'self' 'unsafe-inline' ${isDev ? "'unsafe-eval' " : ""}https://js.stripe.com https://vercel.live`,
   "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://vercel.live https://*.vercel.app https://*.vercel.sh",
-  "frame-src 'self' http://localhost:* https://*.vusercontent.net https://*.lite.vusercontent.net https://generated.vusercontent.net https://*.vercel.net https://*.vercel.run https://*.vercel.app https://*.vercel.sh https://vercel.live https://vercel.com https://vercel.fides-cdn.ethyca.com https://js.stripe.com https://hooks.stripe.com https://*.accounts.dev https://*.clerk.accounts.dev https://ops.askchapter.org https://*.supabase.co",
+  "frame-src 'self' http://localhost:* https://*.vusercontent.net https://*.lite.vusercontent.net https://generated.vusercontent.net https://*.vercel.net https://*.vercel.run https://*.vercel.app https://*.vercel.sh https://vercel.live https://vercel.com https://vercel.fides-cdn.ethyca.com https://js.stripe.com https://hooks.stripe.com https://*.accounts.dev https://*.clerk.accounts.dev https://ops.askchapter.org https://*.supabase.co https://www.google.com https://maps.google.com",
   "worker-src 'self' blob:",
   "upgrade-insecure-requests"
 ].join("; ");

--- a/src/app/_components/PublicTherapistCard.tsx
+++ b/src/app/_components/PublicTherapistCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { CheckCircle2, Star } from "lucide-react";
+import { ArrowUpRight, MapPin, ShieldCheck, Star } from "lucide-react";
 import { useMemo } from "react";
 import type { PublicTherapist } from "@/app/_lib/directory";
 import {
@@ -44,10 +44,14 @@ export function PublicTherapistCard({ therapist }: { therapist: PublicTherapist 
   const profilePath = `/therapists/${therapist.slug || therapist.id}`;
   const isVerified = isVerifiedDirectoryProfile(therapist);
   const isElite = therapist._tier === "elite";
+  const availableNow = therapist.available_now === true;
 
   const startingPrice = getStartingPrice(therapist);
   const priceLabel = formatCurrency(startingPrice);
   const specialty = therapist.specialties?.[0] || therapist.modality || null;
+  const city = therapist.city || null;
+  const state = therapist.state || null;
+  const locationLabel = [city, state].filter(Boolean).join(", ");
 
   const profileImage = useMemo(
     () =>
@@ -59,85 +63,107 @@ export function PublicTherapistCard({ therapist }: { therapist: PublicTherapist 
 
   return (
     <article
-      className="group relative flex flex-col overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/5 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-md hover:ring-black/10"
+      className="group relative isolate flex flex-col overflow-hidden rounded-2xl bg-white shadow-[0_1px_3px_rgba(15,23,42,0.06)] ring-1 ring-black/[0.06] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_-12px_rgba(15,23,42,0.28)] hover:ring-black/10"
       itemScope
       itemType="https://schema.org/Person"
     >
       <Link
         href={profilePath}
         onClick={beginRouteTransition}
-        className="flex flex-col flex-1"
-        aria-label={`${name} – massage therapist${priceLabel ? `, from ${priceLabel}` : ""}`}
+        className="flex flex-1 flex-col"
+        aria-label={`${name} – massage therapist${locationLabel ? ` in ${locationLabel}` : ""}${priceLabel ? `, from ${priceLabel}` : ""}`}
       >
         {/* Photo */}
-        <div className="relative aspect-[3/4] overflow-hidden bg-neutral-100">
+        <div className="relative aspect-[4/5] overflow-hidden bg-neutral-100">
           <Image
             src={profileImage}
-            alt={`${name} – massage therapist in ${therapist.city || "your area"}`}
+            alt={`${name} – massage therapist in ${city || "your area"}`}
             fill
             sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
-            className="object-cover object-top transition-transform duration-500 group-hover:scale-[1.03]"
+            className="object-cover object-top transition-transform duration-[600ms] ease-out group-hover:scale-[1.04]"
             priority={false}
             itemProp="image"
           />
 
-          {/* Bottom gradient */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/15 to-transparent" />
 
-          {/* Verification badge — top left only if verified */}
-          {isVerified && (
-            <div className="absolute left-3 top-3">
-              <span className="inline-flex items-center gap-1 rounded-full bg-white/90 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 backdrop-blur-sm">
-                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+          {/* Top badges */}
+          <div className="absolute inset-x-2.5 top-2.5 flex items-start justify-between gap-2">
+            {isVerified ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-white/92 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 shadow-sm backdrop-blur-sm">
+                <ShieldCheck className="h-3 w-3 text-emerald-500" strokeWidth={2.5} />
                 {isElite ? "Elite" : "Verified"}
               </span>
-            </div>
-          )}
-
-          {/* Review count — top right */}
-          {therapist.review_count ? (
-            <div className="absolute right-3 top-3">
-              <span className="inline-flex items-center gap-1 rounded-full bg-black/40 px-2 py-0.5 text-[11px] font-semibold text-white backdrop-blur-sm">
-                <Star className="h-3 w-3 fill-primary text-primary" />
+            ) : (
+              <span />
+            )}
+            {therapist.review_count ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-black/45 px-2 py-0.5 text-[10px] font-semibold text-white backdrop-blur-sm">
+                <Star className="h-3 w-3 fill-primary text-primary" strokeWidth={2.5} />
                 {therapist.review_count}
               </span>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
+
+          {/* Hover affordance */}
+          <span className="absolute right-2.5 top-1/2 flex h-8 w-8 -translate-y-1/2 translate-x-3 items-center justify-center rounded-full bg-white/95 text-neutral-900 opacity-0 shadow-md transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100">
+            <ArrowUpRight className="h-4 w-4" strokeWidth={2.5} />
+          </span>
 
           {/* Name + specialty overlay */}
-          <div className="absolute bottom-3 left-3 right-3">
+          <div className="absolute inset-x-3 bottom-2.5">
             <h3
-              className="font-['Georgia',serif] text-lg font-normal leading-tight text-white drop-shadow-sm"
+              className="font-['Georgia',serif] text-[15px] font-normal leading-tight text-white drop-shadow-sm"
               itemProp="name"
             >
               {name}
             </h3>
             {specialty && (
-              <p className="mt-0.5 text-[11px] uppercase tracking-wide text-white/65">
+              <p className="mt-0.5 truncate text-[10px] uppercase tracking-[0.12em] text-white/70">
                 {specialty}
               </p>
             )}
           </div>
         </div>
 
-        {/* Rate + status row */}
-        <div className="flex items-center justify-between px-3.5 py-3">
-          <div>
-            <p className="text-[10px] uppercase tracking-widest text-neutral-400">From</p>
-            <p className="text-base font-semibold text-neutral-900" itemProp="priceRange">
+        {/* Info row */}
+        <div className="flex items-center justify-between gap-2 px-3 py-2.5">
+          <div className="min-w-0">
+            {locationLabel ? (
+              <p className="flex items-center gap-1 truncate text-[11px] font-medium text-neutral-500">
+                <MapPin className="h-3 w-3 shrink-0 text-neutral-400" strokeWidth={2.25} />
+                <span className="truncate">{locationLabel}</span>
+              </p>
+            ) : (
+              <p className="text-[11px] font-medium text-neutral-400">Massage therapist</p>
+            )}
+            {availableNow && (
+              <p className="mt-0.5 flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-600">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                Available now
+              </p>
+            )}
+          </div>
+
+          <div className="shrink-0 text-right">
+            <p className="text-[9px] uppercase tracking-widest text-neutral-400">From</p>
+            <p className="text-sm font-semibold text-neutral-900" itemProp="priceRange">
               {priceLabel ?? "Contact"}
             </p>
           </div>
-
-          {/* Availability dot */}
-          <div className="flex items-center gap-1.5 text-xs text-neutral-500">
-            <span className="relative flex h-2 w-2">
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
-            </span>
-            Available
-          </div>
         </div>
       </Link>
+
+      {/* SEO microdata (visually hidden) */}
+      <meta itemProp="jobTitle" content="Massage Therapist" />
+      <meta itemProp="url" content={profilePath} />
+      {(city || state) && (
+        <div className="sr-only" itemProp="address" itemScope itemType="https://schema.org/PostalAddress">
+          {city && <span itemProp="addressLocality">{city}</span>}
+          {state && <span itemProp="addressRegion">{state}</span>}
+          <span itemProp="addressCountry">US</span>
+        </div>
+      )}
     </article>
   );
 }

--- a/src/app/_components/city-directory-page.tsx
+++ b/src/app/_components/city-directory-page.tsx
@@ -201,7 +201,7 @@ export function CityDirectoryPage({
             </div>
 
             {therapists.length > 0 ? (
-              <div className="mt-6 grid gap-5 lg:grid-cols-2">
+              <div className="mt-6 grid grid-cols-2 gap-4 xl:grid-cols-3">
                 {therapists.map((therapist) => (
                   <PublicTherapistCard key={therapist.id} therapist={therapist} />
                 ))}

--- a/src/app/_components/search-directory.tsx
+++ b/src/app/_components/search-directory.tsx
@@ -274,7 +274,7 @@ export function SearchDirectory({
       />
 
       {visibleItems.length > 0 ? (
-        <div className="stagger-grid mt-6 grid gap-5 lg:grid-cols-2">
+        <div className="stagger-grid mt-6 grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4">
           {visibleItems.map((item) => (
             <PublicTherapistCard key={item.id} therapist={item} />
           ))}

--- a/src/app/therapists/[slug]/page.tsx
+++ b/src/app/therapists/[slug]/page.tsx
@@ -12,8 +12,12 @@ import { buildBreadcrumbJsonLd, buildFaqJsonLd, createPageMetadata } from "@/app
 import { InternalLinks } from "@/components/profile/InternalLinks";
 import { MobileContactCTA, StickyContactCard } from "@/components/profile/StickyContactCard";
 import { ProfileHero } from "@/components/profile/ProfileHero";
+import { ProfileKnotty } from "@/components/profile/ProfileKnotty";
+import { ProfileLocationMap } from "@/components/profile/ProfileLocationMap";
+import { ProfileQandA } from "@/components/profile/ProfileQandA";
 import { ProfileStructuredData } from "@/components/profile/ProfileStructuredData";
 import { SeoContentSections } from "@/components/profile/SeoContentSections";
+import { buildProfileFaq } from "@/components/profile/profile-faq";
 import { buildProfileViewModel } from "@/components/profile/profile-utils";
 
 type Params = { slug: string };
@@ -85,7 +89,30 @@ export default async function TherapistPage({ params }: { params: Promise<Params
   const profile = buildProfileViewModel(dbProfile, photos);
   const matchedCity = getCities().find((city) => city.name.toLowerCase() === profile.city.toLowerCase());
   const profilePath = `/therapists/${profile.slug}`;
-  const faqItems = Array.isArray(dbProfile.custom_faq) && dbProfile.custom_faq.length > 0 ? dbProfile.custom_faq : [];
+  const faqItems = buildProfileFaq(
+    profile,
+    Array.isArray(dbProfile.custom_faq) ? dbProfile.custom_faq : [],
+  );
+  const knottyFacts = {
+    name: profile.name,
+    firstName: profile.name.split(" ")[0] || profile.name,
+    city: profile.city,
+    neighborhood: profile.neighborhood,
+    services: profile.services,
+    specialties: profile.specialties,
+    startingPrice: profile.startingPrice,
+    incallPrice: profile.incallPrice,
+    outcallPrice: profile.outcallPrice,
+    incallAvailable: profile.incallAvailable,
+    outcallAvailable: profile.outcallAvailable,
+    travelRadius: /mile/i.test(profile.travelRadius) ? profile.travelRadius : "",
+    availabilityDays: profile.availabilityDays,
+    availabilityHours: profile.availabilityHours,
+    yearsExperience: profile.yearsExperience,
+    preferredContactMethod: profile.preferredContactMethod,
+    lgbtqAffirming: Boolean(dbProfile.lgbtq_affirming),
+    availableNow: Boolean(dbProfile.available_now),
+  };
 
   return (
     <main className="min-h-screen bg-[#071018] text-[#F8FAFC]" style={{ background: "radial-gradient(circle at top left, rgba(59,130,246,0.12), transparent 35%), radial-gradient(circle at bottom right, rgba(14,165,233,0.08), transparent 30%), #071018" }}>
@@ -99,7 +126,9 @@ export default async function TherapistPage({ params }: { params: Promise<Params
           <div className="hidden items-center gap-5 text-sm text-[#94A3B8] md:flex">
             <a href="#services" className="hover:text-white">Services</a>
             <a href="#pricing" className="hover:text-white">Pricing</a>
-            <a href="#gallery" className="hover:text-white">Gallery</a>
+            <a href="#location" className="hover:text-white">Location</a>
+            <a href="#faq" className="hover:text-white">Q&amp;A</a>
+            <a href="#ask-knotty" className="hover:text-white">Ask Knotty</a>
             <a href="#contact" className="hover:text-white">Contact</a>
           </div>
         </div>
@@ -109,6 +138,9 @@ export default async function TherapistPage({ params }: { params: Promise<Params
         <div className="space-y-8">
           <ProfileHero profile={profile} />
           <SeoContentSections profile={profile} />
+          <ProfileLocationMap profile={profile} />
+          <ProfileQandA items={faqItems} name={profile.name} />
+          <ProfileKnotty facts={knottyFacts} />
           <InternalLinks profile={profile} relatedProfiles={relatedResult.items} />
         </div>
         <StickyContactCard profile={profile} />

--- a/src/components/profile/ProfileKnotty.tsx
+++ b/src/components/profile/ProfileKnotty.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Send, Sparkles } from "lucide-react";
+
+export type KnottyProfileFacts = {
+  name: string;
+  firstName: string;
+  city: string;
+  neighborhood: string;
+  services: string[];
+  specialties: string[];
+  startingPrice: string;
+  incallPrice: string;
+  outcallPrice: string;
+  incallAvailable: boolean;
+  outcallAvailable: boolean;
+  travelRadius: string;
+  availabilityDays: string[];
+  availabilityHours: string;
+  yearsExperience: string;
+  preferredContactMethod: string;
+  lgbtqAffirming: boolean;
+  availableNow: boolean;
+};
+
+type ChatMessage = { id: string; role: "user" | "ai"; text: string };
+
+const HAS_RATES = (value: string) => Boolean(value) && value !== "Contact for rates";
+
+function nextId() {
+  return typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `k-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/**
+ * Inline, profile-scoped Knotty assistant. Answers are generated only from the
+ * facts published on this profile — it never invents pricing, availability, or
+ * trust claims. For anything not covered, it points the visitor to the contact
+ * options on the page.
+ */
+export function ProfileKnotty({ facts }: { facts: KnottyProfileFacts }) {
+  const { firstName, city, neighborhood } = facts;
+  const area = neighborhood && neighborhood !== "Serving central areas" ? neighborhood : city;
+
+  const intro = `Hi! I'm Knotty, ${firstName}'s profile assistant. Ask me about services, pricing, availability, or service area — I answer from this profile.`;
+  const quickQuestions = useMemo(
+    () => [
+      `What are ${firstName}'s rates?`,
+      facts.outcallAvailable ? `Does ${firstName} travel to me?` : `Where is ${firstName} based?`,
+      `What does ${firstName} specialize in?`,
+      `When is ${firstName} available?`,
+    ],
+    [firstName, facts.outcallAvailable],
+  );
+
+  const [messages, setMessages] = useState<ChatMessage[]>([{ id: "intro", role: "ai", text: intro }]);
+  const [input, setInput] = useState("");
+  const [isTyping, setIsTyping] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const answer = useCallback(
+    (question: string): string => {
+      const q = question.toLowerCase();
+
+      if (/(rate|price|cost|how much|fee|charge)/.test(q)) {
+        if (HAS_RATES(facts.startingPrice)) {
+          const bits = [`${facts.firstName}'s sessions start at ${facts.startingPrice}.`];
+          if (HAS_RATES(facts.incallPrice)) bits.push(`Incall from ${facts.incallPrice}.`);
+          if (HAS_RATES(facts.outcallPrice)) bits.push(`Outcall from ${facts.outcallPrice}.`);
+          bits.push("Final pricing depends on session length and type — reach out to confirm.");
+          return bits.join(" ");
+        }
+        return `${facts.firstName} shares pricing directly. Use the contact options on this page to ask about current rates.`;
+      }
+
+      if (/(outcall|travel|come to|mobile|to me|my place|my hotel)/.test(q)) {
+        if (facts.outcallAvailable) {
+          return `Yes — ${facts.firstName} offers outcall (mobile) sessions around ${city}${facts.travelRadius ? ` within a ${facts.travelRadius} radius` : ""}${HAS_RATES(facts.outcallPrice) ? `, starting at ${facts.outcallPrice}` : ""}. Travel fees may apply for longer distances.`;
+        }
+        return `${facts.firstName} currently focuses on incall sessions${neighborhood ? ` in ${area}` : ""}. Contact them to ask about outcall availability.`;
+      }
+
+      if (/(incall|studio|where|located|location|address|based)/.test(q)) {
+        return `${facts.firstName} is based in ${area}${facts.incallAvailable && HAS_RATES(facts.incallPrice) ? `, with incall sessions from ${facts.incallPrice}` : ""}. The exact studio address is shared privately after you connect.`;
+      }
+
+      if (/(special|technique|modal|service|deep tissue|swedish|sports|type of massage)/.test(q)) {
+        const list = Array.from(new Set([...facts.specialties, ...facts.services])).slice(0, 6);
+        if (list.length) {
+          return `${facts.firstName} offers ${list.join(", ").toLowerCase()}. Sessions are tailored to what you need — mention your goals when you reach out.`;
+        }
+        return `${facts.firstName} provides professional bodywork tailored to each client. Contact them to discuss the best approach for you.`;
+      }
+
+      if (/(experience|how long|years|qualified|trained)/.test(q)) {
+        if (facts.yearsExperience && !/request/i.test(facts.yearsExperience)) {
+          return `${facts.firstName} has ${facts.yearsExperience} of professional massage experience.`;
+        }
+        return `You'll find ${facts.firstName}'s background in the About section above. Reach out for any specifics on training.`;
+      }
+
+      if (/(available|open|when|hours|schedule|today|book|appointment)/.test(q)) {
+        const base = facts.availabilityDays.length
+          ? `${facts.firstName} is generally available on ${facts.availabilityDays.join(", ")}. ${facts.availabilityHours}.`
+          : `Check the availability section above, or contact ${facts.firstName} for current openings.`;
+        return facts.availableNow ? `${facts.firstName} is marked available now. ${base}` : base;
+      }
+
+      if (/(lgbtq|gay|queer|affirm|safe|welcom)/.test(q)) {
+        return facts.lgbtqAffirming
+          ? `Yes — ${facts.firstName} is LGBTQ+ affirming and provides a welcoming, judgment-free space for every client.`
+          : `${facts.firstName} maintains a professional, respectful space for all clients. Reach out with any specific questions.`;
+      }
+
+      if (/(contact|reach|message|call|text|whatsapp|email)/.test(q)) {
+        return `${facts.firstName} prefers ${facts.preferredContactMethod.toLowerCase()}. Use the contact options on this page to connect directly — MasseurMatch doesn't book on a provider's behalf.`;
+      }
+
+      return `Great question! For specifics beyond this profile, reach out to ${facts.firstName} using the contact options on the page. Anything else I can check from the profile — rates, area, specialties, or availability?`;
+    },
+    [facts, city, neighborhood, area],
+  );
+
+  const send = useCallback(
+    (raw: string) => {
+      const text = raw.trim();
+      if (!text) return;
+      setMessages((prev) => [...prev, { id: nextId(), role: "user", text }]);
+      setInput("");
+      setIsTyping(true);
+      const reply = answer(text);
+      window.setTimeout(() => {
+        setMessages((prev) => [...prev, { id: nextId(), role: "ai", text: reply }]);
+        setIsTyping(false);
+      }, 500 + Math.random() * 400);
+    },
+    [answer],
+  );
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [messages, isTyping]);
+
+  return (
+    <section
+      id="ask-knotty"
+      className="overflow-hidden rounded-[24px] border border-white/5 bg-[#101C2B]/90 shadow-2xl backdrop-blur-xl"
+    >
+      <div className="flex items-center gap-3 border-b border-white/5 bg-gradient-to-r from-[#FF8A1F]/10 to-transparent px-7 py-5">
+        <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-[#FF8A1F] to-[#ff6b00] text-[#0B1F3A]">
+          <Sparkles className="h-5 w-5" strokeWidth={2.25} />
+        </span>
+        <div>
+          <h2 className="font-display text-[22px] font-bold tracking-[-0.03em] text-[#F8FAFC]">
+            Ask Knotty about {firstName}
+          </h2>
+          <p className="flex items-center gap-1.5 font-sans text-xs text-[#94A3B8]">
+            <span className="h-2 w-2 rounded-full bg-[#2ECC8A] motion-safe:animate-pulse" />
+            Answers from this profile
+          </p>
+        </div>
+      </div>
+
+      <div ref={scrollRef} className="max-h-[360px] space-y-3 overflow-y-auto px-7 py-5">
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`max-w-[88%] whitespace-pre-line rounded-[18px] px-4 py-3 text-sm leading-relaxed ${
+              msg.role === "ai"
+                ? "mr-auto border border-white/5 bg-white/[0.05] text-[#E2E8F0]"
+                : "ml-auto bg-gradient-to-r from-[#FF8A1F] to-[#ff6b00] text-white"
+            }`}
+          >
+            {msg.text}
+          </div>
+        ))}
+        {isTyping && (
+          <div className="mr-auto flex max-w-[88%] gap-1.5 rounded-[18px] border border-white/5 bg-white/[0.05] px-4 py-4">
+            <span className="h-2 w-2 rounded-full bg-white/40 motion-safe:animate-bounce" style={{ animationDelay: "0ms" }} />
+            <span className="h-2 w-2 rounded-full bg-white/40 motion-safe:animate-bounce" style={{ animationDelay: "150ms" }} />
+            <span className="h-2 w-2 rounded-full bg-white/40 motion-safe:animate-bounce" style={{ animationDelay: "300ms" }} />
+          </div>
+        )}
+      </div>
+
+      {messages.length <= 1 && (
+        <div className="px-7 pb-3">
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#64748B]">Quick questions</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {quickQuestions.map((q) => (
+              <button
+                key={q}
+                type="button"
+                onClick={() => send(q)}
+                className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs text-[#94A3B8] transition hover:bg-white/[0.08] hover:text-white"
+              >
+                {q}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="border-t border-white/5 bg-white/[0.02] px-5 py-4">
+        <div className="flex items-center gap-3">
+          <input
+            type="text"
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && send(input)}
+            placeholder={`Ask about ${firstName}…`}
+            aria-label={`Ask Knotty a question about ${facts.name}`}
+            className="flex-1 rounded-full border border-white/10 bg-white/[0.06] px-4 py-2.5 text-sm text-white placeholder:text-white/40 focus:border-[#FF8A1F]/50 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => send(input)}
+            disabled={!input.trim()}
+            aria-label="Send question"
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#FF8A1F] text-[#0B1F3A] transition hover:bg-[#ff9d3f] disabled:opacity-40"
+          >
+            <Send className="h-4 w-4" strokeWidth={2.5} />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/profile/ProfileLocationMap.tsx
+++ b/src/components/profile/ProfileLocationMap.tsx
@@ -1,0 +1,82 @@
+import { MapPin, Navigation, ShieldCheck } from "lucide-react";
+import type { ProfileViewModel } from "./profile-utils";
+
+/**
+ * Privacy-safe location map for a therapist profile.
+ *
+ * Renders a keyless Google Maps embed centered on the provider's general area
+ * (neighborhood + city + state) — never an exact street address, which is only
+ * shared after a client connects. Works for every profile because it queries by
+ * place name rather than precise coordinates, so no map API key is required.
+ */
+export function ProfileLocationMap({ profile }: { profile: ProfileViewModel }) {
+  const areaParts = [profile.neighborhood, profile.city, profile.state].filter(
+    (part) => Boolean(part) && part !== "Serving central areas",
+  );
+  const query = (areaParts.length ? areaParts : [profile.city, profile.state])
+    .filter(Boolean)
+    .join(", ");
+
+  if (!query) return null;
+
+  const mapSrc = `https://www.google.com/maps?q=${encodeURIComponent(query)}&z=12&output=embed`;
+  const serviceAreas = profile.serviceAreas.slice(0, 6);
+
+  return (
+    <section
+      id="location"
+      className="overflow-hidden rounded-[24px] border border-white/5 bg-[#101C2B]/90 shadow-2xl backdrop-blur-xl"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4 p-7 pb-5">
+        <div className="flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#3B82F6]/12 text-[#60A5FA]">
+            <MapPin className="h-5 w-5" strokeWidth={2.25} />
+          </span>
+          <div>
+            <h2 className="font-display text-[28px] font-bold tracking-[-0.03em] text-[#F8FAFC]">
+              Location &amp; Service Area
+            </h2>
+            <p className="font-sans text-sm text-[#94A3B8]">
+              {profile.neighborhood}, {profile.city}, {profile.state}
+            </p>
+          </div>
+        </div>
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-300">
+          <ShieldCheck className="h-3.5 w-3.5" strokeWidth={2.5} />
+          Approximate area
+        </span>
+      </div>
+
+      <div className="relative mx-7 aspect-[16/9] overflow-hidden rounded-[18px] border border-white/8">
+        <iframe
+          src={mapSrc}
+          title={`Map of ${profile.name}'s service area in ${profile.city}, ${profile.state}`}
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          className="absolute inset-0 h-full w-full grayscale-[0.25] contrast-[1.05]"
+          style={{ border: 0 }}
+        />
+      </div>
+
+      <div className="p-7 pt-5">
+        {serviceAreas.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {serviceAreas.map((area) => (
+              <span
+                key={area}
+                className="inline-flex items-center gap-1.5 rounded-full border border-white/8 bg-white/[0.03] px-3 py-1.5 text-xs font-medium text-[#94A3B8]"
+              >
+                <Navigation className="h-3 w-3 text-[#60A5FA]" strokeWidth={2.5} />
+                {area}
+              </span>
+            ))}
+          </div>
+        )}
+        <p className="mt-4 font-sans text-sm leading-6 text-[#64748B]">
+          The map shows {profile.name}&apos;s general working area. The exact studio address is shared
+          privately after you connect{profile.outcallAvailable ? `, and ${profile.name} also travels for outcall sessions${/mile/i.test(profile.travelRadius) ? ` (${profile.travelRadius})` : ""}` : ""}.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/profile/ProfileQandA.tsx
+++ b/src/components/profile/ProfileQandA.tsx
@@ -1,0 +1,42 @@
+import { ChevronDown, MessageCircleQuestion } from "lucide-react";
+import type { ProfileFaqItem } from "@/app/_lib/directory";
+
+export function ProfileQandA({ items, name }: { items: ProfileFaqItem[]; name: string }) {
+  if (!items.length) return null;
+
+  return (
+    <section
+      id="faq"
+      className="rounded-[24px] border border-white/5 bg-[#101C2B]/90 p-7 shadow-2xl backdrop-blur-xl"
+    >
+      <div className="flex items-center gap-3">
+        <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#3B82F6]/12 text-[#60A5FA]">
+          <MessageCircleQuestion className="h-5 w-5" strokeWidth={2.25} />
+        </span>
+        <div>
+          <h2 className="font-display text-[28px] font-bold tracking-[-0.03em] text-[#F8FAFC]">
+            Questions &amp; Answers
+          </h2>
+          <p className="font-sans text-sm text-[#64748B]">
+            Common questions about {name}, answered from this profile.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 divide-y divide-white/5 border-t border-white/5">
+        {items.map((item) => (
+          <details key={item.question} className="group py-1">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left font-sans text-base font-semibold text-[#F8FAFC] transition-colors hover:text-white [&::-webkit-details-marker]:hidden">
+              <span itemProp="name">{item.question}</span>
+              <ChevronDown
+                className="h-5 w-5 shrink-0 text-[#64748B] transition-transform duration-300 group-open:rotate-180"
+                strokeWidth={2.25}
+              />
+            </summary>
+            <p className="pb-5 pr-9 font-sans text-base leading-7 text-[#94A3B8]">{item.answer}</p>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/profile/profile-faq.ts
+++ b/src/components/profile/profile-faq.ts
@@ -1,0 +1,94 @@
+import type { ProfileFaqItem } from "@/app/_lib/directory";
+import type { ProfileViewModel } from "./profile-utils";
+
+const HAS_RATES = (value: string) => Boolean(value) && value !== "Contact for rates";
+
+function uniqueList(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+/**
+ * Builds the question/answer list shown on a therapist profile.
+ *
+ * Curated `custom_faq` entries always come first; grounded defaults derived
+ * from the profile data fill in the rest so every profile shows a useful Q&A
+ * section (and a matching FAQPage JSON-LD block). Answers only state facts that
+ * are present in the profile — no fabricated claims, pricing, or guarantees.
+ */
+export function buildProfileFaq(
+  profile: ProfileViewModel,
+  custom: ProfileFaqItem[] = [],
+): ProfileFaqItem[] {
+  const name = profile.name;
+  const city = profile.city;
+  const state = profile.state;
+
+  const curated: ProfileFaqItem[] = custom
+    .filter((item) => item && typeof item.question === "string" && typeof item.answer === "string")
+    .map((item) => ({ question: item.question.trim(), answer: item.answer.trim() }))
+    .filter((item) => item.question && item.answer);
+
+  const services = uniqueList([...profile.services, ...profile.massageTypes, ...profile.specialties]);
+  const defaults: ProfileFaqItem[] = [];
+
+  if (services.length > 0) {
+    defaults.push({
+      question: `What massage services does ${name} offer in ${city}?`,
+      answer: `${name} offers ${services.slice(0, 6).join(", ").toLowerCase()} in ${city}, ${state}. Each session is tailored to your needs — message ${name} to confirm the right approach for you.`,
+    });
+  }
+
+  if (HAS_RATES(profile.startingPrice)) {
+    const parts: string[] = [`Sessions with ${name} start at ${profile.startingPrice}.`];
+    if (HAS_RATES(profile.incallPrice)) parts.push(`Incall from ${profile.incallPrice}.`);
+    if (HAS_RATES(profile.outcallPrice)) parts.push(`Outcall from ${profile.outcallPrice}.`);
+    parts.push(`Final pricing depends on session length and type — contact ${name} to confirm current rates.`);
+    defaults.push({
+      question: `How much does a massage session with ${name} cost?`,
+      answer: parts.join(" "),
+    });
+  } else {
+    defaults.push({
+      question: `How much does a massage session with ${name} cost?`,
+      answer: `${name} shares pricing directly. Use the contact options on this page to ask about current rates and session lengths.`,
+    });
+  }
+
+  if (profile.incallAvailable || profile.outcallAvailable) {
+    const modes: string[] = [];
+    if (profile.incallAvailable) modes.push("incall (at their private studio)");
+    if (profile.outcallAvailable) modes.push("outcall (mobile, travelling to you)");
+    defaults.push({
+      question: `Does ${name} offer incall or outcall massage?`,
+      answer: `${name} offers ${modes.join(" and ")} sessions${profile.outcallAvailable && /mile/i.test(profile.travelRadius) ? `, with a travel radius of ${profile.travelRadius}` : ""}. The exact studio address is shared after you connect.`,
+    });
+  }
+
+  defaults.push({
+    question: `What areas does ${name} serve around ${city}?`,
+    answer: `${name} is based in ${profile.neighborhood} and serves ${profile.serviceAreas.slice(0, 5).join(", ")} across ${city}, ${state}.`,
+  });
+
+  if (profile.availabilityDays.length > 0) {
+    defaults.push({
+      question: `When is ${name} available?`,
+      answer: `${name} is generally available on ${profile.availabilityDays.join(", ")}. ${profile.availabilityHours}. Reach out to confirm a specific time.`,
+    });
+  }
+
+  defaults.push({
+    question: `How do I contact ${name}?`,
+    answer: `${name} prefers ${profile.preferredContactMethod.toLowerCase()}. Connect through the contact options on this page — MasseurMatch is a directory and does not book or manage appointments on a provider's behalf.`,
+  });
+
+  const seen = new Set<string>();
+  const combined: ProfileFaqItem[] = [];
+  for (const item of [...curated, ...defaults]) {
+    const key = item.question.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    combined.push(item);
+  }
+
+  return combined.slice(0, 8);
+}


### PR DESCRIPTION
## Summary

Redesigns the therapist listing card to be **smaller, more beautiful, and SEO-rich**, and brings **map + Q&A + an inline Knotty assistant** to every therapist profile — the three things requested.

## Listing card — `PublicTherapistCard`

- **Smaller & more premium**: tighter `4/5` photo, refined gradient + hairlines, lucide icons everywhere (`ShieldCheck` verified, `Star` rating, `MapPin` location, `ArrowUpRight` hover affordance), serif name, micro-label specialty, and an **"Available now"** pill when the provider is live.
- **Main info for SEO**: visible **city/state**, starting price, rating, and verified status — plus richer structured data: `schema.org/Person` with `jobTitle`, `url`, a nested `PostalAddress` (`addressLocality` / `addressRegion` / `addressCountry`), and `priceRange`.
- **Denser grids** so cards actually render smaller — `search-directory` and `city-directory` now go 2 cols on mobile up to 4 on xl, matching the existing `/therapists` grid.

## Profile page — every therapist now shows

1. **Map** (`ProfileLocationMap`) — a privacy-safe, **keyless** Google Maps embed of the provider's *general area* (neighborhood/city/state), never an exact street address (that's shared only after a client connects). Works for every profile because it queries by place name, so no map API key is needed. The map origin was added to the CSP `frame-src`.
2. **Q&A** (`ProfileQandA`) — a visible Questions & Answers accordion. A new `buildProfileFaq()` merges curated `custom_faq` with **grounded, profile-derived defaults** and feeds **both** the visible Q&A and the `FAQPage` JSON-LD, so the structured data always matches on-page content (Google-compliant).
3. **Knotty inside the profile** (`ProfileKnotty`) — an inline, profile-scoped assistant that answers questions about *this* therapist (rates, area, specialties, availability, LGBTQ+ affirming, contact). It answers **only from the profile's published facts** — no fabricated pricing or claims — and defers to the contact options otherwise. It's **inline (not floating)**, so it doesn't clash with the site-wide Knotty widget.

Also added `Location` / `Q&A` / `Ask Knotty` anchors to the in-page profile nav.

## Files

**New:** `src/components/profile/profile-faq.ts`, `ProfileQandA.tsx`, `ProfileLocationMap.tsx`, `ProfileKnotty.tsx`
**Changed:** `PublicTherapistCard.tsx`, `search-directory.tsx`, `city-directory-page.tsx`, `therapists/[slug]/page.tsx`, `next.config.mjs` (CSP frame-src)

## Design notes (per CLAUDE.md)

- Premium lucide icons only — no text-glyph icons. Brand palette + dark profile surfaces (`#101C2B`, `#FF8A1F`, emerald accents), mono micro-labels.
- No fabricated claims: pricing/availability shown only when present; Q&A and Knotty answers are grounded in profile data; map is explicitly labelled "Approximate area".
- `motion-safe:` used on the Knotty animations to respect reduced-motion.

## Validation results

All green locally:

```
pnpm lint                  exit 0
pnpm typecheck             exit 0
pnpm test                  exit 0
pnpm validate:sitemap      exit 0
pnpm validate:db-contract  exit 0
pnpm release:audit         exit 0
pnpm build                 exit 0
```

## Manual smoke test checklist

- [ ] `/search` and a city page (e.g. `/dallas`) show the new compact cards in a denser grid; city + price + verified render; hover lifts the card.
- [ ] A therapist profile shows the **Location** map (area-level), the **Q&A** accordion, and the **Ask Knotty** panel.
- [ ] Knotty answers rates/area/specialty/availability questions from the profile and defers elsewhere.
- [ ] FAQ rich result validates (visible Q&A matches `FAQPage` JSON-LD).
- [ ] Map iframe loads in production (CSP `frame-src` now allows the maps origin).

## Risk notes

- Only behavioral runtime addition is the map iframe (gated by the CSP change) and the client-side Knotty panel. No data-model or API changes.
- Card microdata is additive; existing `itemProp` usage preserved.

https://claude.ai/code/session_01T6bemjNqJ62yBUZcjykg3r

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6bemjNqJ62yBUZcjykg3r)_