### PR TITLE
fix: make production build green (stale Supabase types + link/bug fixes)

### DIFF
--- a/src/app/[city]/visiting/[therapist-slug]/page.tsx
+++ b/src/app/[city]/visiting/[therapist-slug]/page.tsx
@@ -67,8 +67,8 @@ export async function generateMetadata({
   const dateLabel = formatDateRange(nextVisit.start_date, nextVisit.end_date);
 
   return {
-    title: `${name} Visiting ${cityMeta.label} | MasseurMatch`,
-    description: `${name} is visiting ${cityMeta.label} ${dateLabel}. Book a session with this LGBTQ+-affirming massage therapist during their travel stay.`,
+    title: `${name} Visiting ${cityMeta.name} | MasseurMatch`,
+    description: `${name} is visiting ${cityMeta.name} ${dateLabel}. Book a session with this LGBTQ+-affirming massage therapist during their travel stay.`,
     alternates: { canonical: `https://masseurmatch.com/${city}/visiting/${slug}` },
     robots: { index: true, follow: true },
   };
@@ -115,7 +115,7 @@ export default async function TourPage({
             }}
           >
             <MapPin style={{ width: 11, height: 11 }} strokeWidth={2.25} />
-            Visiting {cityMeta.label}
+            Visiting {cityMeta.name}
           </div>
           <h1
             style={{
@@ -262,7 +262,7 @@ export default async function TourPage({
               textDecoration: "none",
             }}
           >
-            All therapists in {cityMeta.label}
+            All therapists in {cityMeta.name}
           </Link>
         </div>
 
@@ -276,7 +276,7 @@ export default async function TourPage({
               lineHeight: 1.6,
             }}
           >
-            {name} will be in {cityMeta.label}{" "}
+            {name} will be in {cityMeta.name}{" "}
             {formatDateRange(nextVisit.start_date, nextVisit.end_date)}.
             Contact them early — availability during travel visits fills quickly.
           </p>

--- a/src/app/for-therapists/page.tsx
+++ b/src/app/for-therapists/page.tsx
@@ -683,7 +683,7 @@ export default function ForTherapistsPage() {
                 </div>
               ))}
             </div>
-            <a
+            <Link
               href="/pricing"
               style={{
                 display: "inline-flex",
@@ -701,7 +701,7 @@ export default function ForTherapistsPage() {
               }}
             >
               See Elite pricing
-            </a>
+            </Link>
           </div>
         </section>
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -395,6 +395,33 @@ export type Database = {
         }
         Relationships: []
       }
+      contact_events: {
+        Row: {
+          created_at: string
+          id: string
+          ip_hash: string | null
+          method: string
+          profile_id: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          ip_hash?: string | null
+          method: string
+          profile_id: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          ip_hash?: string | null
+          method?: string
+          profile_id?: string
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       contact_inquiries: {
         Row: {
           client_email: string | null
@@ -479,6 +506,45 @@ export type Database = {
           id?: string
           therapist_id?: string | null
           updated_at?: string
+        }
+        Relationships: []
+      }
+      demand_scores: {
+        Row: {
+          city: string
+          competition_index: number
+          created_at: string
+          id: string
+          neighborhood: string | null
+          score: number
+          search_volume_index: number
+          state: string
+          trend: string
+          week_start: string
+        }
+        Insert: {
+          city: string
+          competition_index?: number
+          created_at?: string
+          id?: string
+          neighborhood?: string | null
+          score: number
+          search_volume_index?: number
+          state: string
+          trend?: string
+          week_start: string
+        }
+        Update: {
+          city?: string
+          competition_index?: number
+          created_at?: string
+          id?: string
+          neighborhood?: string | null
+          score?: number
+          search_volume_index?: number
+          state?: string
+          trend?: string
+          week_start?: string
         }
         Relationships: []
       }
@@ -1272,6 +1338,7 @@ export type Database = {
           incall_price: number | null
           is_active: boolean | null
           is_banned: boolean | null
+          identity_verified_at: string | null
           is_demo: boolean | null
           is_featured: boolean | null
           is_suspended: boolean | null
@@ -1391,6 +1458,7 @@ export type Database = {
           incall_price?: number | null
           is_active?: boolean | null
           is_banned?: boolean | null
+          identity_verified_at?: string | null
           is_demo?: boolean | null
           is_featured?: boolean | null
           is_suspended?: boolean | null
@@ -1510,6 +1578,7 @@ export type Database = {
           incall_price?: number | null
           is_active?: boolean | null
           is_banned?: boolean | null
+          identity_verified_at?: string | null
           is_demo?: boolean | null
           is_featured?: boolean | null
           is_suspended?: boolean | null


### PR DESCRIPTION
Makes the production build green. After PR #418 fixed the first batch, the full `main` tree still failed to compile — `main` had accumulated build breakage across earlier feature merges (the build is not an enforced CI gate, so broken code merged repeatedly).

## Fixes
1. **Stale generated Supabase types** (`src/integrations/supabase/types.ts`) — added schema that migrations already created (confirmed applied to prod):
   - `profiles.identity_verified_at` (migration `…200002`) → fixes type errors in `directory.ts`, `api/webhooks/stripe`, `api/admin/profile/[id]/verify_identity`
   - `contact_events` table (`…200004`) → fixes `api/public/contact/[id]` insert + `api/reviews` eligibility check
   - `demand_scores` table (`…200001`) → fixes `pro/demand-radar`
2. **`for-therapists/page.tsx`** — internal `/pricing` link uses `next/link` (`@next/next/no-html-link-for-pages`).
3. **`[city]/visiting/[therapist-slug]/page.tsx`** — `cityMeta.label` → `cityMeta.name` (5 spots; `CityData` has no `label`).

## Validation
`pnpm lint`, `pnpm typecheck`, and `pnpm build` all pass on the full merged-`main` tree.

## Follow-up recommendation
The production build isn't gated in CI, which is how `main` silently broke. Recommend making the `Build` check required on `main`.

https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ)_