### PR TITLE
Launch readiness: remove waitlist redirect, add bot protection, improve email handling

### DIFF
--- a/src/app/api/contact-footer/route.ts
+++ b/src/app/api/contact-footer/route.ts
@@ -1,51 +1,31 @@
 import { z } from "zod";
-import { envAny, envOptional } from "@/app/api/_lib/env";
+import { errorResponse, json, parseJsonBody } from "@/app/api/_lib/http";
+import { assertRateLimit, sanitizeText } from "@/app/_lib/security";
+import { sendSupportEmail } from "@/app/api/_lib/resend";
 
 const schema = z.object({
-  name: z.string().min(1).max(100).trim(),
-  email: z.string().email().trim(),
-  message: z.string().min(10).max(2000).trim(),
+  name: z.string().min(1).max(100),
+  email: z.string().email().max(254),
+  message: z.string().min(10).max(2000),
+  website: z.string().optional(), // honeypot: must be empty for legitimate submissions
 });
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
-    const data = schema.parse(body);
+    assertRateLimit(request, "contact-footer", { limit: 5, windowMs: 60_000 });
 
-    const apiKey = envOptional(["RESEND_API_KEY"]);
-    if (!apiKey) {
-      console.warn("[contact-footer] RESEND_API_KEY not set — email not sent");
-      return Response.json({ ok: true });
-    }
-
-    const from = envAny(["RESEND_FROM_EMAIL"], "MasseurMatch <onboarding@resend.dev>");
-    const resendRes = await fetch("https://api.resend.com/emails", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        from,
-        to: ["support@masseurmatch.com"],
-        reply_to: data.email,
-        subject: `[Footer Contact] ${data.name}`,
-        text: `Name: ${data.name}\nEmail: ${data.email}\n\n${data.message}`,
-      }),
+    const body = await parseJsonBody(request, schema);
+    if (body.website) return json({ ok: true }); // silently discard bot submissions
+    const delivery = await sendSupportEmail({
+      name: sanitizeText(body.name),
+      email: body.email.trim().toLowerCase(),
+      subject: "Website Contact (Footer Form)",
+      message: sanitizeText(body.message),
+      audience: "other",
     });
 
-    if (!resendRes.ok) {
-      const detail = await resendRes.text().catch(() => "");
-      console.error("[contact-footer] Resend error", resendRes.status, detail);
-      return Response.json({ ok: false, message: "Failed to send email" }, { status: 500 });
-    }
-
-    return Response.json({ ok: true });
-  } catch (err) {
-    if (err instanceof z.ZodError) {
-      return Response.json({ ok: false, errors: err.flatten().fieldErrors }, { status: 422 });
-    }
-    console.error("[contact-footer] Unexpected error", err);
-    return Response.json({ ok: false, message: "Unexpected error" }, { status: 500 });
+    return json({ ok: true, mock: delivery.mock });
+  } catch (error) {
+    return errorResponse(error);
   }
 }

--- a/src/app/api/contact-footer/route.ts
+++ b/src/app/api/contact-footer/route.ts
@@ -12,10 +12,11 @@ const schema = z.object({
 
 export async function POST(request: Request) {
   try {
+    const body = await parseJsonBody(request, schema);
+    if (body.website) return json({ ok: true }); // silently discard bot submissions without consuming rate limit
+
     assertRateLimit(request, "contact-footer", { limit: 5, windowMs: 60_000 });
 
-    const body = await parseJsonBody(request, schema);
-    if (body.website) return json({ ok: true }); // silently discard bot submissions
     const delivery = await sendSupportEmail({
       name: sanitizeText(body.name),
       email: body.email.trim().toLowerCase(),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { JsonLd } from "@/app/_components/json-ld";
 import { Hero } from "@/components/marketing/Hero";
@@ -108,9 +107,6 @@ function isRealProfileId(id: string | null | undefined) {
 }
 
 export default async function HomePage() {
-  // Coming-soon mode — redirect to waitlist until public launch (remove when the directory goes live)
-  redirect("/waitlist");
-
   let featuredTherapists: Awaited<ReturnType<typeof getPublicTherapists>>["items"] = [];
   try {
     // Run both queries in parallel — lgbtq-affirming preferred, broad as fallback

--- a/src/app/therapists/bruno-dallas-tx/page.tsx
+++ b/src/app/therapists/bruno-dallas-tx/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function BrunoDallasTxPage() {
-  redirect("/therapists/bruno-santos");
+  redirect("/therapists");
 }

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -286,9 +286,8 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     }
   }, [isEmbedded, trackOpen]);
 
-  // Decide the initial floating state from the persisted choice. A returning
-  // visitor who closed Knotty stays closed; first-time visitors get a gentle
-  // auto-open after a few seconds.
+  // Restore persisted open state for returning visitors who previously opened the chat.
+  // Do NOT auto-open for new visitors — the chat opens only on explicit user action.
   useEffect(() => {
     if (isEmbedded) return;
     let stored: string | null = null;
@@ -297,22 +296,12 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     } catch {
       /* ignore */
     }
-    if (stored === "closed") return;
     if (stored === "open") {
-      // Persisted open: restore the panel but do NOT mark it user-initiated,
-      // so it won't steal focus on page load.
       setIsOpen(true);
       trackOpen();
-      return;
     }
-    autoOpenTimerRef.current = setTimeout(() => {
-      autoOpenTimerRef.current = null;
-      setIsOpen(true);
-      persistState("open");
-      trackOpen();
-    }, 3000);
-    return () => clearAutoOpenTimer();
-  }, [isEmbedded, persistState, trackOpen, clearAutoOpenTimer]);
+  }, [isEmbedded, trackOpen]);
+
 
   // Allow any part of the app to open the floating chat (optionally with a
   // prefilled prompt) by dispatching a `knotty:open` window event.

--- a/src/components/marketing/HeroClient.tsx
+++ b/src/components/marketing/HeroClient.tsx
@@ -29,7 +29,7 @@ const quickPrompts = [
 const trustItems = [
   { label: "Verified profiles", icon: Check },
   { label: "Secure & private", icon: IconLock },
-  { label: "Trusted reviews", icon: IconShield },
+  { label: "Reviewed before listing", icon: IconShield },
 ];
 
 function TherapistCard({ profile, index }: { profile: PublicTherapist; index: number }) {

--- a/src/components/marketing/SiteFooterTalk.tsx
+++ b/src/components/marketing/SiteFooterTalk.tsx
@@ -13,9 +13,11 @@ export function SiteFooterTalk() {
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setFormState("loading");
     const form = e.currentTarget;
     const data = Object.fromEntries(new FormData(form));
+    // Honeypot: bots fill hidden fields, humans don't
+    if (data.website) return;
+    setFormState("loading");
     try {
       const res = await fetch("/api/contact-footer", {
         method: "POST",
@@ -55,6 +57,15 @@ export function SiteFooterTalk() {
               </div>
             ) : (
               <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+                {/* Honeypot — hidden from humans, filled by bots */}
+                <input
+                  name="website"
+                  type="text"
+                  tabIndex={-1}
+                  aria-hidden="true"
+                  style={{ display: "none" }}
+                  autoComplete="off"
+                />
                 <input
                   name="name"
                   type="text"


### PR DESCRIPTION
## Summary
Prepares the site for public launch by removing the coming-soon waitlist redirect, hardening the contact form against bot submissions, refactoring email handling into reusable utilities, and disabling the auto-open floating chat behavior.

## Key Changes

**Homepage & Routing**
- Remove `redirect("/waitlist")` from `src/app/page.tsx` to enable public access to the homepage
- Update therapist profile redirect (`bruno-dallas-tx`) to point to `/therapists` instead of a specific profile

**Contact Form Bot Protection**
- Add honeypot field (`website`) to footer contact form — hidden from humans, filled by bots
- Client-side validation in `SiteFooterTalk.tsx` silently discards submissions with honeypot filled
- Server-side validation in `contact-footer/route.ts` also silently discards honeypot submissions
- Remove `.trim()` from schema (handled explicitly where needed) and add email max length constraint

**Email & API Refactoring**
- Extract email sending logic into `sendSupportEmail()` utility (imported from `@/app/api/_lib/resend`)
- Consolidate HTTP response handling via `json()` and `errorResponse()` utilities
- Add `parseJsonBody()` for schema validation with centralized error handling
- Implement rate limiting via `assertRateLimit()` (5 requests per 60 seconds)
- Add text sanitization via `sanitizeText()` for name and message fields
- Normalize email (trim + lowercase) before sending
- Update email subject line to "Website Contact (Footer Form)" for clarity

**Chat UX**
- Remove auto-open timer from floating chat (`KnottyChat.tsx`) — chat now opens only on explicit user action or `knotty:open` event dispatch

**Copy & Messaging**
- Update hero trust item from "Trusted reviews" to "Reviewed before listing" (aligns with no-fabricated-claims standard)

## Implementation Details
- Rate limiting and security utilities are now centralized in `@/app/_lib/security`
- HTTP utilities (`json`, `errorResponse`, `parseJsonBody`) centralize response formatting and error handling
- Honeypot pattern follows OWASP best practices: field is invisible, has `tabIndex={-1}`, `aria-hidden="true"`, and `display: none`
- Email delivery now returns a `mock` flag for testing/monitoring purposes

https://claude.ai/code/session_01APRyFphwGUh67kdrFKVzvt