### PR TITLE
Fix main CI/Vercel build failures, profile data-wipe bug, and directory visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-router-dom": "^7.18.0",
     "recharts": "^3.8.1",
     "resend": "^6.9.4",
+    "server-only": "0.0.1",
     "sonner": "^1.7.4",
     "stripe": "^18.3.0",
     "tailwind-merge": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       resend:
         specifier: ^6.9.4
         version: 6.9.4(@react-email/render@2.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
       sonner:
         specifier: ^1.7.4
         version: 1.7.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4580,6 +4583,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -9486,6 +9492,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   set-cookie-parser@2.7.2: {}
 

--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -1,11 +1,43 @@
 import "server-only";
 
+import { createClient as createSupabaseJsClient } from "@supabase/supabase-js";
+
 import { US_CITIES } from "@/data/cities";
 import { matchBodyTypeKeyword } from "@/lib/physical-profile";
 import { FALLBACK_PUBLIC_THERAPISTS } from "@/app/_lib/directory-fallback";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+import {
+  SUPABASE_PUBLIC_ANON_KEY,
+  SUPABASE_PUBLIC_URL,
+} from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 
-const supabase = createSupabaseAdminClient();
+// Lazily created so importing this module never throws. Eager creation dies
+// with "SUPABASE_URL is not configured" wherever the env isn't present —
+// vitest, and Next's build-time page-data collection — before any query
+// actually runs. When the service-role env is missing entirely (env-less CI
+// builds, sitemap prerender), public directory reads fall back to the anon
+// key: everything this module serves is public data governed by RLS anyway.
+type AdminClient = ReturnType<typeof createSupabaseAdminClient>;
+let cachedDirectoryClient: AdminClient | null = null;
+
+function createDirectoryClient(): AdminClient {
+  try {
+    return createSupabaseAdminClient();
+  } catch {
+    return createSupabaseJsClient<Database>(SUPABASE_PUBLIC_URL, SUPABASE_PUBLIC_ANON_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+}
+
+const supabase: AdminClient = new Proxy({} as AdminClient, {
+  get(_target, prop) {
+    cachedDirectoryClient ??= createDirectoryClient();
+    const value = cachedDirectoryClient[prop as keyof AdminClient];
+    return typeof value === "function" ? value.bind(cachedDirectoryClient) : value;
+  },
+});
 
 export type TherapistTier = "free" | "standard" | "pro" | "elite";
 

--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -166,18 +166,19 @@ const buildPublicTherapistsQuery = () => {
     .eq("profile_status", "approved")
     .eq("is_suspended", false)
     .eq("is_banned", false)
-    .not("email_address", "ilike", "%@example%")
-    .not("email_address", "ilike", "%admin.dev@%")
+    // Test/debug exclusions. `NOT (col ILIKE ...)` evaluates to NULL (not
+    // TRUE) when the column is NULL, which silently drops legitimate rows
+    // that simply lack a phone/slug/email — so every nullable column gets an
+    // explicit `is.null` escape hatch. display_name is required for a card,
+    // so plain .not() is fine there.
     .not("display_name", "ilike", "%test%")
     .not("display_name", "ilike", "%debug%")
     .not("display_name", "ilike", "%admin%")
     .not("display_name", "ilike", "%example%")
     .not("display_name", "ilike", "%demo%")
-    .not("slug", "ilike", "%admin%")
-    .not("slug", "ilike", "%test%")
-    .not("slug", "ilike", "%example%")
-    .not("slug", "ilike", "%dev%")
-    .not("phone", "ilike", "%555%");
+    .or("email_address.is.null,and(email_address.not.ilike.%@example%,email_address.not.ilike.%admin.dev@%)")
+    .or("slug.is.null,and(slug.not.ilike.%admin%,slug.not.ilike.%test%,slug.not.ilike.%example%,slug.not.ilike.%dev%)")
+    .or("phone.is.null,phone.not.ilike.%555%");
   return q;
 };
 

--- a/src/app/_lib/explore.ts
+++ b/src/app/_lib/explore.ts
@@ -480,10 +480,13 @@ function filterProvider(provider: ExploreProvider, filters: ExploreFilters) {
     return false;
   }
 
-  if (
-    typeof provider.priceFrom === "number" &&
-    (provider.priceFrom < filters.priceMin || provider.priceFrom > filters.priceMax)
-  ) {
+  if (typeof provider.priceFrom === "number") {
+    if (provider.priceFrom < filters.priceMin || provider.priceFrom > filters.priceMax) {
+      return false;
+    }
+  } else if (filters.priceMin > 0 || filters.priceMax < EXPLORE_DEFAULT_PRICE_MAX) {
+    // "Price on request" providers stay listed under the default range, but a
+    // user-narrowed price filter can't be satisfied by an unknown price.
     return false;
   }
 

--- a/src/app/_lib/explore.ts
+++ b/src/app/_lib/explore.ts
@@ -534,6 +534,16 @@ export function recalculateExploreDistances(providers: ExploreProvider[], origin
   return providers.map((provider) => withProviderDistance(provider, origin));
 }
 
+// Only a missing service area makes a card unrenderable (no city page to
+// link, no distance to compute). Missing experience or pricing degrades
+// gracefully on the card ("Price on request"), so those profiles stay
+// listed instead of silently emptying the directory.
+const HARD_MISSING_FIELDS = new Set(["neighborhood"]);
+
+export function isHiddenExploreProvider(provider: ExploreProvider) {
+  return provider.missingFields.some((field) => HARD_MISSING_FIELDS.has(field));
+}
+
 export function applyExploreFilters(
   providers: ExploreProvider[],
   filters: ExploreFilters,
@@ -541,7 +551,7 @@ export function applyExploreFilters(
 ) {
   const nextProviders = origin ? recalculateExploreDistances(providers, origin) : providers;
   return sortProviders(
-    nextProviders.filter((provider) => provider.missingFields.length === 0 && filterProvider(provider, filters)),
+    nextProviders.filter((provider) => !isHiddenExploreProvider(provider) && filterProvider(provider, filters)),
     filters.sort,
   );
 }
@@ -615,7 +625,7 @@ export async function loadExploreProviders(filters: ExploreFilters) {
 
   const normalized = withPhotos.map((profile) => normalizeProvider(profile, origin));
   const sorted = applyExploreFilters(normalized, { ...filters, city: resolvedCity });
-  const invalidProviderCount = normalized.filter((provider) => provider.missingFields.length > 0).length;
+  const invalidProviderCount = normalized.filter(isHiddenExploreProvider).length;
 
   return {
     filters: { ...filters, city: resolvedCity },

--- a/src/app/admin/migrations/page.tsx
+++ b/src/app/admin/migrations/page.tsx
@@ -40,14 +40,15 @@ export default function AdminMigrationsPage() {
 
   const fetchMigrations = async () => {
     try {
-      // TODO: Replace with actual API call
-      // const res = await fetch("/api/admin/migrations");
-      // const data = await res.json();
-      // setMigrations(data);
-      console.log("Fetching migrations...");
-      setIsLoading(false);
+      const res = await fetch("/api/migrate/review");
+      if (!res.ok) {
+        throw new Error(`Failed to load migrations (${res.status})`);
+      }
+      const data = (await res.json()) as { migrations?: Migration[] };
+      setMigrations(data.migrations ?? []);
     } catch (error) {
       console.error("Error fetching migrations:", error);
+    } finally {
       setIsLoading(false);
     }
   };

--- a/src/app/api/migrate/review/route.ts
+++ b/src/app/api/migrate/review/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
-import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+import { createSupabaseAdminClient, requireAdminSession } from "@/app/api/_lib/supabase-server";
 import { sendEmail } from "@/app/api/_lib/email";
 import React from "react";
 
@@ -10,8 +10,54 @@ interface ReviewDecision {
   notes?: string;
 }
 
+// Admin listing for /admin/migrations: pending/processed migrations with
+// their imported reviews attached.
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    const adminClient = createSupabaseAdminClient();
+
+    // Cast: profile_migrations/imported_reviews aren't in the generated
+    // Supabase types yet (see processor.ts).
+    const { data: migrations, error } = await (adminClient as any)
+      .from("profile_migrations")
+      .select("*")
+      .order("created_at", { ascending: false })
+      .limit(100);
+
+    if (error) {
+      throw new RouteError(500, error.message);
+    }
+
+    const migrationIds = (migrations ?? []).map((m: { id: string }) => m.id);
+    let reviews: Array<{ migration_id: string }> = [];
+    if (migrationIds.length > 0) {
+      const { data: reviewRows, error: reviewsError } = await (adminClient as any)
+        .from("imported_reviews")
+        .select("*")
+        .in("migration_id", migrationIds);
+      if (reviewsError) {
+        throw new RouteError(500, reviewsError.message);
+      }
+      reviews = reviewRows ?? [];
+    }
+
+    const items = (migrations ?? []).map((migration: { id: string }) => ({
+      ...migration,
+      reviews: reviews.filter((review) => review.migration_id === migration.id),
+    }));
+
+    return json({ ok: true, migrations: items });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
 export async function PUT(request: Request) {
   try {
+    const session = await requireAdminSession(request);
+    const userId = session.userId;
+
     const body = await request.json();
     const { migrationId, reviews, notes } = body as {
       migrationId: string;
@@ -24,11 +70,6 @@ export async function PUT(request: Request) {
     }
 
     const adminClient = createSupabaseAdminClient();
-    const userId = (await adminClient.auth.getUser()).data.user?.id;
-
-    if (!userId) {
-      throw new RouteError(401, "Not authenticated.");
-    }
 
     // Update each review's approval status
     for (const decision of reviews) {

--- a/src/app/api/pro/profile/route.ts
+++ b/src/app/api/pro/profile/route.ts
@@ -13,13 +13,50 @@ import type { TablesUpdate } from "@/integrations/supabase/types";
 import { slugify } from "@/components/profile/profile-utils";
 import { buildProfileSlug } from "@/app/_lib/profile-slug";
 
+// Fields that must never be blanked by a profile save. A payload with an
+// empty/null value for one of these (typically an unhydrated client form)
+// keeps the existing database value instead of wiping it. Clearing these
+// intentionally goes through admin tooling, not the self-serve editor.
+const PROTECTED_TEXT_FIELDS = [
+  "display_name",
+  "full_name",
+  "bio",
+  "city",
+  "state",
+  "phone",
+  "email_address",
+] as const;
+
+const PROTECTED_ARRAY_FIELDS = [
+  "specialties",
+  "massage_techniques",
+  "service_categories",
+  "languages",
+] as const;
+
+function stripDestructiveEmptyFields(updates: Record<string, unknown>) {
+  for (const field of PROTECTED_TEXT_FIELDS) {
+    const value = updates[field];
+    if (value === null || (typeof value === "string" && !value.trim())) {
+      delete updates[field];
+    }
+  }
+  for (const field of PROTECTED_ARRAY_FIELDS) {
+    const value = updates[field];
+    if (Array.isArray(value) && value.length === 0) {
+      delete updates[field];
+    }
+  }
+  return updates;
+}
+
 function parseProfilePayload(raw: unknown) {
   const modern = massageTherapistProfileSchema.safeParse(raw);
   if (modern.success) {
     const body = modern.data;
     return {
       fields: Object.keys(body),
-      updates: {
+      updates: stripDestructiveEmptyFields({
         display_name: sanitizeText(body.display_name),
         full_name: sanitizeText(body.full_name),
         headline: sanitizeOptionalText(body.headline),
@@ -49,7 +86,7 @@ function parseProfilePayload(raw: unknown) {
         seo_description: sanitizeOptionalText(body.seo_description),
         seo_keywords: sanitizeStringArray(body.seo_keywords || []),
         slug: sanitizeText(body.slug),
-      },
+      }),
     };
   }
 
@@ -58,7 +95,7 @@ function parseProfilePayload(raw: unknown) {
     const body = legacy.data;
     return {
       fields: Object.keys(body),
-      updates: {
+      updates: stripDestructiveEmptyFields({
         display_name: sanitizeText(body.displayName),
         full_name: sanitizeText(body.displayName),
         bio: sanitizeText(body.bio),
@@ -87,7 +124,7 @@ function parseProfilePayload(raw: unknown) {
             end_date: t.end_date,
           })),
         }),
-      },
+      }),
     };
   }
 
@@ -359,11 +396,14 @@ export async function PATCH(request: Request) {
       updates.full_name = body.displayName.trim();
     }
     if (body.headline !== undefined) updates.headline = text(body.headline);
-    if (body.bio !== undefined) updates.bio = text(body.bio);
+    // bio/city/state are load-bearing (routing, SEO, listing eligibility) —
+    // a blank value in the payload means "unset field in the form", never
+    // "erase what's in the database", so only non-empty values are applied.
+    if (text(body.bio)) updates.bio = text(body.bio);
     if (body.tagline !== undefined) updates.tagline = text(body.tagline);
 
-    if (body.city !== undefined) updates.city = text(body.city);
-    if (body.state !== undefined) updates.state = text(body.state);
+    if (text(body.city)) updates.city = text(body.city);
+    if (text(body.state)) updates.state = text(body.state);
     if (body.neighborhood !== undefined) updates.neighborhood = text(body.neighborhood);
     if (body.zipCode !== undefined) updates.zip_code = text(body.zipCode);
 

--- a/src/app/explore/ExplorePageClient.tsx
+++ b/src/app/explore/ExplorePageClient.tsx
@@ -1559,7 +1559,7 @@ export default function ExplorePageClient({
                 </p>
                 {invalidProviderCount > 0 ? (
                   <p className="mt-2 text-xs font-semibold uppercase tracking-[0.16em] text-text-muted">
-                    {invalidProviderCount} incomplete {invalidProviderCount === 1 ? "profile" : "profiles"} hidden until neighborhood, experience, and starting price are complete.
+                    {invalidProviderCount} incomplete {invalidProviderCount === 1 ? "profile" : "profiles"} hidden until a service area is added.
                   </p>
                 ) : null}
                 {geoDenied ? (

--- a/src/app/pro/profile/ProProfilePageClient.tsx
+++ b/src/app/pro/profile/ProProfilePageClient.tsx
@@ -134,6 +134,15 @@ export default function ProProfilePageClient() {
 
   const onSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (loading || loadError) return;
+    if (!form.displayName.trim() || !form.city.trim()) {
+      toast({
+        title: "Missing required fields",
+        description: "Display name and city are required before saving.",
+        variant: "destructive",
+      });
+      return;
+    }
     setSaving(true);
 
     try {

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -15,18 +15,25 @@ const FALLBACK_SUPABASE_URL = "https://ijsdpozjfjjufjsoexod.supabase.co";
 const FALLBACK_SUPABASE_ANON_KEY =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imlqc2Rwb3pqZmpqdWZqc29leG9kIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjIwMDcxNTYsImV4cCI6MjA3NzU4MzE1Nn0.S6fGMlOp8KLHwPGL9ebOQvDUqY3C79bw3SH9IOsCi2M";
 
-const SUPABASE_URL =
+// Exported for server modules (e.g. the public directory) that need an
+// anon-key fallback when the service-role env isn't configured, such as
+// env-less CI builds. The values are public by design; keep the literals in
+// this file only — .gitleaks.toml allowlists exactly this path.
+export const SUPABASE_PUBLIC_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
   process.env.NEXT_PUBLIC_STORAGE_SUPABASE_URL ||
   process.env.VITE_SUPABASE_URL ||
   FALLBACK_SUPABASE_URL;
 
-const SUPABASE_ANON_KEY =
+export const SUPABASE_PUBLIC_ANON_KEY =
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
   process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
   process.env.NEXT_PUBLIC_STORAGE_SUPABASE_ANON_KEY ||
   process.env.VITE_SUPABASE_PUBLISHABLE_KEY ||
   FALLBACK_SUPABASE_ANON_KEY;
+
+const SUPABASE_URL = SUPABASE_PUBLIC_URL;
+const SUPABASE_ANON_KEY = SUPABASE_PUBLIC_ANON_KEY;
 
 export function createClient() {
   return createBrowserClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -555,6 +555,37 @@ create table if not exists public.imported_reviews (
   created_at timestamptz default timezone('utc', now())
 );
 
+alter table public.imported_reviews
+  add column if not exists migration_id uuid,
+  add column if not exists reviewer_anonymized boolean default false,
+  add column if not exists is_public boolean default false,
+  add column if not exists reviewed_by uuid,
+  add column if not exists reviewed_at timestamp,
+  add column if not exists review_notes text,
+  add column if not exists updated_at timestamp default now();
+
+-- Profile migration pipeline (/api/migrate): one row per requested import of
+-- an external profile into MasseurMatch. Mirrors the table already live in
+-- production.
+create table if not exists public.profile_migrations (
+  id uuid primary key default gen_random_uuid(),
+  email text,
+  profile_id uuid,
+  platform text,
+  source_url text,
+  status text default 'pending',
+  imported_reviews integer default 0,
+  imported_rating numeric,
+  migration_notes text,
+  completed_at timestamp,
+  created_at timestamp default now(),
+  updated_at timestamp default now(),
+  imported_review_count integer default 0,
+  is_verified boolean default false,
+  verified_at timestamp,
+  verified_by uuid
+);
+
 create table if not exists public.moderation_queue (
   id uuid primary key default gen_random_uuid(),
   user_id uuid,

--- a/supabase/migrations/20260711120000_enable_geo_extensions.sql
+++ b/supabase/migrations/20260711120000_enable_geo_extensions.sql
@@ -1,0 +1,11 @@
+-- The live database contains a search_public_therapists() function that
+-- computes distances with the earthdistance `<@>` operator, but the cube and
+-- earthdistance extensions were never enabled in production, so every call
+-- fails with: `operator does not exist: point <@> point`.
+--
+-- Enabling the extensions makes the existing function work as written.
+-- Both live in the `extensions` schema per Supabase convention, which is on
+-- the default search_path for database functions.
+
+create extension if not exists cube with schema extensions;
+create extension if not exists earthdistance with schema extensions;

--- a/supabase/migrations/20260711121000_repair_auth_users_null_tokens.sql
+++ b/supabase/migrations/20260711121000_repair_auth_users_null_tokens.sql
@@ -1,0 +1,28 @@
+-- GET /auth/v1/admin/users 500s with "Database error finding users" once the
+-- listing reaches the users seeded on 2025-12-07 (viewer/manager/superadmin
+-- @example.com). Rows inserted directly into auth.users with SQL leave the
+-- token columns NULL, and GoTrue scans them as non-nullable strings, so any
+-- page containing such a row fails. Diagnosed by bisecting per_page: 43 rows
+-- list fine, 44 errors.
+--
+-- Backfill empty strings (GoTrue's own default) for every NULL string column
+-- it scans. Idempotent; touches only corrupted rows.
+
+update auth.users
+set
+  confirmation_token         = coalesce(confirmation_token, ''),
+  recovery_token             = coalesce(recovery_token, ''),
+  email_change               = coalesce(email_change, ''),
+  email_change_token_new     = coalesce(email_change_token_new, ''),
+  email_change_token_current = coalesce(email_change_token_current, ''),
+  phone_change               = coalesce(phone_change, ''),
+  phone_change_token         = coalesce(phone_change_token, ''),
+  reauthentication_token     = coalesce(reauthentication_token, '')
+where confirmation_token is null
+   or recovery_token is null
+   or email_change is null
+   or email_change_token_new is null
+   or email_change_token_current is null
+   or phone_change is null
+   or phone_change_token is null
+   or reauthentication_token is null;

--- a/tests/stubs/server-only.ts
+++ b/tests/stubs/server-only.ts
@@ -1,0 +1,5 @@
+// Vitest stand-in for the `server-only` marker package. The real module
+// throws unless the bundler runs with the `react-server` resolve condition,
+// which vitest's node environment does not set. The marker carries no
+// runtime behavior, so tests substitute this empty module.
+export {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // The real `server-only` package throws outside a react-server bundler
+      // condition; tests run in plain node, so substitute an empty module.
+      "server-only": path.resolve(__dirname, "tests/stubs/server-only.ts"),
       "@": path.resolve(__dirname, "src"),
     },
   },


### PR DESCRIPTION
## Summary

Fixes the red CI on `main` (Unit Tests, DB Contract, and the build job that also fails the Vercel deploy), plus a production data-wipe bug in profile saves and two visibility bugs that left the directory empty.

## CI / Vercel fixes (main is currently red from commit 82f6902)

- **Unit tests**: `server-only` is now a direct dependency and is stubbed in vitest (`tests/stubs/server-only.ts`) — the real module throws outside a `react-server` bundler condition, which broke `knotty-profile-gate.test.ts`.
- **Build / Vercel**: the directory Supabase client is created lazily instead of at module scope. Eager creation threw `SUPABASE_URL is not configured` during `next build` page-data collection and the `/sitemap.xml` prerender in env-less environments. When service-role env is absent, public directory reads fall back to the anon key (public data, RLS-governed).
- **DB Contract**: `profile_migrations` and the new `imported_reviews` columns (`migration_id` etc.) are mirrored into `PRODUCTION_SCHEMA_LOCK.sql`, matching what is already live in production.
- **release:audit**: the `/admin/migrations` TODO stub is replaced with a real implementation — new admin-gated `GET /api/migrate/review` listing migrations with their reviews, wired into the page. Also fixes `PUT /api/migrate/review` auth, which always returned 401 (`auth.getUser()` on a service-role client has no user).

## Production bug fixes

- **Profile saves can no longer wipe data**: `POST /api/pro/profile` dropped empty/null payload values for identity/location/contact fields (an unhydrated client form was blanking bio/city/state/phone on the only live profile). `PATCH` only applies non-empty bio/city/state, and the `/pro/profile` editor blocks unhydrated/invalid saves client-side.
- **Directory query null-safety**: `NOT (col ILIKE ...)` filters silently dropped rows with NULL `phone`/`slug`/`email_address` (SQL three-valued logic), hiding legitimate profiles from `/api/providers` and listings. Exclusion filters now have explicit `is.null` escape hatches.
- **Explore no longer hides price-less profiles**: only a missing service area hides a card; missing price/experience degrades to "Price on request" instead of silently emptying the explore page.

## Migrations (need a manual apply — CI does not run them)

- `20260711120000_enable_geo_extensions.sql`: enables `cube`/`earthdistance`; the live `search_public_therapists()` RPC currently fails with `operator does not exist: point <@> point`.
- `20260711121000_repair_auth_users_null_tokens.sql`: backfills NULL token columns in `auth.users` (rows seeded 2025-12-07) that make `GET /auth/v1/admin/users` 500 with "Database error finding users".

## Validation

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` (126/126), `pnpm validate:db-contract`, `pnpm validate:sitemap`, `pnpm release:audit`, and `pnpm build` (252/252 pages incl. `/sitemap.xml`) all pass locally with no Supabase env configured — the same condition that broke CI.
- New directory query shape verified directly against the production database (previously-hidden approved profile now returned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FVXX6z9SUKZFgM5MkgLzr

---
_Generated by [Claude Code](https://claude.ai/code/session_018FVXX6z9SUKZFgM5MkgLzr)_