### PR TITLE
Add Bugsnag error and performance monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=            # [REQUIRED] same as SUPABASE_ANON_KEY
 SUPABASE_SERVICE_ROLE_KEY=                # [REQUIRED] service role key (server-only)
 SITEMAP_SUPABASE_KEY=                     # [OPTIONAL] read-only key for sitemap generation
 
+# ── Monitoring ───────────────────────────────────────────────────────────────
+NEXT_PUBLIC_BUGSNAG_API_KEY=              # [OPTIONAL] browser error + performance monitoring
+
 # ── Session ───────────────────────────────────────────────────────────────────
 # Signs the mm_session cookie. MUST be set in production (≥32 random chars).
 MM_SESSION_SECRET=                        # [REQUIRED in production]

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "audit:fix": "pnpm audit --fix"
   },
   "dependencies": {
+    "@bugsnag/browser-performance": "^2.21.0",
+    "@bugsnag/js": "^8.5.0",
     "@google/generative-ai": "^0.24.1",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.11",

--- a/src/app/_components/bugsnag-client.tsx
+++ b/src/app/_components/bugsnag-client.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { startBugsnag } from "@/lib/bugsnag";
+
+export function BugsnagClient() {
+  useEffect(() => {
+    startBugsnag();
+  }, []);
+
+  return null;
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useState } from "react";
 
+import { BugsnagClient } from "@/app/_components/bugsnag-client";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -46,6 +47,7 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
       <I18nProvider>
         <AuthProvider>
           <TooltipProvider>
+            <BugsnagClient />
             {children}
             <Toaster />
             <Sonner />

--- a/src/lib/bugsnag.ts
+++ b/src/lib/bugsnag.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import Bugsnag from "@bugsnag/js";
+import BugsnagPerformance from "@bugsnag/browser-performance";
+
+let hasStarted = false;
+
+function getReleaseStage() {
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV) return process.env.NEXT_PUBLIC_VERCEL_ENV;
+  return process.env.NODE_ENV === "production" ? "production" : "development";
+}
+
+export function startBugsnag() {
+  if (hasStarted || typeof window === "undefined") return;
+
+  const apiKey = process.env.NEXT_PUBLIC_BUGSNAG_API_KEY;
+
+  if (!apiKey) return;
+
+  const releaseStage = getReleaseStage();
+  const appVersion = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+
+  Bugsnag.start({
+    apiKey,
+    appType: "browser",
+    appVersion,
+    releaseStage,
+    enabledReleaseStages: ["production", "preview"],
+  });
+
+  BugsnagPerformance.start({
+    apiKey,
+    appVersion,
+    releaseStage,
+    enabledReleaseStages: ["production", "preview"],
+  });
+
+  hasStarted = true;
+}
+
+export function notifyBugsnag(error: Error) {
+  if (!hasStarted) startBugsnag();
+  Bugsnag.notify(error);
+}


### PR DESCRIPTION
## Summary

Adds browser-side Bugsnag monitoring for MasseurMatch error reporting and performance data.

### Added
- `@bugsnag/js`
- `@bugsnag/browser-performance`
- `src/lib/bugsnag.ts` helper to start Bugsnag once
- `src/app/_components/bugsnag-client.tsx` to initialize monitoring from the client providers
- `NEXT_PUBLIC_BUGSNAG_API_KEY` documented in `.env.example`

### Behavior
- Starts only in the browser
- Skips initialization if `NEXT_PUBLIC_BUGSNAG_API_KEY` is missing
- Enables reporting only for `production` and `preview`
- Sends `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` as `appVersion` when available
- Exposes `notifyBugsnag(error)` for manual test notifications

## Required setup after merge

Add this to Vercel Environment Variables:

```env
NEXT_PUBLIC_BUGSNAG_API_KEY=8c335db3e2a7da6cf2ce12367eb0c313
```

Then install/update dependencies locally or in CI:

```bash
pnpm install
```

## Validation

I could not regenerate `pnpm-lock.yaml` or run the local suite from this environment because network access to GitHub/npm is unavailable here. I compared the branch against `main` and confirmed only the intended 5 files changed.