### PR TITLE
Redirect renamed founder profile slug to the display-name URL

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -64,6 +64,8 @@ const LEGACY_REDIRECTS = [
   // infinite 308 loop. Capitalized variants are handled safely by the
   // case-sensitive (===) guards in src/middleware.ts instead.
   { source: "/massage-therapists", destination: "/therapists", permanent: true },
+  // Profile slug renamed from the account name to the display name.
+  { source: "/therapists/gleicimar-hall-3890ba48", destination: "/therapists/bruno-3890ba48", permanent: true },
   // Privacy policy alias — some external links use the longer form
   { source: "/privacy-policy", destination: "/privacy", permanent: true },
   // Legacy therapist profile URL — canonical is /therapists/:slug

--- a/src/app/_lib/redirects-manifest.ts
+++ b/src/app/_lib/redirects-manifest.ts
@@ -66,6 +66,8 @@ export const legacyRedirects: LegacyRedirect[] = [
   // loop infinitely; capitalized variants are handled by case-sensitive guards
   // in src/middleware.ts instead.
   { source: "/massage-therapists", destination: "/therapists", permanent: true },
+  // Profile slug renamed from the account name to the display name.
+  { source: "/therapists/gleicimar-hall-3890ba48", destination: "/therapists/bruno-3890ba48", permanent: true },
   { source: "/home-1-search-form", destination: "/search", permanent: true },
   { source: "/cookies", destination: "/cookie-policy", permanent: true },
 ];


### PR DESCRIPTION
The founder profile slug changed in production from `gleicimar-hall-3890ba48` (account name) to `bruno-3890ba48` (display name). This adds a permanent (308) redirect for the previously published URL in both `next.config.mjs` and its mirror `src/app/_lib/redirects-manifest.ts`, so old links and any indexed copies keep resolving.

Validation: 126 unit tests + 8 API smoke checks pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LycK6MeBM4psNTxFpks1o4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LycK6MeBM4psNTxFpks1o4)_