### PR TITLE
fix: intro splash freezing/blocking pages (login unreachable) + harden E2E install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,16 @@ jobs:
           pnpm --version
       - run: pnpm install --frozen-lockfile
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 12
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          set -euo pipefail
+          # The apt phase of `--with-deps` occasionally stalls on the runner and,
+          # without a cap, consumed the entire job timeout. Give each attempt a
+          # hard 6-minute limit and retry once so a transient stall self-heals.
+          timeout 360 bash -c 'npx playwright install --with-deps chromium' \
+            || timeout 360 bash -c 'npx playwright install --with-deps chromium'
       - name: Run E2E tests
         run: npx playwright test --timeout=30000 --retries=1
       - name: Summarize Playwright report

--- a/src/app/_components/IntroVideoSplash.tsx
+++ b/src/app/_components/IntroVideoSplash.tsx
@@ -1,22 +1,41 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import { X, Volume2, VolumeX } from "lucide-react";
 import { BRAND_ASSETS } from "@/lib/brand";
 
 const SESSION_KEY = "mm_intro_seen";
+// If playback hasn't started by now the asset is stalling — bail so we never
+// trap the visitor behind a frozen overlay.
+const STALL_TIMEOUT_MS = 4000;
+// Absolute ceiling: the splash can never hold the page longer than this,
+// regardless of what the <video> element reports.
+const MAX_VISIBLE_MS = 12000;
 
-// Full-screen opening video shown once per browser session on first visit.
+// Full-screen opening video shown once per browser session on the homepage.
 // Muted autoplay (browser policy), with a Skip control and an optional unmute
-// toggle. Auto-dismisses when the video ends or fails, and is skipped entirely
-// for visitors who prefer reduced motion.
+// toggle. Auto-dismisses when the video ends, fails, stalls, or hits the hard
+// cap — and only mounts on "/", so it can never block /login, /signup, etc.
 export function IntroVideoSplash() {
+  const pathname = usePathname();
   const [visible, setVisible] = useState(false);
   const [muted, setMuted] = useState(true);
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
+  const dismiss = useCallback(() => {
+    try {
+      window.sessionStorage.setItem(SESSION_KEY, "true");
+    } catch {
+      // Ignore storage failures (private mode, etc.) — worst case it replays.
+    }
+    setVisible(false);
+  }, []);
+
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // Homepage only — never overlay functional routes like /login or /signup.
+    if (pathname !== "/") return;
 
     const prefersReducedMotion = window.matchMedia?.(
       "(prefers-reduced-motion: reduce)",
@@ -32,26 +51,32 @@ export function IntroVideoSplash() {
     if (!alreadySeen && !prefersReducedMotion) {
       setVisible(true);
     }
-  }, []);
+  }, [pathname]);
 
   useEffect(() => {
     if (!visible) return;
+
     // Lock background scroll while the splash is open.
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+
+    // Watchdog 1: if playback never starts (stalled/blocked download), bail.
+    const stallTimer = window.setTimeout(() => {
+      const video = videoRef.current;
+      if (!video || video.paused || video.readyState < 3 || video.currentTime === 0) {
+        dismiss();
+      }
+    }, STALL_TIMEOUT_MS);
+
+    // Watchdog 2: hard ceiling so the overlay can never trap the page.
+    const hardCapTimer = window.setTimeout(dismiss, MAX_VISIBLE_MS);
+
     return () => {
       document.body.style.overflow = previousOverflow;
+      window.clearTimeout(stallTimer);
+      window.clearTimeout(hardCapTimer);
     };
-  }, [visible]);
-
-  const dismiss = () => {
-    try {
-      window.sessionStorage.setItem(SESSION_KEY, "true");
-    } catch {
-      // Ignore storage failures (private mode, etc.) — worst case it replays.
-    }
-    setVisible(false);
-  };
+  }, [visible, dismiss]);
 
   const toggleMute = () => {
     const next = !muted;
@@ -80,6 +105,7 @@ export function IntroVideoSplash() {
         poster={BRAND_ASSETS.heroPoster}
         onEnded={dismiss}
         onError={dismiss}
+        onStalled={dismiss}
       >
         <source src={BRAND_ASSETS.introVideo} type="video/mp4" />
       </video>


### PR DESCRIPTION
Fixes the production "page is very slow / freezes" + "login isn't working" reports, and hardens the E2E CI job.

## Root cause (freeze + login unreachable)
`IntroVideoSplash` was mounted in the **root layout**, so on the first visit of every session it rendered a full-screen (`z-[100000]`), scroll-locking autoplay video **on every route — including `/login`**. If the video (a `.MP4` from blob storage) loaded slowly or stalled, the page appeared frozen and the overlay covered the login form, so users literally could not reach it. There was no watchdog, so a stalled video trapped the page indefinitely.

### Fix
- **Homepage only:** the splash now mounts only when `pathname === "/"`. It can no longer cover `/login`, `/signup`, `/pro`, `/admin`, etc. (This alone fixes "can't reach the login form.")
- **Watchdogs:** a 4s stall check (bail if playback hasn't started) + a 12s hard cap + `onStalled` dismiss, so the overlay can never freeze/trap the page.
- Scroll-lock is always restored on cleanup.

No backend login change was needed — the login API is healthy; the form was simply unreachable behind the overlay.

## E2E CI hardening
The `npx playwright install --with-deps chromium` step was hanging (the apt phase) and consuming the entire 30-min E2E job budget (the "cancelled" check). Now each attempt has a hard 6-minute `timeout`, retries once, runs with `DEBIAN_FRONTEND=noninteractive`, and the step has a 12-min cap — so it self-heals or fails fast instead of hanging.

## Validation
`pnpm lint`, `pnpm typecheck`, `pnpm build` all pass; `ci.yml` YAML validated.

## Note
If scrolling on the homepage still feels laggy after this, the next suspect is the Lenis smooth-scroll wrapper (`SmoothScroll.tsx`) — I left it untouched since it wasn't the confirmed cause. Say the word and I'll make it easy to disable.

https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01227kaHGR5JoZA4MmB5GLFJ)_