### PR TITLE
Send signed-out visitors on /pro/join to the recruitment page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -365,6 +365,13 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   }
 
   // ── 9. Auth guards ────────────────────────────────────────────────────────
+  // /pro/join is the therapist entry point: signed-out visitors go to the
+  // public recruitment page instead of hitting a login wall, while providers
+  // who are already signed in fall through to the portal hub below.
+  if (pathname === "/pro/join" && !session) {
+    return NextResponse.redirect(new URL("/for-therapists", request.url));
+  }
+
   if (pathname === "/pro" || pathname.startsWith("/pro/")) {
     if (!session) {
       const loginUrl = new URL("/login", request.url);


### PR DESCRIPTION
`/pro/join` is a portal hub for signed-in providers (links to Onboard / Dashboard / Billing), but anonymous visitors following that path hit a login wall — a dead end for the therapist recruitment funnel. The middleware now sends signed-out visitors on `/pro/join` to the public `/for-therapists` recruitment page ("List Your Massage Practice"); signed-in providers keep reaching the portal hub unchanged.

Validation: 126 unit tests + 8 API smoke checks pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LycK6MeBM4psNTxFpks1o4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LycK6MeBM4psNTxFpks1o4)_