### PR TITLE
feat(support): therapist↔admin ticket desk + admin email alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ STRIPE_PRICE_ELITE=                       # [REQUIRED] price_... for Elite plan
 # before going live or emails will not deliver.
 RESEND_API_KEY=                           # [REQUIRED] re_... from resend.com
 RESEND_FROM_EMAIL=MasseurMatch <concierge@masseurmatch.com>  # [REQUIRED] verified sender
+# Where admin alerts go (new accounts, new/updated support tickets, profiles
+# submitted for review). Defaults to admin@xrankflow.com if unset.
+ADMIN_NOTIFICATION_EMAIL=admin@xrankflow.com
 
 # ── Google Maps ───────────────────────────────────────────────────────────────
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=          # [OPTIONAL] for map embeds (read by the app)

--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -63,6 +63,7 @@ const navSections = [
   {
     title: "Ops",
     items: [
+      { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
       { href: "/admin/support", label: "Support", icon: LifeBuoy },
       { href: "/admin/verification", label: "Verification", icon: ShieldCheck },
       { href: "/admin/legal", label: "Legal", icon: FileText },

--- a/src/app/admin/tickets/page.tsx
+++ b/src/app/admin/tickets/page.tsx
@@ -1,92 +1,210 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { MessageSquare, AlertCircle, CheckCircle2, Clock, Loader2 } from "lucide-react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  ArrowLeft,
+  Loader2,
+  MessageSquare,
+  RefreshCw,
+  Send,
+} from "lucide-react";
 import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type TicketStatus = "open" | "in_progress" | "waiting_on_user" | "resolved" | "closed";
 
 type Ticket = {
   id: string;
-  title: string;
+  user_id: string;
   subject: string;
-  status: "open" | "in_progress" | "resolved" | "closed";
-  priority: "low" | "medium" | "high" | "urgent";
+  category: string;
+  priority: string;
+  status: TicketStatus;
   created_at: string;
   updated_at: string;
-  user_name: string;
-  user_type: "therapist" | "client";
+  last_message_at: string;
+  requester_name: string | null;
+  requester_email: string | null;
 };
 
+type TicketMessage = {
+  id: string;
+  author_role: "provider" | "admin" | "system";
+  author_name: string | null;
+  body: string;
+  created_at: string;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  billing: "Billing",
+  payouts: "Payouts",
+  technical: "Technical",
+  profile: "Profile",
+  verification: "Verification",
+  account: "Account",
+  trust_safety: "Trust & Safety",
+  other: "Other",
+};
+
+const STATUS_OPTIONS: { value: TicketStatus; label: string }[] = [
+  { value: "open", label: "Open" },
+  { value: "in_progress", label: "In progress" },
+  { value: "waiting_on_user", label: "Waiting on user" },
+  { value: "resolved", label: "Resolved" },
+  { value: "closed", label: "Closed" },
+];
+
+const PRIORITY_OPTIONS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "urgent", label: "Urgent" },
+];
+
+const STATUS_STYLES: Record<TicketStatus, string> = {
+  open: "bg-amber-100 text-amber-800",
+  in_progress: "bg-blue-100 text-blue-800",
+  waiting_on_user: "bg-purple-100 text-purple-800",
+  resolved: "bg-green-100 text-green-800",
+  closed: "bg-slate-100 text-slate-700",
+};
+
+const PRIORITY_STYLES: Record<string, string> = {
+  low: "text-slate-500",
+  medium: "text-amber-600",
+  high: "text-orange-600",
+  urgent: "text-red-600",
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 export default function AdminTicketsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+        </div>
+      }
+    >
+      <AdminTicketsInner />
+    </Suspense>
+  );
+}
+
+function AdminTicketsInner() {
+  const searchParams = useSearchParams();
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<"all" | "open" | "in_progress">("all");
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<"all" | "active" | TicketStatus>("active");
   const [search, setSearch] = useState("");
+  const [activeId, setActiveId] = useState<string | null>(null);
 
-  useEffect(() => {
-    setLoading(false);
+  const fetchTickets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/tickets", { cache: "no-store" });
+      if (!res.ok) throw new Error(`Failed to load tickets (${res.status}).`);
+      const json = await res.json();
+      setTickets(json.tickets ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load tickets.");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const getStatusColor = (status: Ticket["status"]) => {
-    const colors = {
-      open: "bg-yellow-100 text-yellow-800",
-      in_progress: "bg-blue-100 text-blue-800",
-      resolved: "bg-green-100 text-green-800",
-      closed: "bg-gray-100 text-gray-800",
-    };
-    return colors[status];
-  };
+  useEffect(() => {
+    void fetchTickets();
+  }, [fetchTickets]);
 
-  const getPriorityColor = (priority: Ticket["priority"]) => {
-    const colors = {
-      low: "text-gray-500",
-      medium: "text-yellow-500",
-      high: "text-orange-500",
-      urgent: "text-red-600",
-    };
-    return colors[priority];
-  };
+  useEffect(() => {
+    const deepLink = searchParams.get("ticket");
+    if (deepLink) setActiveId(deepLink);
+  }, [searchParams]);
 
-  const filteredTickets = tickets.filter((ticket) => {
-    if (filter !== "all" && ticket.status !== filter) return false;
-    if (search && !ticket.title.toLowerCase().includes(search.toLowerCase())) return false;
+  const activeCount = tickets.filter(
+    (t) => t.status === "open" || t.status === "in_progress" || t.status === "waiting_on_user",
+  ).length;
+
+  const filtered = tickets.filter((t) => {
+    if (filter === "active") {
+      if (!["open", "in_progress", "waiting_on_user"].includes(t.status)) return false;
+    } else if (filter !== "all" && t.status !== filter) {
+      return false;
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      const hay = `${t.subject} ${t.requester_name ?? ""} ${t.requester_email ?? ""}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
     return true;
   });
+
+  if (activeId) {
+    return (
+      <AdminTicketThread
+        ticketId={activeId}
+        onBack={() => {
+          setActiveId(null);
+          void fetchTickets();
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-6">
       <AdminPageHeader
         title="Support Tickets"
-        description="Manage customer support tickets and issues"
+        description={`${activeCount} active · ${tickets.length} total`}
+        actions={
+          <Button variant="outline" size="sm" onClick={() => void fetchTickets()}>
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" /> Refresh
+          </Button>
+        }
       />
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex gap-2">
-          <Button
-            variant={filter === "all" ? "default" : "outline"}
-            onClick={() => setFilter("all")}
-            size="sm"
-          >
-            All Tickets
-          </Button>
-          <Button
-            variant={filter === "open" ? "default" : "outline"}
-            onClick={() => setFilter("open")}
-            size="sm"
-          >
-            Open
-          </Button>
-          <Button
-            variant={filter === "in_progress" ? "default" : "outline"}
-            onClick={() => setFilter("in_progress")}
-            size="sm"
-          >
-            In Progress
-          </Button>
+        <div className="flex flex-wrap gap-2">
+          {(["active", "all", "open", "in_progress", "waiting_on_user", "resolved", "closed"] as const).map(
+            (key) => (
+              <Button
+                key={key}
+                variant={filter === key ? "default" : "outline"}
+                onClick={() => setFilter(key)}
+                size="sm"
+              >
+                {key === "all"
+                  ? "All"
+                  : key === "active"
+                    ? "Active"
+                    : STATUS_OPTIONS.find((s) => s.value === key)?.label ?? key}
+              </Button>
+            ),
+          )}
         </div>
         <Input
-          placeholder="Search tickets..."
+          placeholder="Search tickets…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-xs"
@@ -94,42 +212,271 @@ export default function AdminTicketsPage() {
       </div>
 
       {loading ? (
-        <div className="flex items-center justify-center py-12">
+        <div className="flex items-center justify-center py-16">
           <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
         </div>
-      ) : filteredTickets.length === 0 ? (
-        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-10 text-center">
           <MessageSquare className="mx-auto h-8 w-8 text-slate-300" />
-          <p className="mt-2 text-sm text-slate-500">No tickets found</p>
+          <p className="mt-2 text-sm text-slate-500">No tickets found.</p>
         </div>
       ) : (
         <div className="space-y-3">
-          {filteredTickets.map((ticket) => (
-            <div
+          {filtered.map((ticket) => (
+            <button
               key={ticket.id}
-              className="flex items-start gap-4 rounded-lg border border-slate-200 bg-white p-4 transition hover:shadow-md"
+              onClick={() => setActiveId(ticket.id)}
+              className="flex w-full items-start gap-4 rounded-xl border border-slate-200 bg-white p-4 text-left transition hover:border-slate-300 hover:shadow-md"
             >
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-slate-100">
                 <MessageSquare className="h-5 w-5 text-slate-600" />
               </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="font-semibold text-slate-900">{ticket.title}</h3>
+              <div className="min-w-0 flex-1">
+                <h3 className="truncate font-semibold text-slate-900">{ticket.subject}</h3>
                 <p className="mt-0.5 text-xs text-slate-500">
-                  {ticket.user_name} • {new Date(ticket.created_at).toLocaleDateString()}
+                  {ticket.requester_name || ticket.requester_email || "Unknown"} ·{" "}
+                  {CATEGORY_LABELS[ticket.category] ?? ticket.category} · Updated{" "}
+                  {formatDate(ticket.last_message_at)}
                 </p>
               </div>
-              <div className="flex items-center gap-2">
-                <span className={`text-xs font-medium px-2 py-1 rounded ${getStatusColor(ticket.status)}`}>
-                  {ticket.status}
+              <div className="flex shrink-0 items-center gap-2">
+                <span
+                  className={`text-xs font-semibold uppercase ${PRIORITY_STYLES[ticket.priority] ?? ""}`}
+                >
+                  {ticket.priority}
                 </span>
-                <span className={`text-xs font-semibold ${getPriorityColor(ticket.priority)}`}>
-                  {ticket.priority.toUpperCase()}
+                <span
+                  className={`rounded px-2 py-1 text-xs font-medium ${STATUS_STYLES[ticket.status]}`}
+                >
+                  {STATUS_OPTIONS.find((s) => s.value === ticket.status)?.label ?? ticket.status}
                 </span>
               </div>
-            </div>
+            </button>
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function AdminTicketThread({ ticketId, onBack }: { ticketId: string; onBack: () => void }) {
+  const [ticket, setTicket] = useState<Ticket | null>(null);
+  const [messages, setMessages] = useState<TicketMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reply, setReply] = useState("");
+  const [sending, setSending] = useState(false);
+  const [savingMeta, setSavingMeta] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const fetchThread = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/admin/tickets/${ticketId}`, { cache: "no-store" });
+      if (!res.ok) throw new Error(`Failed to load ticket (${res.status}).`);
+      const json = await res.json();
+      setTicket(json.ticket);
+      setMessages(json.messages ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load ticket.");
+    } finally {
+      setLoading(false);
+    }
+  }, [ticketId]);
+
+  useEffect(() => {
+    void fetchThread();
+  }, [fetchThread]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  const updateMeta = async (patch: { status?: TicketStatus; priority?: string }) => {
+    setSavingMeta(true);
+    try {
+      const res = await fetch(`/api/admin/tickets/${ticketId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error ?? "Update failed.");
+      setTicket((prev) => (prev ? { ...prev, ...patch } : prev));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Update failed.");
+    } finally {
+      setSavingMeta(false);
+    }
+  };
+
+  const sendReply = async () => {
+    if (reply.trim().length < 1) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/admin/tickets/${ticketId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: reply }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not send reply.");
+      setReply("");
+      await fetchThread();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not send reply.");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-900"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to tickets
+      </button>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+        </div>
+      ) : error && !ticket ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : ticket ? (
+        <div className="grid gap-5 lg:grid-cols-3">
+          <div className="space-y-4 lg:col-span-2">
+            <div className="border-b border-slate-200 pb-4">
+              <h1 className="text-2xl font-bold text-slate-900">{ticket.subject}</h1>
+              <p className="mt-1 text-xs text-slate-500">
+                {ticket.requester_name || "Unknown"}
+                {ticket.requester_email ? ` · ${ticket.requester_email}` : ""} · Opened{" "}
+                {formatDate(ticket.created_at)}
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              {messages.map((m) => {
+                const fromAdmin = m.author_role === "admin";
+                return (
+                  <div key={m.id} className={`flex ${fromAdmin ? "justify-end" : "justify-start"}`}>
+                    <div
+                      className={`max-w-[85%] rounded-2xl px-4 py-3 ${
+                        fromAdmin
+                          ? "bg-[#8B1E2D] text-white"
+                          : m.author_role === "system"
+                            ? "border border-slate-200 bg-slate-50 text-slate-600"
+                            : "border border-slate-200 bg-white text-slate-900"
+                      }`}
+                    >
+                      <p className="mb-1 text-[11px] font-medium opacity-70">
+                        {fromAdmin ? m.author_name || "Support Team" : m.author_name || "Provider"} ·{" "}
+                        {formatDate(m.created_at)}
+                      </p>
+                      <p className="whitespace-pre-wrap text-sm leading-relaxed">{m.body}</p>
+                    </div>
+                  </div>
+                );
+              })}
+              <div ref={bottomRef} />
+            </div>
+
+            <div className="space-y-2 rounded-xl border border-slate-200 bg-white p-4">
+              <Textarea
+                value={reply}
+                onChange={(e) => setReply(e.target.value)}
+                placeholder="Reply to the provider…"
+                rows={4}
+                maxLength={8000}
+              />
+              {error && ticket && <p className="text-sm text-red-600">{error}</p>}
+              <div className="flex justify-end">
+                <Button
+                  onClick={() => void sendReply()}
+                  disabled={sending || reply.trim().length < 1}
+                  className="gap-2"
+                >
+                  {sending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Send className="h-4 w-4" />
+                  )}
+                  Send reply
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-4">
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Status
+                </label>
+                <Select
+                  value={ticket.status}
+                  onValueChange={(v) => void updateMeta({ status: v as TicketStatus })}
+                  disabled={savingMeta}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUS_OPTIONS.map((s) => (
+                      <SelectItem key={s.value} value={s.value}>
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Priority
+                </label>
+                <Select
+                  value={ticket.priority}
+                  onValueChange={(v) => void updateMeta({ priority: v })}
+                  disabled={savingMeta}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PRIORITY_OPTIONS.map((p) => (
+                      <SelectItem key={p.value} value={p.value}>
+                        {p.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2 rounded-xl border border-slate-200 bg-white p-4 text-sm">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Details</p>
+              <p className="text-slate-600">
+                <span className="text-slate-400">Category:</span>{" "}
+                {CATEGORY_LABELS[ticket.category] ?? ticket.category}
+              </p>
+              <p className="text-slate-600">
+                <span className="text-slate-400">Provider:</span> {ticket.requester_name || "—"}
+              </p>
+              <p className="break-all text-slate-600">
+                <span className="text-slate-400">Email:</span> {ticket.requester_email || "—"}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/api/_lib/admin-notify.ts
+++ b/src/app/api/_lib/admin-notify.ts
@@ -1,0 +1,162 @@
+import { Resend } from "resend";
+
+import { envAny, envOptional } from "@/app/api/_lib/env";
+
+/**
+ * Central place for "something needs an admin's attention" emails.
+ *
+ * Every event that is submitted to the admin team — a new support ticket, a
+ * provider reply, a brand-new account, a profile submitted for review — funnels
+ * through {@link notifyAdmin} so the destination address and branding stay
+ * consistent. The recipient defaults to admin@xrankflow.com and can be
+ * overridden with ADMIN_NOTIFICATION_EMAIL.
+ */
+
+const DEFAULT_ADMIN_RECIPIENT = "admin@xrankflow.com";
+const DEFAULT_FROM = "MasseurMatch <notifications@masseurmatch.com>";
+
+export function getAdminNotificationRecipient(): string {
+  return (
+    envOptional(["ADMIN_NOTIFICATION_EMAIL", "ADMIN_EMAIL"]) ?? DEFAULT_ADMIN_RECIPIENT
+  );
+}
+
+export interface AdminNotificationField {
+  label: string;
+  value: string | null | undefined;
+}
+
+export interface AdminNotificationInput {
+  /** Short summary used as the email subject (an "[Admin]" prefix is added). */
+  subject: string;
+  /** Headline shown at the top of the email body. */
+  heading: string;
+  /** Optional lead paragraph under the heading. */
+  intro?: string;
+  /** Key/value rows rendered as a summary table. */
+  fields?: AdminNotificationField[];
+  /** Optional freeform block (e.g. the message the user wrote). */
+  message?: string | null;
+  /** Optional call-to-action button. */
+  action?: { label: string; url: string };
+  /** Optional reply-to (e.g. the provider's email) so admins can respond. */
+  replyTo?: string | null;
+}
+
+export interface AdminNotificationResult {
+  ok: boolean;
+  id?: string;
+  mock?: boolean;
+  error?: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderAdminEmail(input: AdminNotificationInput): string {
+  const rows = (input.fields ?? [])
+    .filter((field) => field.value != null && String(field.value).trim() !== "")
+    .map(
+      (field) => `
+        <tr>
+          <td style="padding:8px 12px;font-size:13px;color:#6F6F6F;white-space:nowrap;vertical-align:top;">${escapeHtml(field.label)}</td>
+          <td style="padding:8px 12px;font-size:14px;color:#111111;font-weight:600;">${escapeHtml(String(field.value))}</td>
+        </tr>`,
+    )
+    .join("");
+
+  const table = rows
+    ? `<table role="presentation" style="width:100%;border-collapse:collapse;background:#FAFAFA;border:1px solid #E8E8E8;border-radius:10px;margin:16px 0;">${rows}</table>`
+    : "";
+
+  const messageBlock = input.message?.trim()
+    ? `<div style="background:#F7F7F7;border:1px solid #E8E8E8;border-radius:10px;padding:16px;margin:16px 0;font-size:14px;line-height:1.6;color:#111111;white-space:pre-wrap;">${escapeHtml(
+        input.message.trim(),
+      )}</div>`
+    : "";
+
+  const introBlock = input.intro
+    ? `<p style="margin:0 0 12px;font-size:15px;line-height:1.6;color:#6F6F6F;">${escapeHtml(input.intro)}</p>`
+    : "";
+
+  const actionBlock = input.action
+    ? `<p style="margin:24px 0 8px;"><a href="${input.action.url}" style="display:inline-block;background:#8B1E2D;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 22px;border-radius:8px;">${escapeHtml(
+        input.action.label,
+      )}</a></p>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+  <body style="margin:0;background:#F7F7F7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+    <div style="max-width:600px;margin:0 auto;padding:24px;">
+      <div style="background:#111111;border-radius:12px 12px 0 0;padding:20px 24px;">
+        <span style="font-size:11px;letter-spacing:0.18em;text-transform:uppercase;color:#8E8E8E;font-family:monospace;">MasseurMatch · Admin Alert</span>
+        <h1 style="margin:6px 0 0;font-size:22px;color:#ffffff;font-weight:700;">${escapeHtml(input.heading)}</h1>
+      </div>
+      <div style="background:#ffffff;border:1px solid #E8E8E8;border-top:none;border-radius:0 0 12px 12px;padding:24px;">
+        ${introBlock}
+        ${table}
+        ${messageBlock}
+        ${actionBlock}
+        <p style="margin:24px 0 0;padding-top:16px;border-top:1px solid #E8E8E8;font-size:12px;color:#8E8E8E;">
+          Automated notification from MasseurMatch. Sent to ${escapeHtml(getAdminNotificationRecipient())}.
+        </p>
+      </div>
+    </div>
+  </body>
+</html>`;
+}
+
+let _resend: Resend | null = null;
+function getResend(apiKey: string): Resend {
+  if (!_resend) {
+    _resend = new Resend(apiKey);
+  }
+  return _resend;
+}
+
+/**
+ * Best-effort admin notification. Never throws — callers should not fail their
+ * primary operation (creating a ticket, registering a user) if email delivery
+ * hiccups. Returns a result object so callers can log outcomes.
+ */
+export async function notifyAdmin(
+  input: AdminNotificationInput,
+): Promise<AdminNotificationResult> {
+  const to = getAdminNotificationRecipient();
+  const apiKey = envOptional(["RESEND_API_KEY"]);
+
+  if (!apiKey) {
+    console.warn("[admin-notify] RESEND_API_KEY missing; skipping admin email:", input.subject);
+    return { ok: false, mock: true };
+  }
+
+  const from = envAny(["RESEND_FROM_EMAIL"], DEFAULT_FROM);
+
+  try {
+    const result = await getResend(apiKey).emails.send({
+      from,
+      to,
+      subject: `[Admin] ${input.subject}`,
+      html: renderAdminEmail(input),
+      ...(input.replyTo ? { replyTo: input.replyTo } : {}),
+    });
+
+    if (result.error) {
+      console.error("[admin-notify] Resend error:", result.error);
+      return { ok: false, error: result.error.message };
+    }
+
+    return { ok: true, id: result.data?.id };
+  } catch (error) {
+    console.error("[admin-notify] Unexpected error:", error);
+    return { ok: false, error: error instanceof Error ? error.message : "unknown" };
+  }
+}

--- a/src/app/api/_lib/supabase-server.ts
+++ b/src/app/api/_lib/supabase-server.ts
@@ -6,6 +6,7 @@ import {
 import { envAny } from "@/app/api/_lib/env";
 import { RouteError } from "@/app/api/_lib/http";
 import { getRequestSession, type RequestSession } from "@/app/api/_lib/session";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
 import type { Database, Json } from "@/integrations/supabase/types";
 
 export type AppRole = "admin" | "provider" | "client";
@@ -330,6 +331,26 @@ export async function ensureUserProfileAndRole(
     } catch {
       // Legacy public.users sync is best-effort only.
     }
+  }
+
+  // Notify the admin team the first time a profile is created for a user, so a
+  // brand-new signup (email/password, social login, or admin-created) surfaces
+  // in the admin inbox. Best-effort — never blocks account creation.
+  if (profileCreated) {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://masseurmatch.com";
+    await notifyAdmin({
+      subject: `New ${role} account: ${fullName}`,
+      heading: "New account created",
+      intro: `A new ${role} account was just created on MasseurMatch.`,
+      fields: [
+        { label: "Name", value: fullName },
+        { label: "Email", value: user.email },
+        { label: "Role", value: role },
+        { label: "User ID", value: user.id },
+      ],
+      action: { label: "View in admin", url: `${appUrl}/admin/users` },
+      replyTo: user.email ?? null,
+    });
   }
 
   return {

--- a/src/app/api/_lib/support-tickets.ts
+++ b/src/app/api/_lib/support-tickets.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+import { Resend } from "resend";
+
+import { envAny, envOptional } from "@/app/api/_lib/env";
+import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+
+export const TICKET_CATEGORIES = [
+  "billing",
+  "payouts",
+  "technical",
+  "profile",
+  "verification",
+  "account",
+  "trust_safety",
+  "other",
+] as const;
+
+export const TICKET_PRIORITIES = ["low", "medium", "high", "urgent"] as const;
+
+export const TICKET_STATUSES = [
+  "open",
+  "in_progress",
+  "waiting_on_user",
+  "resolved",
+  "closed",
+] as const;
+
+export type TicketCategory = (typeof TICKET_CATEGORIES)[number];
+export type TicketPriority = (typeof TICKET_PRIORITIES)[number];
+export type TicketStatus = (typeof TICKET_STATUSES)[number];
+
+export const CATEGORY_LABELS: Record<TicketCategory, string> = {
+  billing: "Billing",
+  payouts: "Payouts",
+  technical: "Technical issue",
+  profile: "Profile & listing",
+  verification: "Verification",
+  account: "Account",
+  trust_safety: "Trust & Safety",
+  other: "Other",
+};
+
+export const STATUS_LABELS: Record<TicketStatus, string> = {
+  open: "Open",
+  in_progress: "In progress",
+  waiting_on_user: "Waiting on you",
+  resolved: "Resolved",
+  closed: "Closed",
+};
+
+export const createTicketSchema = z.object({
+  subject: z.string().trim().min(3, "Subject is too short.").max(160, "Subject is too long."),
+  category: z.enum(TICKET_CATEGORIES).default("other"),
+  priority: z.enum(TICKET_PRIORITIES).default("medium"),
+  message: z.string().trim().min(1, "Please describe your issue.").max(8000, "Message is too long."),
+});
+
+export const replySchema = z.object({
+  body: z.string().trim().min(1, "Message cannot be empty.").max(8000, "Message is too long."),
+});
+
+export const updateTicketSchema = z.object({
+  status: z.enum(TICKET_STATUSES).optional(),
+  priority: z.enum(TICKET_PRIORITIES).optional(),
+});
+
+export interface RequesterInfo {
+  name: string | null;
+  email: string | null;
+}
+
+/**
+ * Resolve a display name + email for the ticket requester from the profiles
+ * table (falling back to the auth user record). Best-effort — returns nulls if
+ * nothing can be found.
+ */
+export async function resolveRequesterInfo(userId: string): Promise<RequesterInfo> {
+  const admin = createSupabaseAdminClient();
+
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("full_name, display_name, email, email_address")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  let name = profile?.full_name || profile?.display_name || null;
+  let email = profile?.email || profile?.email_address || null;
+
+  if (!email || !name) {
+    try {
+      const { data } = await admin.auth.admin.getUserById(userId);
+      email = email || data.user?.email || null;
+      const metaName =
+        (data.user?.user_metadata?.full_name as string | undefined) ??
+        (data.user?.user_metadata?.name as string | undefined);
+      name = name || metaName || null;
+    } catch {
+      // best effort
+    }
+  }
+
+  return { name, email };
+}
+
+export function ticketAppUrl(path: string): string {
+  const base =
+    process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://masseurmatch.com";
+  return `${base}${path}`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Let the provider know the support team replied to their ticket. Best-effort;
+ * never throws so an email hiccup can't fail the admin's reply.
+ */
+export async function notifyProviderOfReply(input: {
+  to: string | null | undefined;
+  providerName: string | null | undefined;
+  subject: string;
+  body: string;
+  ticketId: string;
+}): Promise<void> {
+  if (!input.to) return;
+
+  const apiKey = envOptional(["RESEND_API_KEY"]);
+  if (!apiKey) {
+    console.warn("[support-tickets] RESEND_API_KEY missing; skipping provider reply email.");
+    return;
+  }
+
+  const from = envAny(["RESEND_FROM_EMAIL"], "MasseurMatch <notifications@masseurmatch.com>");
+  const url = ticketAppUrl(`/pro/tickets?ticket=${input.ticketId}`);
+  const greeting = input.providerName ? `Hi ${escapeHtml(input.providerName.split(" ")[0])},` : "Hi,";
+
+  const html = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+  <body style="margin:0;background:#F7F7F7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+    <div style="max-width:600px;margin:0 auto;padding:24px;">
+      <div style="background:linear-gradient(135deg,#8B1E2D 0%,#6E1521 100%);border-radius:12px 12px 0 0;padding:22px 24px;">
+        <h1 style="margin:0;font-size:20px;color:#ffffff;font-weight:700;">MasseurMatch Support replied</h1>
+      </div>
+      <div style="background:#ffffff;border:1px solid #E8E8E8;border-top:none;border-radius:0 0 12px 12px;padding:24px;">
+        <p style="margin:0 0 12px;font-size:15px;color:#111111;">${greeting}</p>
+        <p style="margin:0 0 12px;font-size:15px;color:#6F6F6F;">Our team responded to your ticket <strong style="color:#111111;">"${escapeHtml(
+          input.subject,
+        )}"</strong>.</p>
+        <div style="background:#F7F7F7;border:1px solid #E8E8E8;border-radius:10px;padding:16px;margin:16px 0;font-size:14px;line-height:1.6;color:#111111;white-space:pre-wrap;">${escapeHtml(
+          input.body,
+        )}</div>
+        <p style="margin:24px 0 8px;"><a href="${url}" style="display:inline-block;background:#8B1E2D;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:12px 22px;border-radius:8px;">View &amp; reply</a></p>
+        <p style="margin:24px 0 0;padding-top:16px;border-top:1px solid #E8E8E8;font-size:12px;color:#8E8E8E;">You're receiving this because you have an open support ticket with MasseurMatch.</p>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+  try {
+    await new Resend(apiKey).emails.send({
+      from,
+      to: input.to,
+      subject: `Re: ${input.subject}`,
+      html,
+    });
+  } catch (error) {
+    console.error("[support-tickets] provider reply email failed:", error);
+  }
+}

--- a/src/app/api/admin/tickets/[id]/messages/route.ts
+++ b/src/app/api/admin/tickets/[id]/messages/route.ts
@@ -1,0 +1,79 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+import {
+  notifyProviderOfReply,
+  replySchema,
+  resolveRequesterInfo,
+} from "@/app/api/_lib/support-tickets";
+
+// POST /api/admin/tickets/[id]/messages — an admin replies on a ticket.
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await requireAdminSession(request);
+    const { id } = await params;
+    const body = await parseJsonBody(request, replySchema);
+    const admin = createSupabaseAdminClient();
+
+    const { data: ticket, error } = await admin
+      .from("support_tickets")
+      .select("id, user_id, subject, status")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!ticket) throw new RouteError(404, "Ticket not found.");
+
+    const { data: inserted, error: messageError } = await admin
+      .from("support_ticket_messages")
+      .insert({
+        ticket_id: id,
+        sender_id: session.userId,
+        sender_role: "admin",
+        body: body.body,
+      })
+      .select("id, sender_role, body, created_at")
+      .single();
+
+    if (messageError || !inserted) {
+      throw new RouteError(500, messageError?.message ?? "Could not post reply.");
+    }
+
+    // An admin reply moves an untouched ticket into "waiting on user".
+    if (ticket.status === "open") {
+      await admin
+        .from("support_tickets")
+        .update({ status: "waiting_on_user", updated_at: new Date().toISOString() })
+        .eq("id", id);
+    }
+
+    await recordAuditLog(session.userId, "reply_support_ticket", "support_ticket", id);
+
+    // Email the provider that support responded.
+    const requester = await resolveRequesterInfo(ticket.user_id);
+    await notifyProviderOfReply({
+      to: requester.email,
+      providerName: requester.name,
+      subject: ticket.subject,
+      body: body.body,
+      ticketId: id,
+    });
+
+    const message = {
+      id: inserted.id,
+      author_role: inserted.sender_role,
+      author_name: "Support Team",
+      body: inserted.body,
+      created_at: inserted.created_at,
+    };
+
+    return json({ ok: true, message }, { status: 201 });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/tickets/[id]/route.ts
+++ b/src/app/api/admin/tickets/[id]/route.ts
@@ -1,0 +1,100 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+import { resolveRequesterInfo, updateTicketSchema } from "@/app/api/_lib/support-tickets";
+import type { TablesUpdate } from "@/integrations/supabase/types";
+
+// GET /api/admin/tickets/[id] — full ticket + thread for admins.
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession(request);
+    const { id } = await params;
+    const admin = createSupabaseAdminClient();
+
+    const { data: row, error } = await admin
+      .from("support_tickets")
+      .select("id, user_id, subject, category, priority, status, created_at, updated_at, resolved_at")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!row) throw new RouteError(404, "Ticket not found.");
+
+    const requester = await resolveRequesterInfo(row.user_id);
+
+    const { data: rows, error: messagesError } = await admin
+      .from("support_ticket_messages")
+      .select("id, sender_role, body, created_at")
+      .eq("ticket_id", id)
+      .order("created_at", { ascending: true });
+
+    if (messagesError) throw new RouteError(500, messagesError.message);
+
+    const messages = (rows ?? []).map((m) => ({
+      id: m.id,
+      author_role: m.sender_role,
+      author_name: m.sender_role === "admin" ? "Support Team" : requester.name,
+      body: m.body,
+      created_at: m.created_at,
+    }));
+
+    const ticket = {
+      ...row,
+      last_message_at: row.updated_at,
+      requester_name: requester.name,
+      requester_email: requester.email,
+    };
+
+    return json({ ok: true, ticket, messages });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+// PATCH /api/admin/tickets/[id] — update status and/or priority.
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await requireAdminSession(request);
+    const { id } = await params;
+    const body = await parseJsonBody(request, updateTicketSchema);
+    const admin = createSupabaseAdminClient();
+
+    if (body.status === undefined && body.priority === undefined) {
+      throw new RouteError(400, "Nothing to update.");
+    }
+
+    const now = new Date().toISOString();
+    const update: TablesUpdate<"support_tickets"> = { updated_at: now };
+    if (body.status !== undefined) {
+      update.status = body.status;
+      update.resolved_at = body.status === "resolved" || body.status === "closed" ? now : null;
+    }
+    if (body.priority !== undefined) {
+      update.priority = body.priority;
+    }
+
+    const { data: ticket, error } = await admin
+      .from("support_tickets")
+      .update(update)
+      .eq("id", id)
+      .select("id, subject, status, priority")
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!ticket) throw new RouteError(404, "Ticket not found.");
+
+    await recordAuditLog(session.userId, "update_support_ticket", "support_ticket", id, {
+      status: body.status,
+      priority: body.priority,
+    });
+
+    return json({ ok: true, ticket });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/tickets/route.ts
+++ b/src/app/api/admin/tickets/route.ts
@@ -1,0 +1,68 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireAdminSession } from "@/app/api/_lib/supabase-server";
+import { TICKET_STATUSES, type TicketStatus } from "@/app/api/_lib/support-tickets";
+
+// GET /api/admin/tickets — every ticket, newest activity first, optional status filter.
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    const admin = createSupabaseAdminClient();
+
+    const url = new URL(request.url);
+    const statusParam = url.searchParams.get("status");
+
+    let query = admin
+      .from("support_tickets")
+      .select("id, user_id, subject, category, priority, status, created_at, updated_at")
+      .order("updated_at", { ascending: false })
+      .limit(500);
+
+    if (statusParam && TICKET_STATUSES.includes(statusParam as TicketStatus)) {
+      query = query.eq("status", statusParam);
+    }
+
+    const { data, error } = await query;
+    if (error) throw new RouteError(500, error.message);
+
+    const rows = data ?? [];
+
+    // Batch-resolve requester name/email from profiles for display.
+    const userIds = Array.from(new Set(rows.map((r) => r.user_id)));
+    const requesterMap = new Map<string, { name: string | null; email: string | null }>();
+
+    if (userIds.length > 0) {
+      const { data: profiles } = await admin
+        .from("profiles")
+        .select("user_id, full_name, display_name, email, email_address")
+        .in("user_id", userIds);
+
+      for (const p of profiles ?? []) {
+        if (!p.user_id) continue;
+        requesterMap.set(p.user_id, {
+          name: p.full_name || p.display_name || null,
+          email: p.email || p.email_address || null,
+        });
+      }
+    }
+
+    const tickets = rows.map((r) => {
+      const requester = requesterMap.get(r.user_id);
+      return {
+        ...r,
+        last_message_at: r.updated_at,
+        requester_name: requester?.name ?? null,
+        requester_email: requester?.email ?? null,
+      };
+    });
+
+    const openCount = tickets.filter(
+      (t) => t.status === "open" || t.status === "in_progress",
+    ).length;
+
+    return json({ ok: true, tickets, openCount });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/signup/submit/route.ts
+++ b/src/app/api/signup/submit/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRequestSession } from "@/app/api/_lib/session";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
-import { sendEmail } from "@/app/api/_lib/email";
-import React from "react";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
 
 export async function POST(request: NextRequest) {
   try {
@@ -80,22 +79,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Failed to save profile." }, { status: 500 });
     }
 
-    await sendEmail({
-      to: process.env.ADMIN_EMAIL || "admin@masseurmatch.com",
-      subject: "New Provider Signup Pending Review",
-      react: React.createElement("div", {}, [
-        React.createElement("h1", { key: "title" }, "New Signup"),
-        React.createElement(
-          "p",
-          { key: "body" },
-          `A new provider (${profile.full_name || session.userId}) has submitted their profile for review.`,
-        ),
-        React.createElement(
-          "a",
-          { key: "link", href: "https://masseurmatch.com/admin/therapists" },
-          "Review in Admin Dashboard",
-        ),
-      ]),
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://masseurmatch.com";
+    await notifyAdmin({
+      subject: "New provider profile submitted for review",
+      heading: "Profile submitted for review",
+      intro: `${profile.full_name || "A provider"} submitted their profile and is awaiting approval.`,
+      fields: [
+        { label: "Name", value: profile.full_name || null },
+        { label: "City", value: profile.city || null },
+        { label: "State", value: profile.state || null },
+        { label: "Plan", value: planTier || null },
+        { label: "User ID", value: session.userId },
+      ],
+      action: { label: "Review in admin", url: `${appUrl}/admin/therapists` },
     });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/support/tickets/[id]/messages/route.ts
+++ b/src/app/api/support/tickets/[id]/messages/route.ts
@@ -1,0 +1,70 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
+import { replySchema, resolveRequesterInfo, ticketAppUrl } from "@/app/api/_lib/support-tickets";
+
+// POST /api/support/tickets/[id]/messages — provider replies on their ticket.
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await requireSession(request);
+    const { id } = await params;
+    const body = await parseJsonBody(request, replySchema);
+    const admin = createSupabaseAdminClient();
+
+    const { data: ticket, error } = await admin
+      .from("support_tickets")
+      .select("id, user_id, subject")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!ticket || ticket.user_id !== session.userId) {
+      throw new RouteError(404, "Ticket not found.");
+    }
+
+    const { data: inserted, error: messageError } = await admin
+      .from("support_ticket_messages")
+      .insert({
+        ticket_id: id,
+        sender_id: session.userId,
+        sender_role: "provider",
+        body: body.body,
+      })
+      .select("id, sender_role, body, created_at")
+      .single();
+
+    if (messageError || !inserted) {
+      throw new RouteError(500, messageError?.message ?? "Could not post reply.");
+    }
+
+    const requester = await resolveRequesterInfo(session.userId);
+
+    await notifyAdmin({
+      subject: `New reply on: ${ticket.subject}`,
+      heading: "New reply on a support ticket",
+      intro: `${requester.name || "A provider"} replied to their support ticket.`,
+      fields: [
+        { label: "From", value: requester.name },
+        { label: "Email", value: requester.email ?? session.email },
+        { label: "Ticket", value: ticket.subject },
+      ],
+      message: body.body,
+      action: { label: "Open in admin", url: ticketAppUrl(`/admin/tickets?ticket=${ticket.id}`) },
+      replyTo: requester.email ?? session.email ?? null,
+    });
+
+    const message = {
+      id: inserted.id,
+      author_role: inserted.sender_role,
+      author_name: null,
+      body: inserted.body,
+      created_at: inserted.created_at,
+    };
+
+    return json({ ok: true, message }, { status: 201 });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/support/tickets/[id]/route.ts
+++ b/src/app/api/support/tickets/[id]/route.ts
@@ -1,0 +1,44 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+
+// GET /api/support/tickets/[id] — a provider's own ticket with its full thread.
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await requireSession(request);
+    const { id } = await params;
+    const admin = createSupabaseAdminClient();
+
+    const { data: ticket, error } = await admin
+      .from("support_tickets")
+      .select("id, user_id, subject, category, priority, status, created_at, updated_at")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!ticket || ticket.user_id !== session.userId) {
+      throw new RouteError(404, "Ticket not found.");
+    }
+
+    const { data: rows, error: messagesError } = await admin
+      .from("support_ticket_messages")
+      .select("id, sender_role, body, created_at")
+      .eq("ticket_id", id)
+      .order("created_at", { ascending: true });
+
+    if (messagesError) throw new RouteError(500, messagesError.message);
+
+    const messages = (rows ?? []).map((m) => ({
+      id: m.id,
+      author_role: m.sender_role,
+      author_name: m.sender_role === "admin" ? "Support Team" : null,
+      body: m.body,
+      created_at: m.created_at,
+    }));
+
+    return json({ ok: true, ticket, messages });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -1,0 +1,102 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
+import {
+  CATEGORY_LABELS,
+  createTicketSchema,
+  resolveRequesterInfo,
+  ticketAppUrl,
+  type TicketCategory,
+} from "@/app/api/_lib/support-tickets";
+
+// GET /api/support/tickets — list the signed-in provider's own tickets.
+export async function GET(request: Request) {
+  try {
+    const session = await requireSession(request);
+    const admin = createSupabaseAdminClient();
+
+    const { data, error } = await admin
+      .from("support_tickets")
+      .select("id, subject, category, priority, status, created_at, updated_at")
+      .eq("user_id", session.userId)
+      .order("updated_at", { ascending: false })
+      .limit(200);
+
+    if (error) throw new RouteError(500, error.message);
+
+    return json({ ok: true, tickets: data ?? [] });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+// POST /api/support/tickets — open a new support ticket (provider → admin).
+export async function POST(request: Request) {
+  try {
+    const session = await requireSession(request);
+    const body = await parseJsonBody(request, createTicketSchema);
+    const admin = createSupabaseAdminClient();
+
+    const requester = await resolveRequesterInfo(session.userId);
+
+    // Link the ticket to the provider's profile row when one exists.
+    const { data: profileRow } = await admin
+      .from("profiles")
+      .select("id")
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    const { data: ticket, error: ticketError } = await admin
+      .from("support_tickets")
+      .insert({
+        user_id: session.userId,
+        profile_id: profileRow?.id ?? null,
+        subject: body.subject,
+        category: body.category,
+        priority: body.priority,
+        status: "open",
+      })
+      .select("id, subject, category, priority, status, created_at")
+      .single();
+
+    if (ticketError || !ticket) {
+      throw new RouteError(500, ticketError?.message ?? "Could not create ticket.");
+    }
+
+    const { error: messageError } = await admin.from("support_ticket_messages").insert({
+      ticket_id: ticket.id,
+      sender_id: session.userId,
+      sender_role: "provider",
+      body: body.message,
+    });
+
+    if (messageError) {
+      // Roll back the orphaned ticket so we don't leave an empty thread.
+      await admin.from("support_tickets").delete().eq("id", ticket.id);
+      throw new RouteError(500, messageError.message);
+    }
+
+    // Notify the admin team that a new ticket was submitted.
+    await notifyAdmin({
+      subject: `New support ticket: ${ticket.subject}`,
+      heading: "New support ticket",
+      intro: `${requester.name || "A provider"} opened a new support ticket.`,
+      fields: [
+        { label: "From", value: requester.name },
+        { label: "Email", value: requester.email ?? session.email },
+        { label: "Category", value: CATEGORY_LABELS[ticket.category as TicketCategory] ?? ticket.category },
+        { label: "Priority", value: ticket.priority },
+        { label: "Subject", value: ticket.subject },
+      ],
+      message: body.message,
+      action: { label: "Open in admin", url: ticketAppUrl(`/admin/tickets?ticket=${ticket.id}`) },
+      replyTo: requester.email ?? session.email ?? null,
+    });
+
+    return json({ ok: true, ticket }, { status: 201 });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/pro/ProLayoutClient.tsx
+++ b/src/app/pro/ProLayoutClient.tsx
@@ -10,6 +10,7 @@ import {
   CreditCard,
   Image as ImageIcon,
   LayoutDashboard,
+  LifeBuoy,
   Loader2,
   Mail,
   Menu,
@@ -29,6 +30,7 @@ const navItems = [
   { name: "Inquiries", href: "/pro/inquiries", icon: Mail },
   { name: "Analytics", href: "/pro/analytics", icon: BarChart },
   { name: "Subscription", href: "/pro/subscription", icon: CreditCard },
+  { name: "Support", href: "/pro/tickets", icon: LifeBuoy },
   { name: "Settings", href: "/pro/settings", icon: Settings },
 ];
 

--- a/src/app/pro/tickets/page.tsx
+++ b/src/app/pro/tickets/page.tsx
@@ -1,152 +1,509 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { MessageSquare, Plus, AlertCircle, CheckCircle2, Clock, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  Loader2,
+  MessageSquare,
+  Plus,
+  RefreshCw,
+  Send,
+  ShieldCheck,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type TicketStatus = "open" | "in_progress" | "waiting_on_user" | "resolved" | "closed";
 
 type Ticket = {
   id: string;
-  title: string;
   subject: string;
-  status: "open" | "in_progress" | "resolved" | "closed";
-  priority: "low" | "medium" | "high" | "urgent";
+  category: string;
+  priority: string;
+  status: TicketStatus;
   created_at: string;
   updated_at: string;
-  last_reply?: string;
 };
+
+type TicketMessage = {
+  id: string;
+  author_role: "provider" | "admin" | "system";
+  author_name: string | null;
+  body: string;
+  created_at: string;
+};
+
+const CATEGORIES: { value: string; label: string }[] = [
+  { value: "billing", label: "Billing" },
+  { value: "payouts", label: "Payouts" },
+  { value: "technical", label: "Technical issue" },
+  { value: "profile", label: "Profile & listing" },
+  { value: "verification", label: "Verification" },
+  { value: "account", label: "Account" },
+  { value: "trust_safety", label: "Trust & Safety" },
+  { value: "other", label: "Other" },
+];
+
+const PRIORITIES = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "urgent", label: "Urgent" },
+];
+
+const STATUS_STYLES: Record<TicketStatus, string> = {
+  open: "bg-amber-100 text-amber-800",
+  in_progress: "bg-blue-100 text-blue-800",
+  waiting_on_user: "bg-purple-100 text-purple-800",
+  resolved: "bg-green-100 text-green-800",
+  closed: "bg-slate-100 text-slate-700",
+};
+
+const STATUS_LABELS: Record<TicketStatus, string> = {
+  open: "Open",
+  in_progress: "In progress",
+  waiting_on_user: "Awaiting your reply",
+  resolved: "Resolved",
+  closed: "Closed",
+};
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
 
 export default function TherapistTicketsPage() {
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<"all" | "open" | "resolved">("all");
-  const [search, setSearch] = useState("");
-  const [showNewTicket, setShowNewTicket] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<"list" | "new" | "thread">("list");
+  const [activeId, setActiveId] = useState<string | null>(null);
 
-  useEffect(() => {
-    setLoading(false);
+  const fetchTickets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/support/tickets", { cache: "no-store" });
+      if (!res.ok) throw new Error(`Failed to load tickets (${res.status}).`);
+      const json = await res.json();
+      setTickets(json.tickets ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load tickets.");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const getStatusColor = (status: Ticket["status"]) => {
-    const colors = {
-      open: "bg-yellow-100 text-yellow-800",
-      in_progress: "bg-blue-100 text-blue-800",
-      resolved: "bg-green-100 text-green-800",
-      closed: "bg-gray-100 text-gray-800",
-    };
-    return colors[status];
-  };
+  useEffect(() => {
+    void fetchTickets();
+  }, [fetchTickets]);
 
-  const getPriorityColor = (priority: Ticket["priority"]) => {
-    const colors = {
-      low: "text-gray-500",
-      medium: "text-yellow-500",
-      high: "text-orange-500",
-      urgent: "text-red-600",
-    };
-    return colors[priority];
-  };
+  const openCount = tickets.filter(
+    (t) => t.status === "open" || t.status === "in_progress" || t.status === "waiting_on_user",
+  ).length;
 
-  const filteredTickets = tickets.filter((ticket) => {
-    if (filter !== "all" && ticket.status !== filter) return false;
-    if (search && !ticket.title.toLowerCase().includes(search.toLowerCase())) return false;
-    return true;
-  });
+  if (view === "new") {
+    return (
+      <NewTicketForm
+        onCancel={() => setView("list")}
+        onCreated={(id) => {
+          void fetchTickets();
+          setActiveId(id);
+          setView("thread");
+        }}
+      />
+    );
+  }
 
-  const openCount = tickets.filter((t) => t.status === "open").length;
+  if (view === "thread" && activeId) {
+    return (
+      <TicketThread
+        ticketId={activeId}
+        onBack={() => {
+          setView("list");
+          void fetchTickets();
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-6 pb-12">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-3xl font-bold text-slate-900">Support Tickets</h1>
-          <p className="mt-1 text-sm text-slate-600">Manage your support requests and messages</p>
+          <p className="mt-1 text-sm text-slate-600">
+            Get help from the MasseurMatch team. We usually reply within one business day.
+          </p>
         </div>
-        <Button onClick={() => setShowNewTicket(true)} className="gap-2">
-          <Plus className="h-4 w-4" />
-          New Ticket
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => void fetchTickets()} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </Button>
+          <Button onClick={() => setView("new")} className="gap-2">
+            <Plus className="h-4 w-4" />
+            New Ticket
+          </Button>
+        </div>
       </div>
 
       {openCount > 0 && (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 flex items-center gap-3">
-          <AlertCircle className="h-5 w-5 text-amber-600 flex-shrink-0" />
-          <div>
-            <p className="font-semibold text-amber-900">You have {openCount} open ticket(s)</p>
-            <p className="text-sm text-amber-700">Our support team will respond soon</p>
-          </div>
+        <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <ShieldCheck className="h-5 w-5 shrink-0 text-amber-600" />
+          <p className="text-sm text-amber-800">
+            You have <strong>{openCount}</strong> active ticket{openCount === 1 ? "" : "s"}. We&apos;ll
+            email you when support replies.
+          </p>
         </div>
       )}
 
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex gap-2">
-          <Button
-            variant={filter === "all" ? "default" : "outline"}
-            onClick={() => setFilter("all")}
-            size="sm"
-          >
-            All
-          </Button>
-          <Button
-            variant={filter === "open" ? "default" : "outline"}
-            onClick={() => setFilter("open")}
-            size="sm"
-          >
-            Open
-          </Button>
-          <Button
-            variant={filter === "resolved" ? "default" : "outline"}
-            onClick={() => setFilter("resolved")}
-            size="sm"
-          >
-            Resolved
-          </Button>
-        </div>
-        <Input
-          placeholder="Search tickets..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="max-w-xs"
-        />
-      </div>
-
       {loading ? (
-        <div className="flex items-center justify-center py-12">
+        <div className="flex items-center justify-center py-20">
           <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
         </div>
-      ) : filteredTickets.length === 0 ? (
-        <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
-          <MessageSquare className="mx-auto h-8 w-8 text-slate-300" />
-          <p className="mt-2 text-sm text-slate-500">
-            {search ? "No tickets match your search" : "You haven't created any tickets yet"}
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : tickets.length === 0 ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-12 text-center">
+          <MessageSquare className="mx-auto h-10 w-10 text-slate-300" />
+          <p className="mt-3 font-medium text-slate-700">No tickets yet</p>
+          <p className="mt-1 text-sm text-slate-500">
+            Open a ticket and our team will get back to you by email.
           </p>
+          <Button onClick={() => setView("new")} className="mt-4 gap-2">
+            <Plus className="h-4 w-4" />
+            New Ticket
+          </Button>
         </div>
       ) : (
         <div className="space-y-3">
-          {filteredTickets.map((ticket) => (
+          {tickets.map((ticket) => (
             <button
               key={ticket.id}
-              className="w-full flex items-start gap-4 rounded-lg border border-slate-200 bg-white p-4 transition hover:shadow-md text-left"
+              onClick={() => {
+                setActiveId(ticket.id);
+                setView("thread");
+              }}
+              className="flex w-full items-start gap-4 rounded-xl border border-slate-200 bg-white p-4 text-left transition hover:border-slate-300 hover:shadow-md"
             >
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-slate-100">
                 <MessageSquare className="h-5 w-5 text-slate-600" />
               </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="font-semibold text-slate-900">{ticket.title}</h3>
+              <div className="min-w-0 flex-1">
+                <h3 className="truncate font-semibold text-slate-900">{ticket.subject}</h3>
                 <p className="mt-0.5 text-xs text-slate-500">
-                  {new Date(ticket.created_at).toLocaleDateString()} •{" "}
-                  {ticket.last_reply ? `Last reply: ${new Date(ticket.last_reply).toLocaleDateString()}` : "Awaiting response"}
+                  {CATEGORIES.find((c) => c.value === ticket.category)?.label ?? ticket.category} ·
+                  Updated {formatDate(ticket.updated_at)}
                 </p>
               </div>
-              <div className="flex items-center gap-2 flex-shrink-0">
-                <span className={`text-xs font-medium px-2 py-1 rounded ${getStatusColor(ticket.status)}`}>
-                  {ticket.status}
-                </span>
-              </div>
+              <span
+                className={`shrink-0 rounded px-2 py-1 text-xs font-medium ${STATUS_STYLES[ticket.status]}`}
+              >
+                {STATUS_LABELS[ticket.status]}
+              </span>
             </button>
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function NewTicketForm({
+  onCancel,
+  onCreated,
+}: {
+  onCancel: () => void;
+  onCreated: (id: string) => void;
+}) {
+  const [subject, setSubject] = useState("");
+  const [category, setCategory] = useState("other");
+  const [priority, setPriority] = useState("medium");
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setError(null);
+    if (subject.trim().length < 3) {
+      setError("Please enter a subject.");
+      return;
+    }
+    if (message.trim().length < 1) {
+      setError("Please describe your issue.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/support/tickets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subject, category, priority, message }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error ?? "Could not create ticket.");
+      }
+      onCreated(json.ticket.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not create ticket.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 pb-12">
+      <button
+        onClick={onCancel}
+        className="flex items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-900"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to tickets
+      </button>
+
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900">New Support Ticket</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Tell us what&apos;s going on and we&apos;ll get back to you by email.
+        </p>
+      </div>
+
+      <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-slate-700">Subject</label>
+          <Input
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Brief summary of your issue"
+            maxLength={160}
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-slate-700">Category</label>
+            <Select value={category} onValueChange={setCategory}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORIES.map((c) => (
+                  <SelectItem key={c.value} value={c.value}>
+                    {c.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-slate-700">Priority</label>
+            <Select value={priority} onValueChange={setPriority}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PRIORITIES.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-slate-700">Message</label>
+          <Textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Describe your issue in detail…"
+            rows={7}
+            maxLength={8000}
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={submitting} className="gap-2">
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            Submit ticket
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TicketThread({ ticketId, onBack }: { ticketId: string; onBack: () => void }) {
+  const [ticket, setTicket] = useState<Ticket | null>(null);
+  const [messages, setMessages] = useState<TicketMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reply, setReply] = useState("");
+  const [sending, setSending] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const fetchThread = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/support/tickets/${ticketId}`, { cache: "no-store" });
+      if (!res.ok) throw new Error(`Failed to load ticket (${res.status}).`);
+      const json = await res.json();
+      setTicket(json.ticket);
+      setMessages(json.messages ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load ticket.");
+    } finally {
+      setLoading(false);
+    }
+  }, [ticketId]);
+
+  useEffect(() => {
+    void fetchThread();
+  }, [fetchThread]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  const sendReply = async () => {
+    if (reply.trim().length < 1) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/support/tickets/${ticketId}/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: reply }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not send reply.");
+      setReply("");
+      await fetchThread();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not send reply.");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const isClosed = ticket?.status === "closed";
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-5 pb-12">
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1.5 text-sm text-slate-500 transition hover:text-slate-900"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to tickets
+      </button>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+        </div>
+      ) : error && !ticket ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : ticket ? (
+        <>
+          <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-200 pb-4">
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900">{ticket.subject}</h1>
+              <p className="mt-1 text-xs text-slate-500">
+                {CATEGORIES.find((c) => c.value === ticket.category)?.label ?? ticket.category} ·
+                Opened {formatDate(ticket.created_at)}
+              </p>
+            </div>
+            <span
+              className={`rounded px-2.5 py-1 text-xs font-medium ${STATUS_STYLES[ticket.status]}`}
+            >
+              {STATUS_LABELS[ticket.status]}
+            </span>
+          </div>
+
+          <div className="space-y-4">
+            {messages.map((m) => {
+              const mine = m.author_role === "provider";
+              return (
+                <div key={m.id} className={`flex ${mine ? "justify-end" : "justify-start"}`}>
+                  <div
+                    className={`max-w-[85%] rounded-2xl px-4 py-3 ${
+                      mine
+                        ? "bg-[#8B1E2D] text-white"
+                        : m.author_role === "system"
+                          ? "border border-slate-200 bg-slate-50 text-slate-600"
+                          : "border border-slate-200 bg-white text-slate-900"
+                    }`}
+                  >
+                    <p className="mb-1 text-[11px] font-medium opacity-70">
+                      {mine ? "You" : m.author_name || "Support Team"} · {formatDate(m.created_at)}
+                    </p>
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed">{m.body}</p>
+                  </div>
+                </div>
+              );
+            })}
+            <div ref={bottomRef} />
+          </div>
+
+          {isClosed ? (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-center text-sm text-slate-500">
+              This ticket is closed. Reply to reopen it.
+            </div>
+          ) : null}
+
+          <div className="space-y-2 rounded-xl border border-slate-200 bg-white p-4">
+            <Textarea
+              value={reply}
+              onChange={(e) => setReply(e.target.value)}
+              placeholder="Write a reply…"
+              rows={3}
+              maxLength={8000}
+            />
+            {error && ticket && <p className="text-sm text-red-600">{error}</p>}
+            <div className="flex justify-end">
+              <Button
+                onClick={() => void sendReply()}
+                disabled={sending || reply.trim().length < 1}
+                className="gap-2"
+              >
+                {sending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+                Send reply
+              </Button>
+            </div>
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -1489,3 +1489,28 @@ alter table public.user_roles
 alter table public.waitlist_rate_limits
   add column if not exists created_at timestamptz not null default now(),
   add column if not exists id uuid default gen_random_uuid();
+
+-- Support ticket desk (providers <-> admins). See migration
+-- 20260712120000_create_support_tickets.sql for triggers and RLS policies.
+create table if not exists public.support_tickets (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  profile_id uuid references public.profiles(id) on delete set null,
+  subject text not null,
+  category text not null default 'other',
+  priority text not null default 'medium',
+  status text not null default 'open',
+  assigned_to uuid,
+  resolved_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.support_ticket_messages (
+  id uuid primary key default gen_random_uuid(),
+  ticket_id uuid not null references public.support_tickets(id) on delete cascade,
+  sender_id uuid not null,
+  sender_role text not null default 'provider',
+  body text not null,
+  created_at timestamptz not null default now()
+);

--- a/supabase/migrations/20260712120000_create_support_tickets.sql
+++ b/supabase/migrations/20260712120000_create_support_tickets.sql
@@ -59,8 +59,11 @@ as $$
 begin
   update public.support_tickets
      set updated_at = new.created_at,
+         -- Any provider reply hands the ticket back to the admins: reopen it
+         -- from a resolved/closed state, and clear a "waiting on user" flag so
+         -- the status no longer implies the provider still owes a response.
          status = case
-           when new.sender_role = 'provider' and status in ('resolved', 'closed')
+           when new.sender_role = 'provider' and status in ('resolved', 'closed', 'waiting_on_user')
              then 'open'
            else status
          end,

--- a/supabase/migrations/20260712120000_create_support_tickets.sql
+++ b/supabase/migrations/20260712120000_create_support_tickets.sql
@@ -1,0 +1,103 @@
+-- MasseurMatch support ticket system
+-- A two-way support desk between massage therapists (providers) and admins.
+--
+-- The support_tickets / support_ticket_messages tables may already exist in the
+-- live project (they are present in the generated types), so every statement
+-- here is written to be idempotent and additive — it creates the tables only if
+-- missing and never rewrites existing columns or data. All reads/writes flow
+-- through server-side API routes using the service-role key, so RLS is
+-- deny-by-default for anon / authenticated clients.
+
+-- ---------------------------------------------------------------------------
+-- Tickets
+-- ---------------------------------------------------------------------------
+create table if not exists public.support_tickets (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  profile_id uuid null references public.profiles(id) on delete set null,
+  subject text not null,
+  category text not null default 'other',
+  priority text not null default 'medium',
+  status text not null default 'open',
+  assigned_to uuid null,
+  resolved_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists support_tickets_user_id_created_at_idx
+  on public.support_tickets (user_id, created_at desc);
+
+create index if not exists support_tickets_status_updated_at_idx
+  on public.support_tickets (status, updated_at desc);
+
+-- ---------------------------------------------------------------------------
+-- Ticket messages (thread)
+-- ---------------------------------------------------------------------------
+create table if not exists public.support_ticket_messages (
+  id uuid primary key default gen_random_uuid(),
+  ticket_id uuid not null references public.support_tickets(id) on delete cascade,
+  sender_id uuid not null,
+  sender_role text not null default 'provider',
+  body text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists support_ticket_messages_ticket_id_created_at_idx
+  on public.support_ticket_messages (ticket_id, created_at asc);
+
+-- ---------------------------------------------------------------------------
+-- Keep the parent ticket's activity timestamp fresh when a message arrives,
+-- and reopen a resolved/closed ticket when the provider replies.
+-- ---------------------------------------------------------------------------
+create or replace function public.support_ticket_touch_parent()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.support_tickets
+     set updated_at = new.created_at,
+         status = case
+           when new.sender_role = 'provider' and status in ('resolved', 'closed')
+             then 'open'
+           else status
+         end,
+         resolved_at = case
+           when new.sender_role = 'provider' and status in ('resolved', 'closed')
+             then null
+           else resolved_at
+         end
+   where id = new.ticket_id;
+  return new;
+end;
+$$;
+
+drop trigger if exists support_ticket_messages_touch_parent on public.support_ticket_messages;
+create trigger support_ticket_messages_touch_parent
+  after insert on public.support_ticket_messages
+  for each row
+  execute function public.support_ticket_touch_parent();
+
+-- ---------------------------------------------------------------------------
+-- Row level security. Tickets are managed exclusively through server routes
+-- that use the service-role key (which bypasses RLS), so direct anon /
+-- authenticated access is denied.
+-- ---------------------------------------------------------------------------
+alter table public.support_tickets enable row level security;
+alter table public.support_ticket_messages enable row level security;
+
+drop policy if exists "support_tickets_no_public_select" on public.support_tickets;
+create policy "support_tickets_no_public_select"
+  on public.support_tickets
+  for select
+  to anon, authenticated
+  using (false);
+
+drop policy if exists "support_ticket_messages_no_public_select" on public.support_ticket_messages;
+create policy "support_ticket_messages_no_public_select"
+  on public.support_ticket_messages
+  for select
+  to anon, authenticated
+  using (false);


### PR DESCRIPTION
## Summary

Builds a complete two-way support ticket system between massage therapists (providers) and admins, plus admin email notifications for every event submitted to the admin team. Notifications default to **admin@xrankflow.com** (override with `ADMIN_NOTIFICATION_EMAIL`).

## Ticket system

- **Migration + schema-lock entry** for `support_tickets` / `support_ticket_messages`. These tables already existed in the generated Supabase types but had no migration, so this aligns to that exact shape (`sender_id`/`sender_role`, `profile_id`, `resolved_at`) and is fully idempotent (`create table if not exists`, `drop … if exists`). A trigger bumps `updated_at` on each reply and auto-reopens a resolved/closed ticket when the provider writes back. RLS denies anon/authenticated; all access is server-side via the service role.
- **Provider API** (`/api/support/tickets…`): list own tickets, open a ticket, view a thread, reply — ownership-checked.
- **Admin API** (`/api/admin/tickets…`): list/filter all tickets, view a thread, reply, update status/priority, with audit-log entries.
- **UI**: rebuilt the placeholder `/pro/tickets` and `/admin/tickets` pages into real chat-style thread views with a new-ticket form and admin status/priority controls, using the brand palette and lucide icons. Added **Support** to the pro nav and **Tickets** to the admin sidebar.

## Admin email notifications (→ admin@xrankflow.com)

A central `notifyAdmin` helper renders a branded HTML alert. It fires on:

- **New account created** — hooked into `ensureUserProfileAndRole`, firing once per account for both email/password registration and social login.
- **New provider profile submitted for review** (existing signup-submit email rerouted through the helper).
- **New support ticket** and **every provider reply**.

Providers are emailed when an admin replies to their ticket. All sends are best-effort and never block the primary operation.

## Verification

- `pnpm typecheck` — 0 errors
- `eslint` on all changed files — clean
- `pnpm build` — succeeds; all new routes compile
- `validate:db-contract` — OK

Could not exercise flows against a live Supabase/Resend from the dev environment (no creds / restricted network). To go live: apply the migration and ensure `RESEND_API_KEY` is set (`ADMIN_NOTIFICATION_EMAIL` documented in `.env.example`, defaults to admin@xrankflow.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dz4JN88eyBZCw9SCWoTqNV)_