### PR TITLE
Enlarge header logo by cropping the mockup to the actual lockup

### DIFF
--- a/src/app/_components/site-header.tsx
+++ b/src/app/_components/site-header.tsx
@@ -288,11 +288,11 @@ function MobileNav({
             aria-label="MasseurMatch home"
           >
             <Image
-              src={BRAND_ASSETS.logo}
+              src={BRAND_ASSETS.logoLockup}
               alt="MasseurMatch"
-              width={110}
-              height={44}
-              className="h-11 w-auto object-contain"
+              width={247}
+              height={40}
+              className="h-10 w-auto object-contain"
             />
           </Link>
           <button
@@ -491,9 +491,9 @@ export default function SiteHeader() {
           aria-label="MasseurMatch home"
         >
           <Image
-            src={BRAND_ASSETS.logo}
+            src={BRAND_ASSETS.logoLockup}
             alt="MasseurMatch"
-            width={140}
+            width={345}
             height={56}
             priority
             className="h-11 w-auto object-contain md:h-14"

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -8,4 +8,12 @@ export const BRAND_ASSETS = {
   heroPoster: "/brand/hero-desktop.png", // desktop hero still
   heroMobile: "/brand/hero-mobile.png", // mobile hero still
   logo: "https://res.cloudinary.com/dyfxkq2nk/image/upload/v1783717666/ChatGPT_Image_Jul_10_2026_04_07_35_PM_vxqgdv.png",
+  // The source upload above is a presentation mockup — the icon + wordmark sit
+  // in a small band in the middle of a large gray frame, so used raw it renders
+  // tiny in the header. This c_crop transform trims to just the icon +
+  // "MasseurMatch" lockup (dropping the in-artwork "RELAX · CONNECT · ENJOY"
+  // tagline) so it fills the header height. Ratio ≈ 1140:185 (~6.16:1). Used by
+  // the public site header (on white); the pro sidebar keeps `logo`.
+  logoLockup:
+    "https://res.cloudinary.com/dyfxkq2nk/image/upload/c_crop,x_180,y_345,w_1140,h_185/v1783717666/ChatGPT_Image_Jul_10_2026_04_07_35_PM_vxqgdv.png",
 } as const;


### PR DESCRIPTION
## Problem
The header logo kept looking tiny even after bumping its CSS height. Root cause: `BRAND_ASSETS.logo` is a **presentation mockup** (1536×1024) where the icon + wordmark occupy a small band in the middle of a large gray frame. `object-contain` fits the *whole frame* into the header height, so the actual mark renders at ~20px and raising the height just adds empty gray margins.

## Fix
- Added `BRAND_ASSETS.logoLockup` — a Cloudinary `c_crop` of the same upload trimmed to just the icon + "MasseurMatch" wordmark (dropping the in-artwork "RELAX · CONNECT · ENJOY" line, since the header already shows the "LGBTQ+-Affirming Male Massage" tagline).
- The public site header uses it at **56px desktop / 44px mobile**; the intrinsic width/height props were corrected to the new ~6.16:1 ratio.
- The pro dashboard sidebar keeps the full `logo` (it sits on a dark surface where the cropped near-white lockup would show a light box), so that surface is unchanged.

## Verification
- `npx tsc --noEmit`, `npx eslint`, and a full `npm run build` pass.
- Rendered in a production build and measured: header logo 56px at 1440px and 44px at 390px, now filling the header — screenshots confirm the mark + wordmark are large and crisp on white.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYVA1ByANa5t4X6vV7HNB1)_