### PR TITLE
Improve KnottyChat accessibility and persistence

### DIFF
--- a/src/app/signup/account/page.tsx
+++ b/src/app/signup/account/page.tsx
@@ -289,6 +289,8 @@ export default function SignupAccountPage() {
                   <Checkbox
                     id="terms"
                     checked={termsChecked}
+                    aria-invalid={!!fieldErrors.terms}
+                    aria-describedby={fieldErrors.terms ? "terms-error" : undefined}
                     onCheckedChange={(v) => {
                       setTermsChecked(v === true);
                       setFieldErrors((prev) => {
@@ -320,6 +322,8 @@ export default function SignupAccountPage() {
                   <Checkbox
                     id="compliance"
                     checked={complianceChecked}
+                    aria-invalid={!!fieldErrors.compliance}
+                    aria-describedby={fieldErrors.compliance ? "compliance-error" : undefined}
                     onCheckedChange={(v) => {
                       setComplianceChecked(v === true);
                       setFieldErrors((prev) => {

--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -47,7 +47,10 @@ function SignupPlanPageContent() {
   }
 
   return (
-    <div className="space-y-8 py-8">
+    // Extra bottom padding keeps the plan buttons clear of the page footer (and
+    // its tel: link) and reserves room for the sticky mobile bar so a tap on a
+    // "Continue" button can never land on the footer phone link below it.
+    <div className="space-y-8 py-8 pb-32 sm:pb-12">
       <Suspense fallback={null}>
         <PreselectFromQuery />
       </Suspense>
@@ -96,8 +99,9 @@ function SignupPlanPageContent() {
                 </ul>
                 <Button
                   variant={plan.popular ? "default" : "outline"}
-                  className="mt-auto"
+                  className="relative z-10 mt-auto min-h-11 w-full"
                   onClick={() => handleSelect(plan.tier)}
+                  aria-label={`Continue with the ${plan.name} plan`}
                 >
                   Continue with {plan.name}
                 </Button>
@@ -107,12 +111,13 @@ function SignupPlanPageContent() {
         })}
       </div>
 
-      {/* Sticky mobile bar */}
+      {/* Sticky mobile bar — sits above the floating chat launcher (z-40) and
+          footer so its CTA is never blocked or tapped through. */}
       {state.selectedPlanTier && (
-        <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 p-4 backdrop-blur sm:hidden">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-semibold text-foreground">
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-[0_-8px_24px_rgba(0,0,0,0.06)] sm:hidden">
+          <div className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-foreground">
                 {SIGNUP_PLANS.find((p) => p.tier === state.selectedPlanTier)?.name}
               </p>
               <p className="text-xs text-muted-foreground">
@@ -121,6 +126,7 @@ function SignupPlanPageContent() {
             </div>
             <Button
               size="sm"
+              className="min-h-11 shrink-0"
               onClick={() => handleSelect(state.selectedPlanTier!)}
             >
               Continue

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowUpRight, Clock3, MapPinned, Send, MessageCircle, ShieldCheck, X } from "lucide-react";
 import { useKnotty } from "@/hooks/useKnotty";
@@ -220,12 +220,44 @@ function KnottyDisclaimer() {
   );
 }
 
+// Persists whether the floating chat is open or closed so the user's choice
+// survives navigation between pages. Once a visitor closes Knotty we never
+// auto-reopen it on subsequent pages.
+const STORAGE_KEY = "knotty-chat-state";
+
 export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) => {
   const isEmbedded = mode === "embedded";
   const [isOpen, setIsOpen] = useState(isEmbedded);
   const { input, isTyping, messages, sendMessage, setInput, trackOpen, trackRecommendationClick } =
     useKnotty();
   const endRef = useRef<HTMLDivElement>(null);
+  const launcherRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const persistState = useCallback(
+    (value: "open" | "closed") => {
+      if (isEmbedded || typeof window === "undefined") return;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, value);
+      } catch {
+        /* localStorage unavailable (private mode / blocked) — ignore */
+      }
+    },
+    [isEmbedded],
+  );
+
+  const openChat = useCallback(() => {
+    setIsOpen(true);
+    persistState("open");
+    trackOpen();
+  }, [persistState, trackOpen]);
+
+  const closeChat = useCallback(() => {
+    setIsOpen(false);
+    persistState("closed");
+    // Return focus to the launcher so keyboard users aren't stranded.
+    requestAnimationFrame(() => launcherRef.current?.focus());
+  }, [persistState]);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -237,23 +269,37 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     }
   }, [isEmbedded, trackOpen]);
 
-  // Auto-open floating chat after 3 seconds on page load.
+  // Decide the initial floating state from the persisted choice. A returning
+  // visitor who closed Knotty stays closed; first-time visitors get a gentle
+  // auto-open after a few seconds.
   useEffect(() => {
     if (isEmbedded) return;
+    let stored: string | null = null;
+    try {
+      stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch {
+      /* ignore */
+    }
+    if (stored === "closed") return;
+    if (stored === "open") {
+      setIsOpen(true);
+      trackOpen();
+      return;
+    }
     const timer = setTimeout(() => {
       setIsOpen(true);
+      persistState("open");
       trackOpen();
     }, 3000);
     return () => clearTimeout(timer);
-  }, [isEmbedded, trackOpen]);
+  }, [isEmbedded, persistState, trackOpen]);
 
   // Allow any part of the app to open the floating chat (optionally with a
   // prefilled prompt) by dispatching a `knotty:open` window event.
   useEffect(() => {
     if (isEmbedded) return;
     const handler = (event: Event) => {
-      setIsOpen(true);
-      trackOpen();
+      openChat();
       const prompt = (event as CustomEvent<{ prompt?: string }>).detail?.prompt;
       if (prompt) {
         void sendMessage({ content: prompt });
@@ -261,7 +307,22 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     };
     window.addEventListener("knotty:open", handler as EventListener);
     return () => window.removeEventListener("knotty:open", handler as EventListener);
-  }, [isEmbedded, trackOpen, sendMessage]);
+  }, [isEmbedded, openChat, sendMessage]);
+
+  // ESC closes the floating chat while it is open; move focus into the panel
+  // when it opens so keyboard/screen-reader users land inside it.
+  useEffect(() => {
+    if (isEmbedded || !isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        closeChat();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    requestAnimationFrame(() => closeButtonRef.current?.focus());
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isEmbedded, isOpen, closeChat]);
 
   const latestAssistantId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -272,6 +333,9 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
 
   const panel = (
     <div
+      role={isEmbedded ? undefined : "dialog"}
+      aria-modal={false}
+      aria-label={isEmbedded ? undefined : "Knotty AI concierge chat"}
       className={cn(
         "relative flex flex-col overflow-hidden rounded-[24px] border border-black/10 bg-white shadow-[0_32px_96px_rgba(15,23,42,0.22)]",
         isEmbedded
@@ -297,10 +361,11 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
         </div>
         {!isEmbedded ? (
           <button
+            ref={closeButtonRef}
             type="button"
-            onClick={() => setIsOpen(false)}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-white/55 transition hover:bg-white/10 hover:text-white"
-            aria-label="Close Knotty chat"
+            onClick={closeChat}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-white/55 transition hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            aria-label="Minimize Knotty chat"
           >
             <X className="h-4 w-4" />
           </button>
@@ -365,22 +430,21 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
   }
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 sm:bottom-6 sm:right-6">
+    <div className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-40 sm:bottom-6 sm:right-6">
       <AnimatePresence mode="wait">
         {!isOpen ? (
           <motion.button
             key="knotty-launcher"
+            ref={launcherRef}
             type="button"
             initial={{ opacity: 0, scale: 0.86 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.86 }}
             transition={{ type: "spring", stiffness: 260, damping: 20 }}
-            onClick={() => {
-              setIsOpen(true);
-              trackOpen();
-            }}
-            className="group relative h-16 w-16 rounded-full border border-white/20 bg-[#8B1E2D] shadow-[0_20px_48px_rgba(139,30,45,0.3)]"
+            onClick={openChat}
+            className="group relative h-14 w-14 rounded-full border border-white/20 bg-[#8B1E2D] shadow-[0_20px_48px_rgba(139,30,45,0.3)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B1E2D]/50 focus-visible:ring-offset-2 sm:h-16 sm:w-16"
             aria-label="Open Knotty chat"
+            aria-expanded={isOpen}
           >
             <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.25),transparent_58%)]" />
             <div className="relative flex h-full w-full items-center justify-center text-white">

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -233,6 +233,19 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
   const endRef = useRef<HTMLDivElement>(null);
   const launcherRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  // Holds the pending first-visit auto-open timer so an explicit open/close can
+  // cancel it — otherwise a late-firing timer could undo a user's close.
+  const autoOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True only when the panel was opened by an explicit user action, so we never
+  // pull focus on an automatic or persisted ("open") page-load open.
+  const userInitiatedOpenRef = useRef(false);
+
+  const clearAutoOpenTimer = useCallback(() => {
+    if (autoOpenTimerRef.current) {
+      clearTimeout(autoOpenTimerRef.current);
+      autoOpenTimerRef.current = null;
+    }
+  }, []);
 
   const persistState = useCallback(
     (value: "open" | "closed") => {
@@ -247,17 +260,21 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
   );
 
   const openChat = useCallback(() => {
+    clearAutoOpenTimer();
+    userInitiatedOpenRef.current = true;
     setIsOpen(true);
     persistState("open");
     trackOpen();
-  }, [persistState, trackOpen]);
+  }, [clearAutoOpenTimer, persistState, trackOpen]);
 
   const closeChat = useCallback(() => {
+    clearAutoOpenTimer();
+    userInitiatedOpenRef.current = false;
     setIsOpen(false);
     persistState("closed");
     // Return focus to the launcher so keyboard users aren't stranded.
     requestAnimationFrame(() => launcherRef.current?.focus());
-  }, [persistState]);
+  }, [clearAutoOpenTimer, persistState]);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -282,17 +299,20 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     }
     if (stored === "closed") return;
     if (stored === "open") {
+      // Persisted open: restore the panel but do NOT mark it user-initiated,
+      // so it won't steal focus on page load.
       setIsOpen(true);
       trackOpen();
       return;
     }
-    const timer = setTimeout(() => {
+    autoOpenTimerRef.current = setTimeout(() => {
+      autoOpenTimerRef.current = null;
       setIsOpen(true);
       persistState("open");
       trackOpen();
     }, 3000);
-    return () => clearTimeout(timer);
-  }, [isEmbedded, persistState, trackOpen]);
+    return () => clearAutoOpenTimer();
+  }, [isEmbedded, persistState, trackOpen, clearAutoOpenTimer]);
 
   // Allow any part of the app to open the floating chat (optionally with a
   // prefilled prompt) by dispatching a `knotty:open` window event.
@@ -309,8 +329,9 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     return () => window.removeEventListener("knotty:open", handler as EventListener);
   }, [isEmbedded, openChat, sendMessage]);
 
-  // ESC closes the floating chat while it is open; move focus into the panel
-  // when it opens so keyboard/screen-reader users land inside it.
+  // ESC closes the floating chat while it is open. Focus only moves into the
+  // panel for explicit user-initiated opens — an automatic or persisted open
+  // must never steal focus from whatever the visitor is doing (e.g. a form).
   useEffect(() => {
     if (isEmbedded || !isOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -320,7 +341,9 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
       }
     };
     window.addEventListener("keydown", handleKeyDown);
-    requestAnimationFrame(() => closeButtonRef.current?.focus());
+    if (userInitiatedOpenRef.current) {
+      requestAnimationFrame(() => closeButtonRef.current?.focus());
+    }
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isEmbedded, isOpen, closeChat]);
 


### PR DESCRIPTION
## Summary
Enhanced the floating Knotty AI chat component with persistent state management, keyboard accessibility, and improved focus handling. Also refined the signup flow's mobile UX to prevent button overlap with the chat launcher and footer.

## Key Changes

### KnottyChat Component (`src/components/ai/KnottyChat.tsx`)
- **State Persistence**: Added localStorage-backed persistence of open/closed state so returning visitors who close Knotty stay closed, while first-time visitors still get the gentle 3-second auto-open
- **Keyboard Navigation**: 
  - ESC key now closes the floating chat
  - Focus automatically moves to the close button when chat opens (for screen reader users)
  - Focus returns to the launcher button when chat closes (prevents keyboard users from being stranded)
- **Accessibility Improvements**:
  - Added `role="dialog"` and `aria-modal` attributes to the chat panel
  - Added `aria-label` and `aria-expanded` to launcher button
  - Enhanced close button with focus ring styling and updated aria-label to "Minimize"
  - Extracted open/close logic into `useCallback` hooks for cleaner event handling
- **Mobile Safe Area**: Updated fixed positioning to respect safe-area insets on notched devices
- **Visual Polish**: Adjusted launcher button size (14×14 on mobile, 16×16 on desktop) and improved focus ring styling

### Signup Plan Page (`src/app/signup/plan/page.tsx`)
- Added bottom padding (`pb-32 sm:pb-12`) to prevent plan buttons from being obscured by the sticky mobile bar or footer
- Increased z-index of plan buttons (`z-10`) to sit above the sticky bar
- Enhanced sticky mobile bar with:
  - Higher z-index (`z-50`) to sit above the chat launcher (`z-40`)
  - Improved shadow and safe-area inset handling
  - Better text truncation and spacing for plan name display
  - Minimum height constraints on buttons for touch targets
- Added descriptive aria-labels to continue buttons

### Signup Account Page (`src/app/signup/account/page.tsx`)
- Added `aria-invalid` and `aria-describedby` attributes to terms and compliance checkboxes for better error state communication to assistive technologies

## Implementation Details
- Used `useCallback` to memoize state persistence and chat control functions, reducing unnecessary re-renders
- Gracefully handles localStorage unavailability (private browsing mode) with try-catch blocks
- Leverages `requestAnimationFrame` for focus management to ensure DOM is ready before focusing
- Maintains backward compatibility with embedded mode (skips persistence logic)

https://claude.ai/code/session_01CFnKPN1squAMakGrt1KSnd