### PR TITLE
Hide the Knotty launcher on admin and provider app surfaces

### DIFF
--- a/src/app/_components/chat-widget.tsx
+++ b/src/app/_components/chat-widget.tsx
@@ -1,7 +1,18 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { KnottyChat } from "@/components/ai/KnottyChat";
 
+// Knotty is the visitor-facing concierge. Keep it off the admin and provider
+// app surfaces, where the floating launcher covers dashboard controls and a
+// consumer chat makes no sense. /pro/join stays eligible because it is a
+// public marketing page, not part of the provider dashboard.
 export function ChatWidget() {
+  const pathname = usePathname() ?? "";
+  const isAppSurface =
+    pathname.startsWith("/admin") ||
+    (pathname.startsWith("/pro") && !pathname.startsWith("/pro/join"));
+
+  if (isAppSurface) return null;
   return <KnottyChat mode="floating" />;
 }


### PR DESCRIPTION
Restores the one remaining fix from the closed pre-launch QA PR #479.

## What
The floating Knotty concierge mounted on every route, covering dashboard controls in `/admin` and `/pro` — surfaces where a visitor-facing chat makes no sense. `ChatWidget` now returns `null` there. `/pro/join` stays eligible because it is a public marketing page.

## Why the rest of #479 is not needed
Item-by-item audit against current `main`: cookie-banner storage guards ✅ already landed, signup `noindex` ✅ present, stale "May 7, 2026" copy ✅ already removed, close-persistence ✅ implemented (better: full open/closed persistence). The aggressive first-visit auto-open that #479 route-gated no longer exists — the chat only reopens when the visitor previously left it open.

## Verification
126 unit tests + 8 API smoke checks pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LycK6MeBM4psNTxFpks1o4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LycK6MeBM4psNTxFpks1o4)_