### PR TITLE
Refine cookie consent, FAQ, and launch messaging

### DIFF
--- a/src/app/_components/CookieConsent.tsx
+++ b/src/app/_components/CookieConsent.tsx
@@ -2,26 +2,30 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 
 export function CookieConsent() {
   const [show, setShow] = useState(false);
-  const pathname = usePathname();
 
   useEffect(() => {
-    if (pathname === "/") {
-      setShow(false);
-      return;
-    }
-
-    const consent = localStorage.getItem("mm_cookie_consent");
-    if (!consent) {
+    // Show on every page until the visitor records a choice. localStorage is
+    // read on the client only, so the banner never causes an SSR mismatch.
+    try {
+      const consent = localStorage.getItem("mm_cookie_consent");
+      if (!consent) {
+        setShow(true);
+      }
+    } catch {
+      // Private-mode / storage-blocked browsers: surface the banner anyway.
       setShow(true);
     }
-  }, [pathname]);
+  }, []);
 
   const savePreference = (value: "accepted" | "rejected") => {
-    localStorage.setItem("mm_cookie_consent", value);
+    try {
+      localStorage.setItem("mm_cookie_consent", value);
+    } catch {
+      // Ignore storage failures — at minimum dismiss for this session.
+    }
     setShow(false);
   };
 
@@ -41,6 +45,10 @@ export function CookieConsent() {
               experience. Review our{" "}
               <Link href="/cookie-policy" className="font-semibold text-[#111111] underline underline-offset-2 hover:text-[#8B1E2D]">
                 Cookie Policy
+              </Link>{" "}
+              and{" "}
+              <Link href="/privacy" className="font-semibold text-[#111111] underline underline-offset-2 hover:text-[#8B1E2D]">
+                Privacy Policy
               </Link>
               .
             </p>

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -23,7 +23,11 @@ const faqs = [
     items: [
       {
         q: "What is MasseurMatch?",
-        a: "MasseurMatch is a directory platform that connects clients with verified, professional massage therapists across the United States. We specialize in creating a safe, LGBTQ+-inclusive environment where every client feels welcome and respected.",
+        a: "MasseurMatch is an online directory of professional massage therapists across the United States — not a booking or payment platform. We help you discover and compare therapists; you then contact them directly to arrange a session. Our focus is a safe, LGBTQ+-inclusive, strictly professional and non-sexual massage experience where every client feels welcome and respected.",
+      },
+      {
+        q: "Does MasseurMatch handle booking or payments?",
+        a: "No. MasseurMatch is a discovery directory, not a booking platform. We don't schedule appointments, process session payments, or take booking fees. You arrange the session, rate, and any payment directly with the therapist.",
       },
       {
         q: "Is MasseurMatch LGBTQ+-friendly?",
@@ -31,11 +35,15 @@ const faqs = [
       },
       {
         q: "How do I find a massage therapist near me?",
-        a: "Use our search bar to enter your city or ZIP code. You can filter results by massage modality, pricing, availability, and LGBTQ+ certifications. Each profile includes the therapist's services, rates, and availability.",
+        a: "Use our search bar to enter your city or ZIP code. You can filter results by massage modality, pricing, availability, and LGBTQ+-affirming options. Each profile lists the therapist's services, rates, and availability so you can contact them directly.",
       },
       {
         q: "How are therapists reviewed on MasseurMatch?",
-        a: "Profiles go through identity and quality checks before publication. Clients should still confirm service fit, boundaries, and session details directly with each therapist.",
+        a: "Profiles go through an identity and photo review and a basic quality check before publication. MasseurMatch does not verify professional licenses, certifications, or insurance — please confirm a therapist's credentials, service fit, boundaries, and session details directly with them.",
+      },
+      {
+        q: "What do the badges on a profile mean?",
+        a: "An 'Identity Verified' badge means the therapist completed an identity and photo check through Stripe Identity — it confirms who they are. It is not a guarantee of professional licensing, qualifications, or the outcome of any session. Promotional labels such as 'Featured' or 'Boosted' are paid placements and do not imply endorsement or recommendation by MasseurMatch.",
       },
       {
         q: "Is my information private when I search?",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -108,7 +108,7 @@ function isRealProfileId(id: string | null | undefined) {
 }
 
 export default async function HomePage() {
-  // Coming-soon mode — redirect to waitlist until launch (remove after May 7, 2026)
+  // Coming-soon mode — redirect to waitlist until public launch (remove when the directory goes live)
   redirect("/waitlist");
 
   let featuredTherapists: Awaited<ReturnType<typeof getPublicTherapists>>["items"] = [];

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = createPageMetadata({
     "therapist listing signup",
     "get massage clients online",
   ],
+  // Onboarding funnel — keep out of the index alongside /login, /register, and
+  // /forgot-password (robots.txt also disallows /signup).
+  noIndex: true,
 });
 
 export default function SignupLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/waitlist/_components/WaitlistChat.tsx
+++ b/src/app/waitlist/_components/WaitlistChat.tsx
@@ -63,7 +63,7 @@ function sanitize(text: string): string {
 
 function TypingDots() {
   return (
-    <span className="inline-flex items-center gap-1" aria-label="Knotty is typing">
+    <span className="inline-flex items-center gap-1" role="status" aria-label="Knotty is typing">
       {[0, 1, 2].map((i) => (
         <span
           key={i}

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -341,12 +341,12 @@ export default function WaitlistPage() {
               <table className="w-full min-w-[640px] border-collapse text-sm">
                 <thead>
                   <tr>
-                    <th className="w-[32%] pb-4 text-left text-xs font-semibold uppercase tracking-widest text-[#8E8E8E]">Feature</th>
+                    <th className="w-[32%] pb-4 text-left text-xs font-semibold uppercase tracking-widest text-[#6F6F6F]">Feature</th>
                     <th className="w-[23%] pb-4 text-center">
                       <span className="inline-block rounded-full bg-[#8B1E2D] px-3 py-1 text-xs font-bold text-white">MasseurMatch</span>
                     </th>
-                    <th className="w-[22%] pb-4 text-center text-xs font-semibold text-[#8E8E8E]">MasseurFinder</th>
-                    <th className="w-[23%] pb-4 text-center text-xs font-semibold text-[#8E8E8E]">RentMasseur</th>
+                    <th className="w-[22%] pb-4 text-center text-xs font-semibold text-[#6F6F6F]">MasseurFinder</th>
+                    <th className="w-[23%] pb-4 text-center text-xs font-semibold text-[#6F6F6F]">RentMasseur</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-[#E8E8E8]">
@@ -361,7 +361,7 @@ export default function WaitlistPage() {
                       </td>
                       <td className="py-3.5 text-center text-sm text-[#6F6F6F]">
                         {row.mmBetter ? (
-                          <span className="inline-flex items-center gap-1 text-[#8E8E8E]">
+                          <span className="inline-flex items-center gap-1 text-[#6F6F6F]">
                             <X className="h-3.5 w-3.5 text-red-400" strokeWidth={2.5} />
                             {row.masseurfinder}
                           </span>
@@ -371,7 +371,7 @@ export default function WaitlistPage() {
                       </td>
                       <td className="py-3.5 text-center text-sm text-[#6F6F6F]">
                         {row.mmBetter ? (
-                          <span className="inline-flex items-center gap-1 text-[#8E8E8E]">
+                          <span className="inline-flex items-center gap-1 text-[#6F6F6F]">
                             <X className="h-3.5 w-3.5 text-red-400" strokeWidth={2.5} />
                             {row.rentmasseur}
                           </span>
@@ -385,7 +385,7 @@ export default function WaitlistPage() {
               </table>
             </div>
 
-            <p className="mt-6 text-center text-xs text-[#8E8E8E]">
+            <p className="mt-6 text-center text-xs text-[#6F6F6F]">
               Competitor pricing based on publicly available information as of 2026. Features subject to change.
             </p>
           </div>
@@ -505,10 +505,10 @@ export default function WaitlistPage() {
         <div className="border-t border-[#E8E8E8] bg-[#f7f7f7] py-8">
           <div className="mx-auto flex max-w-[1200px] flex-col items-center gap-3 px-4 text-center sm:flex-row sm:justify-between">
             <p className="text-sm font-semibold text-[#111111]">MasseurMatch</p>
-            <p className="text-xs text-[#8E8E8E]">
+            <p className="text-xs text-[#6F6F6F]">
               Launching in Dallas first. More cities coming fast.
             </p>
-            <div className="flex gap-4 text-xs text-[#8E8E8E]">
+            <div className="flex gap-4 text-xs text-[#6F6F6F]">
               <Link href="/privacy" className="hover:text-[#111111] transition-colors">Privacy</Link>
               <Link href="/terms" className="hover:text-[#111111] transition-colors">Terms</Link>
               <Link href="/contact" className="hover:text-[#111111] transition-colors">Contact</Link>

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import {
   BadgeCheck,
   Brain,
+  CalendarClock,
   Check,
   DollarSign,
   Globe,
@@ -90,7 +91,7 @@ const faqJsonLd = {
       name: "When is MasseurMatch launching?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "MasseurMatch launches on May 7, 2026 — starting in Dallas, then expanding to all major US cities. Join the waitlist to get early access.",
+        text: "MasseurMatch is preparing verified early access, starting in Dallas and then expanding to other major US cities. Join the waitlist to be first in line.",
       },
     },
     {
@@ -232,7 +233,7 @@ const faqs = [
   },
   {
     q: "When does MasseurMatch launch?",
-    a: "MasseurMatch launches on May 7, 2026 — starting in Dallas, then expanding fast to New York, Miami, Los Angeles, and every major US city. Join the waitlist to get first access.",
+    a: "We're opening verified early access soon — starting in Dallas, then expanding to New York, Miami, Los Angeles, and other major US cities. Join the waitlist to get first access.",
   },
   {
     q: "Is MasseurMatch free for therapists?",
@@ -277,7 +278,8 @@ export default function WaitlistPage() {
                   Coming soon
                 </p>
                 <span className="inline-flex items-center gap-1.5 rounded-full border border-[#8B1E2D]/40 bg-[#8B1E2D]/10 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-[#8B1E2D]">
-                  🗓 Launching May 7, 2026
+                  <CalendarClock className="h-3 w-3" strokeWidth={2.5} />
+                  Early access opening soon
                 </span>
               </div>
               <h1 className="mt-4 font-display text-[clamp(2.4rem,5.5vw,4.2rem)] font-extrabold leading-[0.95] tracking-tight text-white">


### PR DESCRIPTION
## Summary
Updates cookie consent logic, expands FAQ content with clearer disclaimers, refines launch messaging from a fixed date to "early access opening soon," and adds SEO metadata to the signup funnel.

## Key changes

**Cookie Consent (`CookieConsent.tsx`)**
- Removed pathname-based logic that hid the banner on the homepage; now shows on every page until a choice is recorded
- Added try/catch blocks around localStorage access to gracefully handle private-mode and storage-blocked browsers
- Removed `usePathname` dependency; simplified effect to run once on mount
- Added Privacy Policy link alongside existing Cookie Policy link

**FAQ (`faq/page.tsx`)**
- Clarified that MasseurMatch is a discovery directory, not a booking/payment platform
- Added new FAQ item: "Does MasseurMatch handle booking or payments?" with explicit "No"
- Updated therapist search description to reference "LGBTQ+-affirming options" instead of "certifications"
- Expanded profile review FAQ to explicitly state that MasseurMatch does **not** verify licenses, certifications, or insurance
- Added new FAQ item: "What do the badges on a profile mean?" explaining Identity Verified badge and paid promotional labels

**Waitlist & Launch Messaging (`waitlist/page.tsx`, `page.tsx`)**
- Replaced hardcoded "May 7, 2026" launch date with "early access opening soon" and "verified early access"
- Updated FAQ JSON-LD and visible FAQ to reflect softer, more flexible launch timeline
- Replaced calendar emoji with `CalendarClock` lucide icon (premium icon standard)
- Updated homepage redirect comment to reflect "public launch" rather than specific date

**SEO & Metadata (`signup/layout.tsx`)**
- Added `noIndex: true` to signup layout metadata with explanatory comment about onboarding funnel exclusion (aligns with robots.txt)

## Implementation notes
- All localStorage operations now wrapped in try/catch to handle edge cases (private browsing, storage quota exceeded)
- Cookie banner now appears universally until dismissed, improving UX for all visitors
- FAQ content now includes explicit disclaimers about what MasseurMatch does and does not verify, reducing liability and setting clear expectations
- Launch messaging shifted from a hard date commitment to a softer "early access" narrative, providing flexibility for phased rollout

https://claude.ai/code/session_01EiFtBtgPUNZNcR3eG63y6s