### PR TITLE
fix(schema): add missing reviews columns to schema lock

### DIFF
--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -404,6 +404,10 @@ create table if not exists public.reviews (
   created_at timestamptz default timezone('utc', now())
 );
 
+alter table public.reviews
+  add column if not exists source_platform text,
+  add column if not exists helpful_count integer default 0;
+
 create table if not exists public.client_favorites (
   id uuid primary key default gen_random_uuid(),
   user_id uuid,


### PR DESCRIPTION
Add source_platform and helpful_count to the reviews table in the
production schema lock to match code references.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016zANeRJ4LxTjfmRCS9qGny