### PR TITLE
fix: waitlist chat a11y contrast + cookie consent storage fallback

### DIFF
--- a/src/app/_components/CookieConsent.tsx
+++ b/src/app/_components/CookieConsent.tsx
@@ -3,6 +3,11 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 
+// In-memory fallback for browsers where localStorage throws (Safari private
+// mode, blocked storage). Persists for the page's lifetime so a recorded
+// choice survives client-side navigation instead of re-showing the banner.
+let inMemoryConsent: string | null = null;
+
 export function CookieConsent() {
   const [show, setShow] = useState(false);
 
@@ -10,21 +15,27 @@ export function CookieConsent() {
     // Show on every page until the visitor records a choice. localStorage is
     // read on the client only, so the banner never causes an SSR mismatch.
     try {
-      const consent = localStorage.getItem("mm_cookie_consent");
+      const consent = localStorage.getItem("mm_cookie_consent") ?? inMemoryConsent;
       if (!consent) {
         setShow(true);
       }
     } catch {
-      // Private-mode / storage-blocked browsers: surface the banner anyway.
-      setShow(true);
+      // Private-mode / storage-blocked browsers: fall back to the in-memory
+      // choice and only surface the banner if none was recorded this session.
+      if (!inMemoryConsent) {
+        setShow(true);
+      }
     }
   }, []);
 
   const savePreference = (value: "accepted" | "rejected") => {
+    // Record in memory first so the choice is honored even when the persistent
+    // write below fails (otherwise the banner reappears on every navigation).
+    inMemoryConsent = value;
     try {
       localStorage.setItem("mm_cookie_consent", value);
     } catch {
-      // Ignore storage failures — at minimum dismiss for this session.
+      // Ignore storage failures — the in-memory fallback above still applies.
     }
     setShow(false);
   };
@@ -33,7 +44,7 @@ export function CookieConsent() {
 
   return (
     <div
-      className="fixed bottom-3 left-3 right-3 z-50 sm:bottom-4 sm:left-4 sm:right-auto sm:max-w-sm"
+      className="fixed bottom-24 left-3 right-3 z-50 sm:bottom-4 sm:left-4 sm:right-auto sm:max-w-sm"
       aria-live="polite"
     >
       <div className="max-h-[46vh] overflow-y-auto rounded-xl border border-slate-200 bg-white p-4 shadow-2xl shadow-slate-950/20">

--- a/src/app/waitlist/_components/WaitlistChat.tsx
+++ b/src/app/waitlist/_components/WaitlistChat.tsx
@@ -99,7 +99,7 @@ function StepProgress({ current }: { current: Step }) {
                 ? "bg-emerald-400 text-slate-950"
                 : i === doneIdx
                   ? "bg-[#8B1E2D] text-white"
-                  : "bg-white/10 text-white/40",
+                  : "bg-white/10 text-white/55",
             ].join(" ")}
           >
             {i < doneIdx ? "✓" : i + 1}
@@ -111,7 +111,7 @@ function StepProgress({ current }: { current: Step }) {
                 ? "text-emerald-400"
                 : i === doneIdx
                   ? "text-white"
-                  : "text-white/30",
+                  : "text-white/55",
             ].join(" ")}
           >
             {STEP_LABELS[s]}
@@ -272,7 +272,7 @@ export function WaitlistChat() {
           </div>
           <div>
             <p className="text-sm font-semibold text-white">Knotty</p>
-            <p className="text-[10px] text-white/40 tracking-wide">MasseurMatch AI · Waitlist</p>
+            <p className="text-[10px] text-white/55 tracking-wide">MasseurMatch AI · Waitlist</p>
           </div>
           {isDone && (
             <span className="ml-auto inline-flex items-center gap-1.5 rounded-full bg-emerald-400/10 px-2.5 py-1 text-[10px] font-semibold text-emerald-400">
@@ -331,7 +331,7 @@ export function WaitlistChat() {
           <div className="flex items-center gap-2 rounded-[1.2rem] border border-white/10 bg-white/5 px-4 py-2.5 focus-within:border-[#8B1E2D]/60 transition-colors">
             <input
               ref={inputRef}
-              className="flex-1 bg-transparent text-sm text-white placeholder:text-white/30 outline-none"
+              className="flex-1 bg-transparent text-sm text-white placeholder:text-white/55 outline-none"
               placeholder={placeholder}
               value={input}
               onChange={(e) => setInput(e.target.value)}


### PR DESCRIPTION
## Summary

Follow-up to the pre-launch audit. The bulk of that audit landed via #476/#477/#478; **#479 was closed as superseded** because it conflicted and would have re-introduced Knotty auto-open. This PR carries only the genuinely net-new items that current `main` is still missing, rebuilt cleanly on top of `main`.

## Changes

**WaitlistChat — WCAG 2.1 AA color contrast** (`src/app/waitlist/_components/WaitlistChat.tsx`)
- Bumps the muted step labels, the "MasseurMatch AI · Waitlist" header caption, and the input placeholder from `white/30–40` → `white/55` so they clear the 4.5:1 contrast ratio on the dark chat panel. (The comparison-table `#8E8E8E` contrast was already fixed on `main`.)

**CookieConsent** (`src/app/_components/CookieConsent.tsx`)
- Adds a module-level **in-memory fallback** for the accept/reject choice, written before the `localStorage` write. In private-mode / storage-blocked browsers the write throws, and without this the banner reappeared on every client-side navigation; now the choice is honored for the session. (Addresses a Codex P2 raised on the closed PR.)
- Lifts the banner above the floating chat launcher on mobile (`bottom-3` → `bottom-24`) so the two no longer overlap on small screens.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm eslint` (changed files)
- [x] `pnpm build`
- [ ] Preview QA: chat labels readable on the dark panel; cookie banner shows once, doesn't overlap the chat launcher on mobile, and doesn't re-appear after choosing in a storage-blocked browser.

> Note: the `Accessibility` / `E2E` CI jobs run Playwright against **production** (`vars.PLAYWRIGHT_BASE_URL`), so they validate the live site rather than this branch — they'll reflect these fixes only after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6Z6LsjuNTowzRoHxwRXUB)_