### PR TITLE
Pre-launch audit: P0/P1 fixes + Vercel build unblock

### DIFF
--- a/src/app/_components/demo-profile-banner.tsx
+++ b/src/app/_components/demo-profile-banner.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { FlaskConical } from "lucide-react";
 
 /**
@@ -15,9 +16,9 @@ export function DemoProfileBanner() {
       <FlaskConical className="h-4 w-4 shrink-0 text-amber-600" strokeWidth={2.25} />
       <span>
         <strong>Sample profile</strong> — this is a design showcase listing, not a verified therapist.{" "}
-        <a href="/search" className="underline underline-offset-2 hover:text-amber-900">
+        <Link href="/search" className="underline underline-offset-2 hover:text-amber-900">
           Browse real profiles
-        </a>
+        </Link>
         .
       </span>
     </div>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import Script from "next/script";
 
 export const metadata: Metadata = {
@@ -273,9 +274,9 @@ export default function CookiePolicyPage() {
                 privacy@masseurmatch.com
               </a>
               . For broader privacy rights, see our{" "}
-              <a href="/privacy" style={{ color: "#FF8A1F", textDecoration: "none" }}>
+              <Link href="/privacy" style={{ color: "#FF8A1F", textDecoration: "none" }}>
                 Privacy Policy
-              </a>
+              </Link>
               .
             </p>
           </section>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1272,6 +1272,7 @@ export type Database = {
           incall_price: number | null
           is_active: boolean | null
           is_banned: boolean | null
+          is_demo: boolean | null
           is_featured: boolean | null
           is_suspended: boolean | null
           is_verified_identity: boolean | null
@@ -1390,6 +1391,7 @@ export type Database = {
           incall_price?: number | null
           is_active?: boolean | null
           is_banned?: boolean | null
+          is_demo?: boolean | null
           is_featured?: boolean | null
           is_suspended?: boolean | null
           is_verified_identity?: boolean | null
@@ -1508,6 +1510,7 @@ export type Database = {
           incall_price?: number | null
           is_active?: boolean | null
           is_banned?: boolean | null
+          is_demo?: boolean | null
           is_featured?: boolean | null
           is_suspended?: boolean | null
           is_verified_identity?: boolean | null

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -316,6 +316,8 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     }
   }
 
+  const topLevelParts = pathname.split("/").filter(Boolean);
+
   // ── 7a. Legacy /{city}/therapist/{slug} → /therapists/{slug} ─────────────
   if (topLevelParts.length === 3 && topLevelParts[1] === "therapist") {
     const citySlug = resolveCitySlug(topLevelParts[0] || "");
@@ -325,7 +327,6 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   }
 
   // ── 7. Legacy /{city}/massage-therapists → /{city} ───────────────────────
-  const topLevelParts = pathname.split("/").filter(Boolean);
   if (topLevelParts.length === 2 && topLevelParts[1] === "massage-therapists") {
     const citySlug = resolveCitySlug(topLevelParts[0] || "");
     if (citySlug) {


### PR DESCRIPTION
Pre-launch audit fixes (SEO, pricing, UI, trust) plus the build fixes needed to get the Vercel deploy green.

## Build unblock (this session)
The Vercel build was failing with three sequential blockers — each fixed and verified with a full `next build`:

1. **ESLint `@next/next/no-html-link-for-pages`** — internal-route `<a>` tags switched to `next/link`:
   - `src/app/_components/demo-profile-banner.tsx` (`/search`)
   - `src/app/cookie-policy/page.tsx` (`/privacy`) — the `mailto:` link stays a plain `<a>`.
2. **Type error in `src/app/_lib/directory.ts`** — the new `is_demo` column (migration `20260611100000_add_is_demo_to_profiles.sql`) wasn't reflected in the generated Supabase types, so the typed client rejected the query. Added `is_demo` to the `profiles` Row/Insert/Update types in `src/integrations/supabase/types.ts`.
3. **Type error in `src/middleware.ts`** — `topLevelParts` was used in the legacy `/{city}/therapist/{slug}` redirect before its declaration; hoisted the `const` above its first use.

## Validation
`pnpm lint`, `pnpm typecheck`, and `pnpm build` all pass.

## ⚠️ Deploy dependency
The `is_demo` feature requires migration `20260611100000_add_is_demo_to_profiles.sql` to be applied to the production Supabase project. Apply it before/with launch, or queries selecting `is_demo` will error at runtime.

https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ)_