### PR TITLE
Port launch fixes: serverless-safe content store, resilient /near-me, data-driven city marquee

### DIFF
--- a/src/app/_components/near-me-redirect.tsx
+++ b/src/app/_components/near-me-redirect.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowUpRight, MapPin } from "lucide-react";
 import { getCities } from "@/app/_lib/directory";
 import { requestJson } from "@/app/_lib/request";
+import { PRIORITY_CITY_SLUGS } from "@/lib/marketing/home-data";
 
 type ReverseGeocodeResponse = {
   ok: boolean;
@@ -12,13 +15,11 @@ type ReverseGeocodeResponse = {
   state: string | null;
 };
 
+const CHECKING_MESSAGE = "Checking your location…";
+const FALLBACK_MESSAGE = "Pick a city below to browse the directory.";
+
 function normalize(value: string | null | undefined) {
   return (value || "").trim().toLowerCase();
-}
-
-function resolveFallbackPath() {
-  const fallbackCity = getCities()[0];
-  return fallbackCity ? `/${fallbackCity.slug}` : "/search";
 }
 
 function matchCity(cityName: string | null, stateCode: string | null) {
@@ -32,16 +33,31 @@ function matchCity(cityName: string | null, stateCode: string | null) {
   });
 }
 
+// Top markets first, falling back to the first cities in the directory so the
+// page always has clickable links to offer.
+function browseCities() {
+  const all = getCities();
+  const priority = PRIORITY_CITY_SLUGS.flatMap((slug) => {
+    const city = all.find((c) => c.slug === slug);
+    return city ? [city] : [];
+  });
+  return priority.length > 0 ? priority : all.slice(0, 12);
+}
+
 export function NearMeRedirect() {
   const router = useRouter();
+  const cities = useMemo(() => browseCities(), []);
+  const [message, setMessage] = useState(CHECKING_MESSAGE);
 
   useEffect(() => {
-    const fallbackPath = resolveFallbackPath();
-
-    if (!navigator.geolocation) {
-      router.replace(fallbackPath);
+    // Guard against SSR, browsers without geolocation, and an empty directory —
+    // in every case we just present the clickable city list below.
+    if (typeof navigator === "undefined" || !navigator.geolocation || cities.length === 0) {
+      setMessage(FALLBACK_MESSAGE);
       return;
     }
+
+    let cancelled = false;
 
     navigator.geolocation.getCurrentPosition(
       async (position) => {
@@ -50,19 +66,57 @@ export function NearMeRedirect() {
             `/api/reverse-geocode?lat=${position.coords.latitude}&lng=${position.coords.longitude}`,
           );
           const matchedCity = matchCity(response.city, response.stateCode);
-          router.replace(matchedCity ? `/${matchedCity.slug}` : fallbackPath);
+          if (cancelled) return;
+          if (matchedCity) {
+            router.replace(`/${matchedCity.slug}`);
+          } else {
+            setMessage(FALLBACK_MESSAGE);
+          }
         } catch {
-          router.replace("/search");
+          if (!cancelled) setMessage(FALLBACK_MESSAGE);
         }
       },
-      () => router.replace(fallbackPath),
-      {
-        enableHighAccuracy: false,
-        timeout: 8000,
-        maximumAge: 300_000,
+      () => {
+        // Permission denied, dismissed, or timed out — never leave the user stuck.
+        if (!cancelled) setMessage(FALLBACK_MESSAGE);
       },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 60000 },
     );
-  }, [router]);
 
-  return <p className="text-muted-foreground">Finding nearby therapists...</p>;
+    return () => {
+      cancelled = true;
+    };
+  }, [router, cities]);
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        <MapPin className="h-4 w-4 text-primary" strokeWidth={2.25} aria-hidden />
+        {message}
+      </div>
+
+      <ul className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {cities.map((city) => (
+          <li key={city.slug}>
+            <Link
+              href={`/${city.slug}`}
+              className="group flex items-center justify-between rounded-xl border border-border bg-card px-4 py-3 text-sm font-semibold text-foreground transition hover:border-primary/50 hover:bg-accent"
+            >
+              <span>
+                {city.name}
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  {city.stateCode}
+                </span>
+              </span>
+              <ArrowUpRight
+                className="h-4 w-4 text-muted-foreground transition group-hover:text-primary"
+                strokeWidth={2.25}
+                aria-hidden
+              />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/app/api/_lib/content-store.ts
+++ b/src/app/api/_lib/content-store.ts
@@ -1,7 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
+import seedContent from "../_data/admin-content.json";
 import type { BlogPost } from "@/app/blog/posts";
 
 export interface StoredBlogPost extends BlogPost {
@@ -32,9 +33,14 @@ interface ContentStore {
   keywords: StoredKeyword[];
 }
 
-const cwdValue = process.cwd() as unknown;
-const cwdPath = cwdValue instanceof URL ? fileURLToPath(cwdValue) : String(cwdValue);
-const storePath = path.join(cwdPath, "src", "app", "api", "_data", "admin-content.json");
+// The original implementation wrote into the project tree under
+// `process.cwd()`, which is read-only on serverless platforms (Vercel) and
+// threw on the first admin write. Persist into the OS temp dir instead and keep
+// an in-memory cache so reads/writes never crash a request even when the
+// filesystem is fully read-only.
+const storePath = path.join(os.tmpdir(), "masseurmatch", "admin-content.json");
+
+let memoryStore: ContentStore | null = null;
 
 function normalizeStore(raw: Partial<ContentStore> | null | undefined): ContentStore {
   return {
@@ -44,16 +50,38 @@ function normalizeStore(raw: Partial<ContentStore> | null | undefined): ContentS
   };
 }
 
-export async function readContentStore(): Promise<ContentStore> {
+// Best-effort persistence: swallow read-only filesystem errors so admin writes
+// still succeed (the in-memory cache keeps them live for the instance's life).
+async function persist(store: ContentStore): Promise<void> {
   try {
-    const contents = await readFile(storePath, "utf8");
-    return normalizeStore(JSON.parse(contents) as Partial<ContentStore>);
+    await mkdir(path.dirname(storePath), { recursive: true });
+    await writeFile(storePath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
   } catch {
-    return normalizeStore(null);
+    // Ignore — serverless filesystems are read-only outside the temp dir.
   }
 }
 
+export async function readContentStore(): Promise<ContentStore> {
+  if (memoryStore) {
+    return memoryStore;
+  }
+
+  // Prefer the runtime-persisted copy in the writable temp dir.
+  try {
+    const contents = await readFile(storePath, "utf8");
+    memoryStore = normalizeStore(JSON.parse(contents) as Partial<ContentStore>);
+    return memoryStore;
+  } catch {
+    // No runtime copy yet — fall back to the seed bundled with the app.
+  }
+
+  memoryStore = normalizeStore(seedContent as unknown as Partial<ContentStore>);
+  await persist(memoryStore);
+  return memoryStore;
+}
+
 export async function writeContentStore(store: ContentStore) {
-  await mkdir(path.dirname(storePath), { recursive: true });
-  await writeFile(storePath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  const normalized = normalizeStore(store);
+  memoryStore = normalized;
+  await persist(normalized);
 }

--- a/src/components/marketing/CityMarquee.tsx
+++ b/src/components/marketing/CityMarquee.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import { US_CITIES } from "@/data/cities";
 
 /**
  * Animated marquee of top MasseurMatch cities. Names scroll continuously to the
@@ -8,30 +9,38 @@ import { motion, useReducedMotion } from "framer-motion";
  * "city skyline" sense of depth. Sits on the dark first-fold band.
  */
 
-type City = { name: string; tier: 1 | 2 | 3 };
+type CityTier = 1 | 2 | 3;
+type City = { name: string; tier: CityTier };
 
-// tier 1 = hero markets (big & bright), 2 = mid, 3 = supporting (small & dim)
-const CITIES: City[] = [
-  { name: "New York", tier: 1 },
-  { name: "Philadelphia", tier: 3 },
-  { name: "Miami", tier: 1 },
-  { name: "Sarasota", tier: 3 },
-  { name: "Los Angeles", tier: 1 },
-  { name: "Orlando", tier: 2 },
-  { name: "Houston", tier: 1 },
-  { name: "Tampa", tier: 3 },
-  { name: "Atlanta", tier: 1 },
-  { name: "Las Vegas", tier: 2 },
-  { name: "Chicago", tier: 1 },
-  { name: "Boston", tier: 2 },
-  { name: "Dallas", tier: 1 },
-  { name: "Seattle", tier: 3 },
-  { name: "Washington DC", tier: 2 },
-  { name: "Denver", tier: 3 },
-  { name: "San Francisco", tier: 2 },
-  { name: "Austin", tier: 3 },
-  { name: "Phoenix", tier: 3 },
+// tier 1 = hero markets (big & bright), 2 = mid, 3 = supporting (small & dim).
+// Driven by slug so display names resolve from the canonical city dataset and
+// any city dropped from the directory automatically disappears from the marquee.
+const CITY_TIERS: { slug: string; tier: CityTier }[] = [
+  { slug: "new-york", tier: 1 },
+  { slug: "philadelphia", tier: 3 },
+  { slug: "miami", tier: 1 },
+  { slug: "sarasota", tier: 3 },
+  { slug: "los-angeles", tier: 1 },
+  { slug: "orlando", tier: 2 },
+  { slug: "houston", tier: 1 },
+  { slug: "tampa", tier: 3 },
+  { slug: "atlanta", tier: 1 },
+  { slug: "las-vegas", tier: 2 },
+  { slug: "chicago", tier: 1 },
+  { slug: "boston", tier: 2 },
+  { slug: "dallas", tier: 1 },
+  { slug: "seattle", tier: 3 },
+  { slug: "washington-dc", tier: 2 },
+  { slug: "denver", tier: 3 },
+  { slug: "san-francisco", tier: 2 },
+  { slug: "austin", tier: 3 },
+  { slug: "phoenix", tier: 3 },
 ];
+
+const CITIES: City[] = CITY_TIERS.flatMap(({ slug, tier }) => {
+  const city = US_CITIES.find((c) => c.slug === slug);
+  return city ? [{ name: city.name, tier }] : [];
+});
 
 const TIER_STYLES: Record<City["tier"], string> = {
   1: "text-[clamp(1.75rem,4vw,3.25rem)] text-white",


### PR DESCRIPTION
Ports three already-validated launch fixes from `segattihall-ops/masseurmatch`, **adapted** to this repo's structure (which has since diverged with the profile redesign). The conceptual fixes are the same; the file locations and implementations differ.

## Fix 1 — Serverless-safe content store (`src/app/api/_lib/content-store.ts`)
**Problem:** the admin content store wrote under `process.cwd()` (`src/app/api/_data/admin-content.json`), which is read-only on Vercel → the first admin write (cities/keywords/blog) crashed with a 500.

**Fix (adapted):** the source repo's fix targeted `src/mm/lib/store.ts`; this repo's equivalent is `content-store.ts`. Applied the same concept:
- Persist to `os.tmpdir()/masseurmatch/admin-content.json` instead of the project tree.
- Added an in-memory `memoryStore` cache.
- `persist()` does `mkdir + writeFile` inside `try/catch` so a read-only FS never throws.
- `readContentStore()` returns the cache if loaded, else reads the temp copy, else **seeds from the bundled `admin-content.json`** (imported as a module so it's always in the serverless bundle) and persists best-effort.
- `writeContentStore()` updates the cache and persists best-effort. Public signatures unchanged.

## Fix 2 — `/near-me` never traps the user (`src/app/_components/near-me-redirect.tsx`)
**Problem:** if the geolocation prompt was ignored/dismissed the page could sit forever, and the fallback was a bare redirect with no escape hatch.

**Fix:**
- Guard for `typeof navigator === "undefined"`, missing `navigator.geolocation`, or an empty city list → show "Pick a city below to browse the directory."
- Pass `{ timeout: 8000, maximumAge: 60000 }` to `getCurrentPosition` (plus an effect-cancel guard).
- **Always render a clickable list of cities** (`<Link href={`/${city.slug}`}>`, top markets first), so the page is never a dead end — on success it still auto-redirects to the matched city.

## Fix 3 — Home city display is data-driven (`src/components/marketing/CityMarquee.tsx`)
**Problem (source repo):** a hardcoded city list could link to cities that don't exist → 404s.

**In this redesign the clickable city links were already data-driven** — `CityCaseStudies` reads from `getCities()`/`PRIORITY_CITY_SLUGS` (missing slugs are filtered out) and `CityCoverageSection` maps over `US_CITIES`, so there are no broken city links on the home. The only remaining hardcoded city content was the decorative `CityMarquee`. Drove it by slug from the canonical `US_CITIES` dataset so display names always stay in sync and any city removed from the directory automatically drops out. (No `getDirectoryStats()` helper exists in this repo, so the hero/stats band was left as-is.)

## Validation
`pnpm lint`, `pnpm typecheck`, and `pnpm build` all pass.

## Deploy
No direct deploy — Vercel publishes via merge to `main`.

https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ)_