### PR TITLE
Header: LGBTQ+-affirming tagline and larger logo

### DIFF
--- a/src/app/_components/site-header.tsx
+++ b/src/app/_components/site-header.tsx
@@ -290,9 +290,9 @@ function MobileNav({
             <Image
               src={BRAND_ASSETS.logo}
               alt="MasseurMatch"
-              width={100}
-              height={40}
-              className="h-9 w-auto object-contain"
+              width={110}
+              height={44}
+              className="h-11 w-auto object-contain"
             />
           </Link>
           <button
@@ -493,14 +493,14 @@ export default function SiteHeader() {
           <Image
             src={BRAND_ASSETS.logo}
             alt="MasseurMatch"
-            width={120}
-            height={48}
+            width={140}
+            height={56}
             priority
-            className="h-9 w-auto object-contain md:h-12"
+            className="h-11 w-auto object-contain md:h-14"
           />
           <div className="hidden lg:flex flex-col">
             <span className="text-[9px] font-semibold text-[#6F6F6F] tracking-[0.12em] uppercase leading-tight">
-              Premium Sports Recovery &amp; Wellness
+              LGBTQ+-Affirming Male Massage
             </span>
           </div>
         </Link>


### PR DESCRIPTION
## Summary
Two small header refinements:

- **Tagline** — replaced "Premium Sports Recovery & Wellness" with **"LGBTQ+-Affirming Male Massage"**, matching the site's actual positioning (a directory of LGBTQ+-affirming male massage therapists). Kept the existing uppercase micro-label styling; no fabricated claims.
- **Logo size** — enlarged the header logo to **56px on desktop / 44px on mobile** (mobile drawer logo also bumped to 44px).

## Verification
- `npx tsc --noEmit`, `npx eslint`, and a full `npm run build` all pass.
- Rendered header measured in a production build: logo 56px at 1440px width, 44px at 390px; tagline reads "LGBTQ+-AFFIRMING MALE MASSAGE".

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYVA1ByANa5t4X6vV7HNB1)_