### PR TITLE
fix: pre-launch QA — Knotty widget, cookie banner, signup UX, stale launch date

### DIFF
--- a/src/app/_components/CookieConsent.tsx
+++ b/src/app/_components/CookieConsent.tsx
@@ -4,6 +4,11 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+// In-memory fallback for environments where localStorage throws (Safari
+// private mode, blocked storage). Persists for the lifetime of the page so the
+// banner doesn't reappear on every client-side navigation for those users.
+let inMemoryConsent: string | null = null;
+
 export function CookieConsent() {
   const [show, setShow] = useState(false);
   const pathname = usePathname();
@@ -16,12 +21,12 @@ export function CookieConsent() {
 
     // localStorage access can throw (Safari private mode, blocked storage).
     // Guard it so a thrown read never leaves the banner in an inconsistent
-    // state — default to showing it when we can't confirm a prior choice.
-    let consent: string | null = null;
+    // state, and fall back to the in-memory choice when storage is unavailable.
+    let consent: string | null = inMemoryConsent;
     try {
-      consent = localStorage.getItem("mm_cookie_consent");
+      consent = localStorage.getItem("mm_cookie_consent") ?? inMemoryConsent;
     } catch {
-      consent = null;
+      consent = inMemoryConsent;
     }
     if (!consent) {
       setShow(true);
@@ -29,10 +34,13 @@ export function CookieConsent() {
   }, [pathname]);
 
   const savePreference = (value: "accepted" | "rejected") => {
+    // Always record the choice in memory so it survives client-side navigation
+    // even when the persistent write below fails.
+    inMemoryConsent = value;
     try {
       localStorage.setItem("mm_cookie_consent", value);
     } catch {
-      /* storage unavailable — still honor the choice for this session */
+      /* storage unavailable — honored via the in-memory fallback above */
     }
     setShow(false);
   };

--- a/src/app/_components/CookieConsent.tsx
+++ b/src/app/_components/CookieConsent.tsx
@@ -14,14 +14,26 @@ export function CookieConsent() {
       return;
     }
 
-    const consent = localStorage.getItem("mm_cookie_consent");
+    // localStorage access can throw (Safari private mode, blocked storage).
+    // Guard it so a thrown read never leaves the banner in an inconsistent
+    // state — default to showing it when we can't confirm a prior choice.
+    let consent: string | null = null;
+    try {
+      consent = localStorage.getItem("mm_cookie_consent");
+    } catch {
+      consent = null;
+    }
     if (!consent) {
       setShow(true);
     }
   }, [pathname]);
 
   const savePreference = (value: "accepted" | "rejected") => {
-    localStorage.setItem("mm_cookie_consent", value);
+    try {
+      localStorage.setItem("mm_cookie_consent", value);
+    } catch {
+      /* storage unavailable — still honor the choice for this session */
+    }
     setShow(false);
   };
 
@@ -29,7 +41,7 @@ export function CookieConsent() {
 
   return (
     <div
-      className="fixed bottom-3 left-3 right-3 z-50 sm:bottom-4 sm:left-4 sm:right-auto sm:max-w-sm"
+      className="fixed bottom-24 left-3 right-3 z-50 sm:bottom-4 sm:left-4 sm:right-auto sm:max-w-sm"
       aria-live="polite"
     >
       <div className="max-h-[46vh] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4 shadow-2xl shadow-slate-950/20">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -108,7 +108,7 @@ function isRealProfileId(id: string | null | undefined) {
 }
 
 export default async function HomePage() {
-  // Coming-soon mode — redirect to waitlist until launch (remove after May 7, 2026)
+  // Coming-soon mode — redirect to waitlist until launch (remove this redirect to go live)
   redirect("/waitlist");
 
   let featuredTherapists: Awaited<ReturnType<typeof getPublicTherapists>>["items"] = [];

--- a/src/app/signup/account/page.tsx
+++ b/src/app/signup/account/page.tsx
@@ -289,6 +289,9 @@ export default function SignupAccountPage() {
                   <Checkbox
                     id="terms"
                     checked={termsChecked}
+                    aria-invalid={!!fieldErrors.terms}
+                    aria-describedby={fieldErrors.terms ? "terms-error" : undefined}
+                    className={fieldErrors.terms ? "border-destructive ring-2 ring-destructive/30" : undefined}
                     onCheckedChange={(v) => {
                       setTermsChecked(v === true);
                       setFieldErrors((prev) => {
@@ -320,6 +323,9 @@ export default function SignupAccountPage() {
                   <Checkbox
                     id="compliance"
                     checked={complianceChecked}
+                    aria-invalid={!!fieldErrors.compliance}
+                    aria-describedby={fieldErrors.compliance ? "compliance-error" : undefined}
+                    className={fieldErrors.compliance ? "border-destructive ring-2 ring-destructive/30" : undefined}
                     onCheckedChange={(v) => {
                       setComplianceChecked(v === true);
                       setFieldErrors((prev) => {

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -7,6 +7,8 @@ export const metadata: Metadata = createPageMetadata({
   description:
     "Create your professional profile on MasseurMatch, verify your identity, and start getting discovered by clients near you.",
   path: "/signup",
+  // Account-creation funnel — disallowed in robots.txt; keep it out of the index too.
+  noIndex: true,
   keywords: [
     "massage therapist sign up",
     "get listed as a massage therapist",

--- a/src/app/signup/plan/page.tsx
+++ b/src/app/signup/plan/page.tsx
@@ -47,7 +47,7 @@ function SignupPlanPageContent() {
   }
 
   return (
-    <div className="space-y-8 py-8">
+    <div className="space-y-8 py-8 pb-28 sm:pb-12">
       <Suspense fallback={null}>
         <PreselectFromQuery />
       </Suspense>

--- a/src/app/waitlist/_components/WaitlistChat.tsx
+++ b/src/app/waitlist/_components/WaitlistChat.tsx
@@ -99,7 +99,7 @@ function StepProgress({ current }: { current: Step }) {
                 ? "bg-emerald-400 text-slate-950"
                 : i === doneIdx
                   ? "bg-[#8B1E2D] text-white"
-                  : "bg-white/10 text-white/40",
+                  : "bg-white/10 text-white/55",
             ].join(" ")}
           >
             {i < doneIdx ? "✓" : i + 1}
@@ -111,7 +111,7 @@ function StepProgress({ current }: { current: Step }) {
                 ? "text-emerald-400"
                 : i === doneIdx
                   ? "text-white"
-                  : "text-white/30",
+                  : "text-white/55",
             ].join(" ")}
           >
             {STEP_LABELS[s]}
@@ -272,7 +272,7 @@ export function WaitlistChat() {
           </div>
           <div>
             <p className="text-sm font-semibold text-white">Knotty</p>
-            <p className="text-[10px] text-white/40 tracking-wide">MasseurMatch AI · Waitlist</p>
+            <p className="text-[10px] text-white/55 tracking-wide">MasseurMatch AI · Waitlist</p>
           </div>
           {isDone && (
             <span className="ml-auto inline-flex items-center gap-1.5 rounded-full bg-emerald-400/10 px-2.5 py-1 text-[10px] font-semibold text-emerald-400">
@@ -331,7 +331,7 @@ export function WaitlistChat() {
           <div className="flex items-center gap-2 rounded-[1.2rem] border border-white/10 bg-white/5 px-4 py-2.5 focus-within:border-[#8B1E2D]/60 transition-colors">
             <input
               ref={inputRef}
-              className="flex-1 bg-transparent text-sm text-white placeholder:text-white/30 outline-none"
+              className="flex-1 bg-transparent text-sm text-white placeholder:text-white/55 outline-none"
               placeholder={placeholder}
               value={input}
               onChange={(e) => setInput(e.target.value)}

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -341,12 +341,12 @@ export default function WaitlistPage() {
               <table className="w-full min-w-[640px] border-collapse text-sm">
                 <thead>
                   <tr>
-                    <th className="w-[32%] pb-4 text-left text-xs font-semibold uppercase tracking-widest text-[#8E8E8E]">Feature</th>
+                    <th className="w-[32%] pb-4 text-left text-xs font-semibold uppercase tracking-widest text-[#6F6F6F]">Feature</th>
                     <th className="w-[23%] pb-4 text-center">
                       <span className="inline-block rounded-full bg-[#8B1E2D] px-3 py-1 text-xs font-bold text-white">MasseurMatch</span>
                     </th>
-                    <th className="w-[22%] pb-4 text-center text-xs font-semibold text-[#8E8E8E]">MasseurFinder</th>
-                    <th className="w-[23%] pb-4 text-center text-xs font-semibold text-[#8E8E8E]">RentMasseur</th>
+                    <th className="w-[22%] pb-4 text-center text-xs font-semibold text-[#6F6F6F]">MasseurFinder</th>
+                    <th className="w-[23%] pb-4 text-center text-xs font-semibold text-[#6F6F6F]">RentMasseur</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-[#E8E8E8]">
@@ -361,7 +361,7 @@ export default function WaitlistPage() {
                       </td>
                       <td className="py-3.5 text-center text-sm text-[#6F6F6F]">
                         {row.mmBetter ? (
-                          <span className="inline-flex items-center gap-1 text-[#8E8E8E]">
+                          <span className="inline-flex items-center gap-1 text-[#6F6F6F]">
                             <X className="h-3.5 w-3.5 text-red-400" strokeWidth={2.5} />
                             {row.masseurfinder}
                           </span>
@@ -371,7 +371,7 @@ export default function WaitlistPage() {
                       </td>
                       <td className="py-3.5 text-center text-sm text-[#6F6F6F]">
                         {row.mmBetter ? (
-                          <span className="inline-flex items-center gap-1 text-[#8E8E8E]">
+                          <span className="inline-flex items-center gap-1 text-[#6F6F6F]">
                             <X className="h-3.5 w-3.5 text-red-400" strokeWidth={2.5} />
                             {row.rentmasseur}
                           </span>
@@ -385,7 +385,7 @@ export default function WaitlistPage() {
               </table>
             </div>
 
-            <p className="mt-6 text-center text-xs text-[#8E8E8E]">
+            <p className="mt-6 text-center text-xs text-[#6F6F6F]">
               Competitor pricing based on publicly available information as of 2026. Features subject to change.
             </p>
           </div>
@@ -505,10 +505,10 @@ export default function WaitlistPage() {
         <div className="border-t border-[#E8E8E8] bg-[#f7f7f7] py-8">
           <div className="mx-auto flex max-w-[1200px] flex-col items-center gap-3 px-4 text-center sm:flex-row sm:justify-between">
             <p className="text-sm font-semibold text-[#111111]">MasseurMatch</p>
-            <p className="text-xs text-[#8E8E8E]">
+            <p className="text-xs text-[#6F6F6F]">
               Launching in Dallas first. More cities coming fast.
             </p>
-            <div className="flex gap-4 text-xs text-[#8E8E8E]">
+            <div className="flex gap-4 text-xs text-[#6F6F6F]">
               <Link href="/privacy" className="hover:text-[#111111] transition-colors">Privacy</Link>
               <Link href="/terms" className="hover:text-[#111111] transition-colors">Terms</Link>
               <Link href="/contact" className="hover:text-[#111111] transition-colors">Contact</Link>

--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import {
   BadgeCheck,
   Brain,
+  CalendarClock,
   Check,
   DollarSign,
   Globe,
@@ -90,7 +91,7 @@ const faqJsonLd = {
       name: "When is MasseurMatch launching?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "MasseurMatch launches on May 7, 2026 — starting in Dallas, then expanding to all major US cities. Join the waitlist to get early access.",
+        text: "MasseurMatch is launching soon — starting in Dallas, then expanding to all major US cities. Join the waitlist to get early access.",
       },
     },
     {
@@ -232,7 +233,7 @@ const faqs = [
   },
   {
     q: "When does MasseurMatch launch?",
-    a: "MasseurMatch launches on May 7, 2026 — starting in Dallas, then expanding fast to New York, Miami, Los Angeles, and every major US city. Join the waitlist to get first access.",
+    a: "MasseurMatch is launching soon — starting in Dallas, then expanding fast to New York, Miami, Los Angeles, and every major US city. Join the waitlist to get first access.",
   },
   {
     q: "Is MasseurMatch free for therapists?",
@@ -277,7 +278,8 @@ export default function WaitlistPage() {
                   Coming soon
                 </p>
                 <span className="inline-flex items-center gap-1.5 rounded-full border border-[#8B1E2D]/40 bg-[#8B1E2D]/10 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-[#8B1E2D]">
-                  🗓 Launching May 7, 2026
+                  <CalendarClock className="h-3 w-3" strokeWidth={2.5} aria-hidden="true" />
+                  Launching in Dallas first
                 </span>
               </div>
               <h1 className="mt-4 font-display text-[clamp(2.4rem,5.5vw,4.2rem)] font-extrabold leading-[0.95] tracking-tight text-white">

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowUpRight, Clock3, MapPinned, Send, MessageCircle, ShieldCheck, X } from "lucide-react";
 import { useKnotty } from "@/hooks/useKnotty";
@@ -220,12 +221,51 @@ function KnottyDisclaimer() {
   );
 }
 
+// Routes where the floating concierge should NOT render at all — focused app
+// surfaces (provider dashboard, admin) own their own chrome.
+const HIDDEN_ROUTE_PREFIXES = ["/pro", "/admin"];
+
+// Routes where the chat must never auto-open: it would cover primary form
+// fields, CTAs, or results. The user can still open it manually.
+const NO_AUTO_OPEN_PREFIXES = [
+  "/signup",
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password",
+  "/pricing",
+  "/search",
+  "/checkout",
+  "/verification",
+];
+
+const DISMISS_STORAGE_KEY = "mm_knotty_dismissed";
+
+function matchesPrefix(pathname: string | null, prefixes: string[]): boolean {
+  if (!pathname) return false;
+  return prefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
 export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) => {
   const isEmbedded = mode === "embedded";
+  const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(isEmbedded);
   const { input, isTyping, messages, sendMessage, setInput, trackOpen, trackRecommendationClick } =
     useKnotty();
   const endRef = useRef<HTMLDivElement>(null);
+
+  const isHiddenRoute = !isEmbedded && matchesPrefix(pathname, HIDDEN_ROUTE_PREFIXES);
+
+  // Close = minimize and remember the choice for the rest of the session so the
+  // auto-open timer never re-covers content after the user dismissed it.
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    try {
+      window.sessionStorage.setItem(DISMISS_STORAGE_KEY, "1");
+    } catch {
+      /* storage unavailable — best effort */
+    }
+  }, []);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -237,23 +277,40 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
     }
   }, [isEmbedded, trackOpen]);
 
-  // Auto-open floating chat after 3 seconds on page load.
+  // Auto-open floating chat after a short delay — but only when the user hasn't
+  // already dismissed it this session and the current route isn't one where the
+  // panel would obscure important content (signup, login, pricing, search, …).
   useEffect(() => {
-    if (isEmbedded) return;
+    if (isEmbedded || isHiddenRoute) return;
+    if (matchesPrefix(pathname, NO_AUTO_OPEN_PREFIXES)) return;
+    let dismissed = false;
+    try {
+      dismissed = window.sessionStorage.getItem(DISMISS_STORAGE_KEY) === "1";
+    } catch {
+      /* storage unavailable — proceed with default behavior */
+    }
+    if (dismissed) return;
+
     const timer = setTimeout(() => {
       setIsOpen(true);
       trackOpen();
-    }, 3000);
+    }, 4000);
     return () => clearTimeout(timer);
-  }, [isEmbedded, trackOpen]);
+  }, [isEmbedded, isHiddenRoute, pathname, trackOpen]);
 
   // Allow any part of the app to open the floating chat (optionally with a
-  // prefilled prompt) by dispatching a `knotty:open` window event.
+  // prefilled prompt) by dispatching a `knotty:open` window event. Explicit
+  // intent clears the dismissed flag.
   useEffect(() => {
     if (isEmbedded) return;
     const handler = (event: Event) => {
       setIsOpen(true);
       trackOpen();
+      try {
+        window.sessionStorage.removeItem(DISMISS_STORAGE_KEY);
+      } catch {
+        /* storage unavailable */
+      }
       const prompt = (event as CustomEvent<{ prompt?: string }>).detail?.prompt;
       if (prompt) {
         void sendMessage({ content: prompt });
@@ -298,9 +355,9 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
         {!isEmbedded ? (
           <button
             type="button"
-            onClick={() => setIsOpen(false)}
+            onClick={handleClose}
             className="flex h-8 w-8 items-center justify-center rounded-full text-white/55 transition hover:bg-white/10 hover:text-white"
-            aria-label="Close Knotty chat"
+            aria-label="Minimize Knotty chat"
           >
             <X className="h-4 w-4" />
           </button>
@@ -362,6 +419,11 @@ export const KnottyChat = ({ mode = "floating", className }: KnottyChatProps) =>
 
   if (isEmbedded) {
     return panel;
+  }
+
+  // Don't render the floating concierge on focused app surfaces.
+  if (isHiddenRoute) {
+    return null;
   }
 
   return (

--- a/src/components/ai/KnottyChat.tsx
+++ b/src/components/ai/KnottyChat.tsx
@@ -231,6 +231,7 @@ const NO_AUTO_OPEN_PREFIXES = [
   "/signup",
   "/login",
   "/register",
+  "/auth",
   "/forgot-password",
   "/reset-password",
   "/pricing",


### PR DESCRIPTION
## Summary

Addresses the critical bugs from the manual pre-launch audit. Read-before-change, no routes removed, no functional regressions. Validated locally with **typecheck ✓, eslint ✓, `next build` ✓, and 117 unit tests ✓**.

## Findings fixed

| # | Finding | Fix |
|---|---------|-----|
| 1, 2 | Knotty AI widget covers content & doesn't minimize properly | Closing now **persists per session** (`sessionStorage`) so the auto-open timer never re-covers content; no longer auto-opens on `/signup`, `/login`, `/register`, `/pricing`, `/search`, `/checkout`, `/verification`, or auth pages; **hidden entirely** on `/pro` and `/admin`. Close button relabeled "Minimize"; auto-open delay raised 3s → 4s. |
| 3 | "Continue" CTA on `/signup/plan` too close to footer `tel:` link | Added bottom clearance (`pb-28` mobile) so the plan CTAs / mobile sticky bar no longer crowd the footer phone link. |
| 4–6 | Signup form validation / Confirm Password / checkbox feedback | Inline field validation was already solid; reinforced the **Terms** and **Therapist Agreement** checkboxes with a visible destructive border/ring plus `aria-invalid` / `aria-describedby` when missing. |
| 7 | Home/waitlist still showed past "Launching May 7, 2026" | Removed the past date from the hero badge and FAQ/JSON-LD in favor of neutral "launching soon / Dallas first" copy; replaced the 🗓 emoji with a lucide `CalendarClock` icon (per design standards — no emoji icons). |
| 8 | Cookie banner appears inconsistently | Guarded `localStorage` reads/writes against private-mode throws (root cause); lifted the banner above the chat launcher on mobile so they no longer collide. |
| 9 | Private pages indexable | Signup funnel is now `noindex` (already disallowed in `robots.txt`); confirmed login / forgot-password / reset-password already noindex and that robots/sitemap exclude admin, api, pro, dashboard, and private profile slugs. |
| 10 | Security headers | Audited — CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and HSTS already configured in `next.config.mjs`. No change needed. |

## Files changed

- `src/components/ai/KnottyChat.tsx` — route-aware auto-open, session-persisted dismissal, hidden on app surfaces
- `src/app/_components/CookieConsent.tsx` — storage guards + mobile positioning
- `src/app/signup/plan/page.tsx` — footer clearance
- `src/app/signup/account/page.tsx` — checkbox error styling + ARIA
- `src/app/signup/layout.tsx` — noindex
- `src/app/waitlist/page.tsx` — launch-date copy + icon
- `src/app/page.tsx` — stale comment

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm eslint` (changed files)
- [x] `pnpm build`
- [x] `pnpm test:unit` (117 passing)
- [ ] Manual QA on preview: confirm Knotty stays minimized after close + across nav, doesn't auto-open on signup/login/pricing/search, cookie banner shows once and doesn't overlap chat, signup checkbox errors visible.

> Note: launch-date copy is intentionally neutral since no new confirmed date exists — happy to swap in an exact date when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6Z6LsjuNTowzRoHxwRXUB)_