### PR TITLE
Add analytics and Google Tag Manager tracking for MasseurMatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ SITEMAP_SUPABASE_KEY=                     # [OPTIONAL] read-only key for sitemap
 
 # ── Analytics ────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_GA_MEASUREMENT_ID=            # [OPTIONAL] GA4 measurement ID, e.g. G-XXXXXXXXXX
+NEXT_PUBLIC_GTM_ID=                       # [OPTIONAL] Google Tag Manager container ID, e.g. GTM-XXXXXXX
 
 # ── Session ───────────────────────────────────────────────────────────────────
 # Signs the mm_session cookie. MUST be set in production (≥32 random chars).

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=            # [REQUIRED] same as SUPABASE_ANON_KEY
 SUPABASE_SERVICE_ROLE_KEY=                # [REQUIRED] service role key (server-only)
 SITEMAP_SUPABASE_KEY=                     # [OPTIONAL] read-only key for sitemap generation
 
+# ── Analytics ────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_GA_MEASUREMENT_ID=            # [OPTIONAL] GA4 measurement ID, e.g. G-XXXXXXXXXX
+
 # ── Session ───────────────────────────────────────────────────────────────────
 # Signs the mm_session cookie. MUST be set in production (≥32 random chars).
 MM_SESSION_SECRET=                        # [REQUIRED in production]

--- a/src/app/_components/analytics-page-tracker.tsx
+++ b/src/app/_components/analytics-page-tracker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { trackEvent } from "@/lib/analytics";
+
+function getSourcePage(pathname: string) {
+  if (pathname === "/") return "home";
+  if (pathname.startsWith("/explore")) return "explore";
+  if (pathname.startsWith("/profile")) return "profile";
+  if (pathname.startsWith("/join")) return "join";
+  if (pathname.startsWith("/waitlist")) return "waitlist";
+  if (pathname.startsWith("/dashboard")) return "dashboard";
+  if (pathname.startsWith("/admin")) return "admin";
+  return pathname.split("/").filter(Boolean)[0] ?? "unknown";
+}
+
+function getPageEventName(pathname: string) {
+  if (pathname.startsWith("/explore")) return "explore_view";
+  if (pathname.startsWith("/profile")) return "profile_view";
+  if (pathname.includes("/city/") || pathname.startsWith("/cities/")) return "city_page_view";
+  return "page_view";
+}
+
+export function AnalyticsPageTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const queryString = searchParams.toString();
+    const pathWithQuery = queryString ? `${pathname}?${queryString}` : pathname;
+
+    void trackEvent({
+      eventName: getPageEventName(pathname),
+      sourcePage: getSourcePage(pathname),
+      metadata: {
+        path: pathname,
+        path_with_query: pathWithQuery,
+      },
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/app/_components/google-analytics.tsx
+++ b/src/app/_components/google-analytics.tsx
@@ -1,0 +1,21 @@
+import Script from "next/script";
+
+const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+export function GoogleAnalytics() {
+  if (!gaMeasurementId) return null;
+
+  return (
+    <>
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`} strategy="afterInteractive" />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${gaMeasurementId}', { send_page_view: false });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/src/app/_components/google-tag-manager.tsx
+++ b/src/app/_components/google-tag-manager.tsx
@@ -1,0 +1,35 @@
+import Script from "next/script";
+
+const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
+
+export function GoogleTagManager() {
+  if (!gtmId) return null;
+
+  return (
+    <>
+      <Script id="google-tag-manager" strategy="afterInteractive">
+        {`
+          (function(w,d,s,l,i){
+            w[l]=w[l]||[];
+            w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});
+            var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),
+              dl=l!='dataLayer'?'&l='+l:'';
+            j.async=true;
+            j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+            f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','${gtmId}');
+        `}
+      </Script>
+      <noscript>
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+          height="0"
+          width="0"
+          style={{ display: "none", visibility: "hidden" }}
+          title="Google Tag Manager"
+        />
+      </noscript>
+    </>
+  );
+}

--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+
+const analyticsPayloadSchema = z.object({
+  eventName: z.string().trim().min(2).max(80),
+  profileId: z.string().uuid().nullable().optional(),
+  sessionId: z.string().trim().max(120).nullable().optional(),
+  city: z.string().trim().max(120).nullable().optional(),
+  state: z.string().trim().max(80).nullable().optional(),
+  sourcePage: z.string().trim().max(120).nullable().optional(),
+  metadata: z.record(z.unknown()).optional().default({}),
+});
+
+function getSupabaseAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) return null;
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown>) {
+  const blockedKeys = new Set(["email", "phone", "phone_number", "address", "full_address", "name", "full_name"]);
+
+  return Object.fromEntries(
+    Object.entries(metadata)
+      .filter(([key]) => !blockedKeys.has(key.toLowerCase()))
+      .slice(0, 50),
+  );
+}
+
+export async function POST(request: Request) {
+  const payload = analyticsPayloadSchema.safeParse(await request.json().catch(() => null));
+
+  if (!payload.success) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  if (!supabase) {
+    return NextResponse.json({ ok: true, skipped: true }, { status: 202 });
+  }
+
+  const headers = request.headers;
+  const userAgent = headers.get("user-agent")?.slice(0, 500) ?? null;
+  const referrer = headers.get("referer")?.slice(0, 500) ?? null;
+
+  const { error } = await supabase.from("analytics_events").insert({
+    event_name: payload.data.eventName,
+    profile_id: payload.data.profileId ?? null,
+    session_id: payload.data.sessionId ?? null,
+    city: payload.data.city ?? null,
+    state: payload.data.state ?? null,
+    source_page: payload.data.sourcePage ?? null,
+    metadata: sanitizeMetadata(payload.data.metadata),
+    user_agent: userAgent,
+    referrer,
+  });
+
+  if (error) {
+    console.error("Analytics event insert failed", error);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { AppMotionShell } from "@/app/_components/app-motion-shell";
+import { GoogleAnalytics } from "@/app/_components/google-analytics";
 import { SiteFooter } from "@/app/_components/site-footer";
 import SiteHeader from "@/app/_components/site-header";
 import { CookieConsent } from "@/app/_components/CookieConsent";
@@ -43,6 +44,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={satoshi.variable}>
       <body className="theme-masseurmatch min-h-screen overflow-x-hidden font-sans text-foreground antialiased">
+        <GoogleAnalytics />
         <AppProviders>
           <SketchFilter />
           <IntroVideoSplash />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { AppMotionShell } from "@/app/_components/app-motion-shell";
 import { GoogleAnalytics } from "@/app/_components/google-analytics";
+import { GoogleTagManager } from "@/app/_components/google-tag-manager";
 import { SiteFooter } from "@/app/_components/site-footer";
 import SiteHeader from "@/app/_components/site-header";
 import { CookieConsent } from "@/app/_components/CookieConsent";
@@ -44,6 +45,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={satoshi.variable}>
       <body className="theme-masseurmatch min-h-screen overflow-x-hidden font-sans text-foreground antialiased">
+        <GoogleTagManager />
         <GoogleAnalytics />
         <AppProviders>
           <SketchFilter />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useState } from "react";
 
+import { AnalyticsPageTracker } from "@/app/_components/analytics-page-tracker";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -46,6 +47,9 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
       <I18nProvider>
         <AuthProvider>
           <TooltipProvider>
+            <React.Suspense fallback={null}>
+              <AnalyticsPageTracker />
+            </React.Suspense>
             {children}
             <Toaster />
             <Sonner />

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,136 @@
+export const ANALYTICS_EVENT_NAMES = [
+  "page_view",
+  "explore_view",
+  "city_page_view",
+  "profile_view",
+  "search_performed",
+  "filter_used",
+  "ai_chat_opened",
+  "ai_chat_question",
+  "contact_click",
+  "phone_call_click",
+  "sms_click",
+  "email_click",
+  "profile_share_click",
+  "favorite_added",
+  "directions_click",
+  "signup_started",
+  "signup_completed",
+  "checkout_started",
+  "checkout_completed",
+  "checkout_failed",
+  "subscription_started",
+  "subscription_upgraded",
+  "boost_purchased",
+  "available_now_started",
+  "featured_profile_clicked",
+  "masseur_of_day_viewed",
+] as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENT_NAMES)[number] | (string & {});
+
+export type AnalyticsPayload = {
+  eventName: AnalyticsEventName;
+  profileId?: string | null;
+  sessionId?: string | null;
+  city?: string | null;
+  state?: string | null;
+  sourcePage?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+declare global {
+  interface Window {
+    gtag?: (command: "event", eventName: string, params?: Record<string, unknown>) => void;
+  }
+}
+
+function compactRecord(record: Record<string, unknown>) {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined && value !== null));
+}
+
+function toGtagParams(payload: AnalyticsPayload) {
+  return compactRecord({
+    profile_id: payload.profileId,
+    session_id: payload.sessionId,
+    city: payload.city,
+    state: payload.state,
+    source_page: payload.sourcePage,
+    ...(payload.metadata ?? {}),
+  });
+}
+
+export async function trackEvent(payload: AnalyticsPayload) {
+  if (typeof window === "undefined") return;
+
+  const normalizedPayload = compactRecord({
+    eventName: payload.eventName,
+    profileId: payload.profileId,
+    sessionId: payload.sessionId,
+    city: payload.city,
+    state: payload.state,
+    sourcePage: payload.sourcePage,
+    metadata: payload.metadata ?? {},
+  }) as AnalyticsPayload;
+
+  try {
+    window.gtag?.("event", payload.eventName, toGtagParams(payload));
+  } catch {
+    // GA4 should never block product flows.
+  }
+
+  try {
+    const body = JSON.stringify(normalizedPayload);
+
+    if (navigator.sendBeacon) {
+      const blob = new Blob([body], { type: "application/json" });
+      const queued = navigator.sendBeacon("/api/analytics/track", blob);
+      if (queued) return;
+    }
+
+    await fetch("/api/analytics/track", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      keepalive: true,
+    });
+  } catch {
+    // Analytics failure must not affect the user experience.
+  }
+}
+
+export function trackProfileView(params: Omit<AnalyticsPayload, "eventName">) {
+  return trackEvent({ ...params, eventName: "profile_view", sourcePage: params.sourcePage ?? "profile" });
+}
+
+export function trackContactClick(params: Omit<AnalyticsPayload, "eventName"> & { contactType: "phone" | "sms" | "email" }) {
+  const eventNameByType = {
+    phone: "phone_call_click",
+    sms: "sms_click",
+    email: "email_click",
+  } as const;
+
+  return trackEvent({
+    ...params,
+    eventName: eventNameByType[params.contactType],
+    metadata: {
+      ...(params.metadata ?? {}),
+      contact_type: params.contactType,
+    },
+  });
+}
+
+export function trackSearchPerformed(params: Omit<AnalyticsPayload, "eventName"> & { searchTerm?: string; filters?: Record<string, unknown> }) {
+  const { searchTerm, filters, metadata, ...rest } = params;
+
+  return trackEvent({
+    ...rest,
+    eventName: "search_performed",
+    sourcePage: rest.sourcePage ?? "explore",
+    metadata: {
+      ...(metadata ?? {}),
+      search_term: searchTerm,
+      filters,
+    },
+  });
+}

--- a/supabase/migrations/20260627000000_add_analytics_events.sql
+++ b/supabase/migrations/20260627000000_add_analytics_events.sql
@@ -1,0 +1,54 @@
+-- MasseurMatch analytics event ledger
+-- Stores privacy-conscious product and conversion events for internal dashboards.
+
+create table if not exists public.analytics_events (
+  id uuid primary key default gen_random_uuid(),
+  event_name text not null,
+  user_id uuid null references auth.users(id) on delete set null,
+  profile_id uuid null,
+  session_id text null,
+  city text null,
+  state text null,
+  source_page text null,
+  metadata jsonb not null default '{}'::jsonb,
+  user_agent text null,
+  referrer text null,
+  created_at timestamptz not null default now(),
+
+  constraint analytics_events_event_name_length check (char_length(event_name) between 2 and 80),
+  constraint analytics_events_source_page_length check (source_page is null or char_length(source_page) <= 120),
+  constraint analytics_events_session_id_length check (session_id is null or char_length(session_id) <= 120),
+  constraint analytics_events_city_length check (city is null or char_length(city) <= 120),
+  constraint analytics_events_state_length check (state is null or char_length(state) <= 80)
+);
+
+create index if not exists analytics_events_event_name_created_at_idx
+  on public.analytics_events (event_name, created_at desc);
+
+create index if not exists analytics_events_profile_created_at_idx
+  on public.analytics_events (profile_id, created_at desc)
+  where profile_id is not null;
+
+create index if not exists analytics_events_user_created_at_idx
+  on public.analytics_events (user_id, created_at desc)
+  where user_id is not null;
+
+create index if not exists analytics_events_city_state_created_at_idx
+  on public.analytics_events (city, state, created_at desc)
+  where city is not null;
+
+create index if not exists analytics_events_metadata_gin_idx
+  on public.analytics_events using gin (metadata);
+
+alter table public.analytics_events enable row level security;
+
+-- Inserts are performed by server-side API routes using the service role key.
+-- Public read access is intentionally blocked; dashboard-specific reads should use
+-- secure server routes or future role-aware policies.
+
+drop policy if exists "analytics_events_no_public_select" on public.analytics_events;
+create policy "analytics_events_no_public_select"
+  on public.analytics_events
+  for select
+  to anon, authenticated
+  using (false);


### PR DESCRIPTION
## Summary

Adds a clean analytics foundation for MasseurMatch based on the tracking model reviewed earlier, without copying the external Google script.

### Added
- `analytics_events` Supabase table with indexes and RLS locked down for public reads
- `/api/analytics/track` server route using the Supabase service role key
- Frontend `trackEvent` helper with GA4 forwarding when `gtag` exists
- Helper methods for profile views, contact clicks, and searches
- Automatic page/explore/profile page-view tracking on route changes
- Optional GA4 loader via `NEXT_PUBLIC_GA_MEASUREMENT_ID`
- Optional Google Tag Manager loader via `NEXT_PUBLIC_GTM_ID`
- GTM noscript fallback iframe inside the root layout
- `.env.example` documentation for GA4 and GTM IDs

### Key events now supported
- `page_view`
- `explore_view`
- `city_page_view`
- `profile_view`
- `search_performed`
- `filter_used`
- `phone_call_click`
- `sms_click`
- `email_click`
- `signup_started`
- `signup_completed`
- `checkout_started`
- `checkout_completed`
- `subscription_upgraded`
- `boost_purchased`
- `available_now_started`

## Required setup after merge

Add this to Vercel Environment Variables:

```env
NEXT_PUBLIC_GTM_ID=GTM-NWQFCM26
```

Optional if using direct GA4 outside GTM:

```env
NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
```

## Notes

The API route sanitizes common PII keys from metadata before writing to Supabase. Analytics failures are intentionally non-blocking so they never break user flows.

## Validation

I could not run the local test suite from this environment because GitHub cloning is unavailable here, but I compared the branch against `main` and confirmed the intended files are changed only.