### PR TITLE
Add provider city landing pages with dynamic routing

### DIFF
--- a/src/app/_components/site-footer.tsx
+++ b/src/app/_components/site-footer.tsx
@@ -14,8 +14,13 @@ export function SiteFooter() {
     return <SiteFooterTalk />;
   }
 
-  // Admin and Pro layouts have their own chrome — hide the marketing footer
-  if (pathname?.startsWith("/admin") || pathname?.startsWith("/pro")) {
+  // Admin, Pro, and the provider landing pages have their own chrome —
+  // hide the marketing footer
+  if (
+    pathname?.startsWith("/admin") ||
+    pathname?.startsWith("/pro") ||
+    pathname?.startsWith("/providers")
+  ) {
     return null;
   }
 

--- a/src/app/_components/site-header.tsx
+++ b/src/app/_components/site-header.tsx
@@ -418,7 +418,9 @@ export default function SiteHeader() {
   const router = useRouter();
   const shouldReduceMotion = useReducedMotion();
   const isAppSection =
-    pathname?.startsWith("/admin") || pathname?.startsWith("/pro");
+    pathname?.startsWith("/admin") ||
+    pathname?.startsWith("/pro") ||
+    pathname?.startsWith("/providers");
 
   useEffect(() => {
     const handleScroll = () => setIsScrolled(window.scrollY > 20);

--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -1,11 +1,25 @@
 "use client";
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/integrations/supabase/client";
 
-export default function AuthConfirmPage() {
+function ConfirmShell() {
+  return (
+    <div className="container mx-auto max-w-lg px-4 py-10">
+      <div className="rounded-lg border border-border p-6 text-center text-sm text-muted-foreground">
+        Validating your reset link… If nothing happens, please{" "}
+        <Link href="/forgot-password" className="underline">
+          request a new link
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}
+
+function AuthConfirm() {
   const router = useRouter();
   const params = useSearchParams();
 
@@ -36,15 +50,15 @@ export default function AuthConfirmPage() {
       });
   }, []);
 
+  return <ConfirmShell />;
+}
+
+// `useSearchParams()` requires a Suspense boundary so the page can be
+// statically prerendered without bailing the whole build.
+export default function AuthConfirmPage() {
   return (
-    <div className="container mx-auto max-w-lg px-4 py-10">
-      <div className="rounded-lg border border-border p-6 text-center text-sm text-muted-foreground">
-        Validating your reset link… If nothing happens, please{" "}
-        <Link href="/forgot-password" className="underline">
-          request a new link
-        </Link>
-        .
-      </div>
-    </div>
+    <Suspense fallback={<ConfirmShell />}>
+      <AuthConfirm />
+    </Suspense>
   );
 }

--- a/src/app/providers/[citySlug]/page.tsx
+++ b/src/app/providers/[citySlug]/page.tsx
@@ -1,0 +1,221 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight } from "lucide-react";
+
+import { Benefits } from "@/components/city-landing/Benefits";
+import { CityHero } from "@/components/city-landing/CityHero";
+import { FAQ, FAQ_ITEMS } from "@/components/city-landing/FAQ";
+import { FinalCTA } from "@/components/city-landing/FinalCTA";
+import { HowItWorks } from "@/components/city-landing/HowItWorks";
+import { LocalHighlight } from "@/components/city-landing/LocalHighlight";
+import { TrustSection } from "@/components/city-landing/TrustSection";
+import type { City } from "@/data/provider-cities";
+import { getCity, getCitySlugs } from "@/lib/get-city";
+import { SITE_URL } from "@/lib/site";
+
+type Params = { citySlug: string };
+
+/** Base site URL used for canonical + Open Graph absolute URLs. */
+const baseUrl = SITE_URL;
+/** Where the "Create Your Profile" flow lives. */
+const signupUrl = "/signup";
+
+/** Build the tracked signup CTA for a given city. */
+function buildProfileHref(city: City): string {
+  return `${signupUrl}?city=${city.slug}&utm_source=landing_page&utm_medium=organic&utm_campaign=city_directory`;
+}
+
+/** Pre-render every registered city at build time. */
+export function generateStaticParams(): Params[] {
+  return getCitySlugs().map((citySlug) => ({ citySlug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { citySlug } = await params;
+  const city = getCity(citySlug);
+
+  if (!city) {
+    return {
+      title: "City Not Found | MasseurMatch",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const title = `Massage Professionals in ${city.name}, ${city.stateCode} | MasseurMatch`;
+  const description = `Create your professional MasseurMatch profile and join the massage provider directory for ${city.name}, ${city.stateCode}. Start a 14-day free trial with no credit card required.`;
+  const path = `/providers/${city.slug}`;
+  const canonical = `${baseUrl}${path}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: "website",
+      url: canonical,
+      siteName: "MasseurMatch",
+      title,
+      description,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function ProviderCityLandingPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { citySlug } = await params;
+  const city = getCity(citySlug);
+
+  if (!city) {
+    notFound();
+  }
+
+  const path = `/providers/${city.slug}`;
+  const canonical = `${baseUrl}${path}`;
+  const profileHref = buildProfileHref(city);
+
+  // JSON-LD: WebPage (not LocalBusiness — MasseurMatch is a directory platform,
+  // not a physical massage business).
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: `Massage Professionals in ${city.name}, ${city.stateCode} | MasseurMatch`,
+    description: `Create your professional MasseurMatch profile and join the massage provider directory for ${city.name}, ${city.stateCode}. Start a 14-day free trial with no credit card required.`,
+    url: canonical,
+    inLanguage: "en-US",
+    isPartOf: {
+      "@type": "WebSite",
+      name: "MasseurMatch",
+      url: baseUrl,
+    },
+    mainEntity: {
+      "@type": "FAQPage",
+      mainEntity: FAQ_ITEMS.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: { "@type": "Answer", text: item.answer },
+      })),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <div className="flex min-h-screen flex-col bg-background font-sans text-foreground">
+        <SiteHeader profileHref={profileHref} />
+
+        <main id="main" className="flex-1">
+          <CityHero city={city} profileHref={profileHref} />
+          <Benefits />
+          <HowItWorks />
+          <LocalHighlight city={city} />
+          <TrustSection />
+          <FAQ />
+          <FinalCTA city={city} profileHref={profileHref} />
+        </main>
+
+        <SiteFooter />
+      </div>
+    </>
+  );
+}
+
+/** Landing-page header: wordmark, login, and primary CTA. */
+function SiteHeader({ profileHref }: { profileHref: string }) {
+  return (
+    <header className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur">
+      <div className="page-shell flex h-16 items-center justify-between">
+        <Link
+          href="/"
+          className="rounded-md text-lg font-bold tracking-tight text-foreground focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20"
+        >
+          Masseur<span className="text-accent">Match</span>
+        </Link>
+
+        <nav className="flex items-center gap-2 sm:gap-4" aria-label="Primary">
+          <Link
+            href="/login"
+            className="rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20"
+          >
+            Log in
+          </Link>
+          <Link
+            href={profileHref}
+            className="inline-flex items-center gap-1.5 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#6E1521] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20"
+          >
+            Create Your Profile
+            <ArrowRight className="size-4" strokeWidth={2.5} aria-hidden="true" />
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+const FOOTER_LINKS: { label: string; href: string }[] = [
+  { label: "Terms of Service", href: "/terms" },
+  { label: "Privacy Policy", href: "/privacy" },
+  { label: "Provider Guidelines", href: "/community-guidelines" },
+  { label: "Content Policy", href: "/content-guidelines" },
+  { label: "Contact", href: "/contact" },
+  { label: "Login", href: "/login" },
+];
+
+/** Landing-page footer: legal links + directory-only disclaimer. */
+function SiteFooter() {
+  return (
+    <footer className="border-t border-border bg-[#F7F7F7]">
+      <div className="page-shell py-12">
+        <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="text-lg font-bold tracking-tight text-foreground">
+              Masseur<span className="text-accent">Match</span>
+            </p>
+            <p className="mt-3 max-w-md text-sm leading-relaxed text-muted-foreground">
+              MasseurMatch is a directory platform only. We do not provide
+              massage services directly, and we do not employ or represent the
+              independent providers listed in the directory.
+            </p>
+          </div>
+
+          <nav aria-label="Footer">
+            <ul className="grid grid-cols-2 gap-x-10 gap-y-3 sm:grid-cols-3">
+              {FOOTER_LINKS.map(({ label, href }) => (
+                <li key={label}>
+                  <Link
+                    href={href}
+                    className="rounded-md text-sm text-muted-foreground transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20"
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+
+        <div className="mt-10 border-t border-border pt-6">
+          <p className="text-xs text-muted-foreground">
+            © {new Date().getFullYear()} MasseurMatch. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,6 +9,7 @@ import {
   buildBlogPostsSitemapEntries,
   buildTourPagesSitemapEntries,
 } from "@/app/_lib/seo-routes";
+import { getAllCities } from "@/lib/get-city";
 import { siteUrl } from "@/lib/site";
 
 // Regenerate sitemap every hour so new profiles and city pages appear promptly
@@ -27,6 +28,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]);
 
   const core = buildCoreSitemapEntries(now);
+
+  // Provider signup landing pages (/providers/[citySlug]) — surfaced so the
+  // pre-rendered per-city SEO pages are discoverable by crawlers.
+  const providerLandingPages: MetadataRoute.Sitemap = getAllCities().map((city) => ({
+    url: siteUrl(`/providers/${city.slug}`),
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: 0.75,
+  }));
 
   // High-priority hub pages
   const hubs: MetadataRoute.Sitemap = [
@@ -47,6 +57,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     ...hubs,
     ...core,
+    ...providerLandingPages,
     ...cities,
     ...services,
     ...neighborhoods,

--- a/src/components/city-landing/Benefits.tsx
+++ b/src/components/city-landing/Benefits.tsx
@@ -1,0 +1,64 @@
+import {
+  BadgeCheck,
+  Images,
+  LayoutDashboard,
+  MapPin,
+  MessageSquare,
+  type LucideIcon,
+} from "lucide-react";
+
+type Benefit = {
+  icon: LucideIcon;
+  title: string;
+};
+
+const BENEFITS: Benefit[] = [
+  { icon: BadgeCheck, title: "Create a professional provider profile" },
+  { icon: Images, title: "Showcase your services, photos, rates and service area" },
+  { icon: MapPin, title: "Appear in the local MasseurMatch directory" },
+  { icon: MessageSquare, title: "Receive inquiries directly from potential clients" },
+  { icon: LayoutDashboard, title: "Manage your listing through your provider dashboard" },
+];
+
+/**
+ * "What you get" grid. Generic and city-agnostic — no results are promised
+ * (no client counts, leads, bookings, or income).
+ */
+export function Benefits() {
+  return (
+    <section aria-labelledby="benefits-heading" className="bg-[#F7F7F7]">
+      <div className="page-shell py-20 sm:py-24">
+        <div className="mx-auto max-w-2xl text-center">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+            What you get
+          </span>
+          <h2
+            id="benefits-heading"
+            className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-[2rem]"
+          >
+            Everything you need to build your listing
+          </h2>
+        </div>
+
+        <ul
+          role="list"
+          className="mx-auto mt-12 grid max-w-5xl gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {BENEFITS.map(({ icon: Icon, title }) => (
+            <li
+              key={title}
+              className="flex items-start gap-4 rounded-2xl border border-border bg-[#FAFAFA] p-6 transition-colors hover:border-[#D9D9D9]"
+            >
+              <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent">
+                <Icon className="size-6" strokeWidth={2.25} aria-hidden="true" />
+              </span>
+              <p className="pt-1 text-base font-medium leading-snug text-foreground">
+                {title}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/city-landing/CityHero.tsx
+++ b/src/components/city-landing/CityHero.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import { ArrowRight, PlayCircle, ShieldCheck } from "lucide-react";
+import type { City } from "@/data/provider-cities";
+
+type CityHeroProps = {
+  city: City;
+  /** Fully-built signup CTA URL (includes ?city=…&utm_*). */
+  profileHref: string;
+  /** Anchor target for the secondary "how it works" button. */
+  howItWorksHref?: string;
+};
+
+/**
+ * Hero band for the provider landing page. Fully dynamic — every city string is
+ * interpolated from `city`, nothing is hard-coded.
+ */
+export function CityHero({ city, profileHref, howItWorksHref = "#how-it-works" }: CityHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-background">
+      {/* Restrained radial dot grid + soft glow, per brand effects guidance. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-[0.5]"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 1px 1px, rgb(17 17 17 / 0.06) 1px, transparent 0)",
+          backgroundSize: "22px 22px",
+          maskImage:
+            "radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%)",
+          WebkitMaskImage:
+            "radial-gradient(ellipse 80% 60% at 50% 0%, #000 40%, transparent 100%)",
+        }}
+      />
+      <div className="page-shell relative py-20 sm:py-28 lg:py-32">
+        <div className="mx-auto max-w-3xl text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-accent/5 px-4 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+            <ShieldCheck className="size-3.5" strokeWidth={2.5} aria-hidden="true" />
+            {city.state} · {city.stateCode}
+          </span>
+
+          <h1 className="mt-6 text-[2rem] font-bold leading-[1.1] tracking-tight text-foreground sm:text-[2.75rem] lg:text-[3.5rem]">
+            Get Listed in the Massage Directory for{" "}
+            <span className="text-accent">{city.name}</span>
+          </h1>
+
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+            Create a professional profile and make it easier for clients in{" "}
+            {city.name}, {city.stateCode} to discover your massage and bodywork
+            services.
+          </p>
+
+          <div className="mt-8 flex flex-col items-center gap-3">
+            <p className="text-lg font-semibold text-foreground">
+              Start your 14-day free trial
+            </p>
+            <p className="text-sm text-muted-foreground">No credit card required.</p>
+          </div>
+
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Link
+              href={profileHref}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-accent px-7 py-3.5 text-base font-semibold text-white shadow-sm transition-colors hover:bg-[#6E1521] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20 sm:w-auto"
+            >
+              Create Your Profile
+              <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden="true" />
+            </Link>
+            <Link
+              href={howItWorksHref}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-border bg-background px-7 py-3.5 text-base font-semibold text-foreground transition-colors hover:bg-[#F7F7F7] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20 sm:w-auto"
+            >
+              <PlayCircle className="size-5" strokeWidth={2.25} aria-hidden="true" />
+              Learn How It Works
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/city-landing/FAQ.tsx
+++ b/src/components/city-landing/FAQ.tsx
@@ -1,0 +1,91 @@
+import { ChevronDown } from "lucide-react";
+
+export type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+/**
+ * Reusable, city-agnostic FAQ content. Exported so the same set can be fed into
+ * JSON-LD or reused elsewhere. Answers avoid promising any results.
+ */
+export const FAQ_ITEMS: FaqItem[] = [
+  {
+    question: "Is a credit card required for the trial?",
+    answer:
+      "No. As long as this offer remains active, you can start your free trial without entering any credit card details.",
+  },
+  {
+    question: "How long is the free trial?",
+    answer: "The free trial lasts 14 days.",
+  },
+  {
+    question: "Does MasseurMatch guarantee clients or bookings?",
+    answer:
+      "No. MasseurMatch is a directory platform and does not guarantee clients, leads, bookings, income or any results. It helps make your profile easier to find.",
+  },
+  {
+    question: "Can I edit my profile after publishing?",
+    answer:
+      "Yes. You can update your services, photos, rates and other details at any time from your provider dashboard.",
+  },
+  {
+    question: "Who is responsible for verifying professional licensing requirements?",
+    answer:
+      "You are. As an independent provider, you are responsible for verifying and meeting any licensing and legal requirements that apply to your services in your area.",
+  },
+  {
+    question: "What types of services are prohibited?",
+    answer:
+      "Sexual services, erotic services, escorting, solicitation and any illegal activity are strictly prohibited on the platform.",
+  },
+];
+
+type FAQProps = {
+  items?: FaqItem[];
+};
+
+/**
+ * FAQ accordion built on native <details>/<summary> — fully keyboard
+ * accessible with visible focus, and no client-side JavaScript required.
+ */
+export function FAQ({ items = FAQ_ITEMS }: FAQProps) {
+  return (
+    <section aria-labelledby="faq-heading" className="bg-[#F7F7F7]">
+      <div className="page-shell py-20 sm:py-24">
+        <div className="mx-auto max-w-2xl text-center">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+            FAQ
+          </span>
+          <h2
+            id="faq-heading"
+            className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-[2rem]"
+          >
+            Frequently asked questions
+          </h2>
+        </div>
+
+        <div className="mx-auto mt-10 max-w-3xl space-y-3">
+          {items.map(({ question, answer }) => (
+            <details
+              key={question}
+              className="group rounded-2xl border border-border bg-background px-6 [&_summary]:list-none"
+            >
+              <summary className="flex cursor-pointer items-center justify-between gap-4 py-5 text-left text-base font-semibold text-foreground focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-accent/20 rounded-2xl">
+                {question}
+                <ChevronDown
+                  className="size-5 shrink-0 text-accent transition-transform duration-200 group-open:rotate-180"
+                  strokeWidth={2.25}
+                  aria-hidden="true"
+                />
+              </summary>
+              <p className="pb-5 text-sm leading-relaxed text-muted-foreground">
+                {answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/city-landing/FinalCTA.tsx
+++ b/src/components/city-landing/FinalCTA.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import type { City } from "@/data/provider-cities";
+
+type FinalCTAProps = {
+  city: City;
+  /** Fully-built signup CTA URL (includes ?city=…&utm_*). */
+  profileHref: string;
+};
+
+/**
+ * Closing call-to-action. City name is interpolated; no results are promised.
+ */
+export function FinalCTA({ city, profileHref }: FinalCTAProps) {
+  return (
+    <section aria-labelledby="final-cta-heading" className="bg-background">
+      <div className="page-shell pb-24 pt-4 sm:pb-28">
+        <div className="relative mx-auto max-w-4xl overflow-hidden rounded-3xl bg-accent px-8 py-14 text-center sm:px-12 sm:py-16">
+          {/* Restrained single-color glow. */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 opacity-40"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 50% 0%, rgb(255 255 255 / 0.25), transparent 60%)",
+            }}
+          />
+          <div className="relative">
+            <h2
+              id="final-cta-heading"
+              className="text-2xl font-bold tracking-tight text-white sm:text-[2rem]"
+            >
+              Ready to Create Your Professional Profile?
+            </h2>
+            <p className="mx-auto mt-4 max-w-xl text-base leading-relaxed text-white/85 sm:text-lg">
+              Start your 14-day free trial and build your presence in the{" "}
+              {city.name} directory.
+            </p>
+            <Link
+              href={profileHref}
+              className="mt-8 inline-flex items-center justify-center gap-2 rounded-full bg-white px-8 py-3.5 text-base font-semibold text-accent shadow-sm transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-white/40"
+            >
+              Start Your Free Trial
+              <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden="true" />
+            </Link>
+            <p className="mt-4 text-sm text-white/70">No credit card required.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/city-landing/HowItWorks.tsx
+++ b/src/components/city-landing/HowItWorks.tsx
@@ -1,0 +1,83 @@
+import { ClipboardList, UserPlus, UserSquare, type LucideIcon } from "lucide-react";
+
+type Step = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+const STEPS: Step[] = [
+  {
+    icon: UserPlus,
+    title: "Create your account",
+    description: "Sign up in a few minutes to get started — no credit card required.",
+  },
+  {
+    icon: UserSquare,
+    title: "Build your professional profile",
+    description:
+      "Add your services, photos, rates and service area so clients understand what you offer.",
+  },
+  {
+    icon: ClipboardList,
+    title: "Submit your listing for platform review",
+    description:
+      "Send your profile in and our team reviews it before it goes live in the directory.",
+  },
+];
+
+/**
+ * Three-step "how it works". The `#how-it-works` id is the target of the hero's
+ * secondary CTA.
+ */
+export function HowItWorks() {
+  return (
+    <section
+      id="how-it-works"
+      aria-labelledby="how-it-works-heading"
+      className="scroll-mt-20 bg-background"
+    >
+      <div className="page-shell py-20 sm:py-24">
+        <div className="mx-auto max-w-2xl text-center">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-accent">
+            How it works
+          </span>
+          <h2
+            id="how-it-works-heading"
+            className="mt-3 text-2xl font-bold tracking-tight text-foreground sm:text-[2rem]"
+          >
+            Three steps to your listing
+          </h2>
+        </div>
+
+        <ol
+          role="list"
+          className="mx-auto mt-12 grid max-w-5xl gap-6 md:grid-cols-3"
+        >
+          {STEPS.map(({ icon: Icon, title, description }, index) => (
+            <li
+              key={title}
+              className="relative rounded-2xl border border-border bg-[#FAFAFA] p-7"
+            >
+              <div className="flex items-center gap-3">
+                <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent text-white">
+                  <Icon className="size-6" strokeWidth={2.25} aria-hidden="true" />
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="font-mono text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+                >
+                  Step {index + 1}
+                </span>
+              </div>
+              <h3 className="mt-5 text-lg font-semibold text-foreground">{title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/components/city-landing/LocalHighlight.tsx
+++ b/src/components/city-landing/LocalHighlight.tsx
@@ -1,0 +1,35 @@
+import { MapPinned } from "lucide-react";
+import type { City } from "@/data/provider-cities";
+
+type LocalHighlightProps = {
+  city: City;
+};
+
+/**
+ * Dynamic local-presence band. Title interpolates the city name; copy stays
+ * generic and makes no promises about results or guarantees.
+ */
+export function LocalHighlight({ city }: LocalHighlightProps) {
+  return (
+    <section aria-labelledby="local-highlight-heading" className="bg-[#111111]">
+      <div className="page-shell py-20 sm:py-24">
+        <div className="mx-auto max-w-3xl text-center text-white">
+          <span className="inline-flex items-center justify-center rounded-2xl bg-white/10 p-3 text-white">
+            <MapPinned className="size-6" strokeWidth={2.25} aria-hidden="true" />
+          </span>
+          <h2
+            id="local-highlight-heading"
+            className="mt-6 text-2xl font-bold tracking-tight sm:text-[2rem]"
+          >
+            Build Your Professional Presence in {city.name}
+          </h2>
+          <p className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-white/70 sm:text-lg">
+            MasseurMatch helps independent massage and bodywork professionals
+            create an online presence and become easier to find through a
+            dedicated local directory.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/city-landing/TrustSection.tsx
+++ b/src/components/city-landing/TrustSection.tsx
@@ -1,0 +1,52 @@
+import { Info, ShieldAlert } from "lucide-react";
+
+/**
+ * Trust / disclaimer band. Uses clear, professional language and makes the
+ * platform's role explicit: MasseurMatch is a directory, not a service provider
+ * or employer. No claims about verifying licensing, safety, quality, or
+ * credentials are made here.
+ */
+export function TrustSection() {
+  return (
+    <section aria-labelledby="trust-heading" className="bg-background">
+      <div className="page-shell py-20 sm:py-24">
+        <div className="mx-auto max-w-3xl">
+          <div className="rounded-3xl border border-border bg-[#FAFAFA] p-8 sm:p-10">
+            <div className="flex items-start gap-4">
+              <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent">
+                <Info className="size-6" strokeWidth={2.25} aria-hidden="true" />
+              </span>
+              <div>
+                <h2
+                  id="trust-heading"
+                  className="text-xl font-bold tracking-tight text-foreground"
+                >
+                  About the platform
+                </h2>
+                <p className="mt-3 text-base leading-relaxed text-muted-foreground">
+                  MasseurMatch is an online directory for independent massage and
+                  bodywork providers. Providers are independent third parties and
+                  are responsible for their own services, credentials,
+                  communications, scheduling, payments and compliance with
+                  applicable laws.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-6 flex items-start gap-4 rounded-2xl border border-[#F1D9DC] bg-[#F8EDEE] p-5">
+              <ShieldAlert
+                className="mt-0.5 size-5 shrink-0 text-accent"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+              <p className="text-sm font-medium leading-relaxed text-[#6E1521]">
+                Sexual services, erotic services, escorting, solicitation and
+                illegal activity are strictly prohibited.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/data/provider-cities.ts
+++ b/src/data/provider-cities.ts
@@ -1,0 +1,74 @@
+/**
+ * Provider landing-page city configuration.
+ *
+ * This is the single source of truth for the reusable `/providers/[citySlug]`
+ * marketing landing pages. Every city that should have a landing page must be
+ * registered here — the page component reads from this map and never hard-codes
+ * a city name.
+ *
+ * NOTE: This is intentionally separate from `src/data/cities.ts` (the large
+ * directory dataset consumed by the public `[city]` browse routes). Keeping the
+ * landing-page config isolated lets us grow the marketing template independently
+ * without touching directory data.
+ *
+ * ── How to add a new city ──────────────────────────────────────────────────
+ *   Add one entry to the `cities` object below, keyed by its URL slug:
+ *
+ *     "sarasota": {
+ *       name: "Sarasota",
+ *       state: "Florida",
+ *       stateCode: "FL",
+ *     },
+ *
+ *   The slug (the object key) becomes the URL: /providers/sarasota
+ *   Rules for a good slug: lowercase, ASCII, words separated by single hyphens,
+ *   no spaces or punctuation (e.g. "St. Petersburg" -> "st-petersburg").
+ *   That's it — `generateStaticParams()` will pre-render the new page on the
+ *   next build, and metadata/SEO are generated automatically.
+ */
+
+/** Raw config shape authored by hand in the `cities` map below. */
+export type CityConfig = {
+  /** Display name, e.g. "St. Petersburg". */
+  name: string;
+  /** Full state name, e.g. "Florida". */
+  state: string;
+  /** Two-letter USPS state code, e.g. "FL". */
+  stateCode: string;
+};
+
+/**
+ * Resolved city passed to page components. Adds the URL `slug` (the map key)
+ * so components never have to know where the data came from.
+ */
+export type City = CityConfig & {
+  /** URL slug, e.g. "st-petersburg". Matches the key in the `cities` map. */
+  slug: string;
+};
+
+/**
+ * Registered cities, keyed by URL slug. Add new cities here — see the
+ * "How to add a new city" note at the top of this file.
+ */
+export const cities: Record<string, CityConfig> = {
+  "st-petersburg": {
+    name: "St. Petersburg",
+    state: "Florida",
+    stateCode: "FL",
+  },
+  miami: {
+    name: "Miami",
+    state: "Florida",
+    stateCode: "FL",
+  },
+  orlando: {
+    name: "Orlando",
+    state: "Florida",
+    stateCode: "FL",
+  },
+  tampa: {
+    name: "Tampa",
+    state: "Florida",
+    stateCode: "FL",
+  },
+};

--- a/src/lib/get-city.ts
+++ b/src/lib/get-city.ts
@@ -1,0 +1,22 @@
+import { cities, type City } from "@/data/provider-cities";
+
+/**
+ * Resolve a city by its URL slug from the provider landing-page config.
+ * Returns the fully-resolved {@link City} (config + slug) or `null` when the
+ * slug is not registered, so callers can trigger `notFound()`.
+ */
+export function getCity(slug: string): City | null {
+  const config = cities[slug];
+  if (!config) return null;
+  return { ...config, slug };
+}
+
+/** Every registered city slug — used by `generateStaticParams()`. */
+export function getCitySlugs(): string[] {
+  return Object.keys(cities);
+}
+
+/** Every registered city, resolved. */
+export function getAllCities(): City[] {
+  return getCitySlugs().map((slug) => ({ ...cities[slug], slug }));
+}


### PR DESCRIPTION
## Summary

Introduces a new `/providers/[citySlug]` dynamic landing page template for marketing massage provider sign-ups by city. The page is fully data-driven, pulling city metadata from a centralized config, and pre-renders all registered cities at build time. Every section is reusable, city-agnostic, and makes no fabricated claims about results or guarantees.

## Key Changes

- **New page route** `src/app/providers/[citySlug]/page.tsx`
  - Dynamic, pre-rendered via `generateStaticParams()` for all registered cities
  - Metadata generation (title, description, canonical, Open Graph, Twitter cards)
  - JSON-LD structured data (WebPage + FAQPage schema)
  - Tracked signup CTAs with UTM parameters (`?city=…&utm_source=landing_page&utm_medium=organic&utm_campaign=city_directory`)
  - Sticky header with logo, login link, and primary CTA
  - Footer with legal links and directory-only disclaimer

- **City configuration** `src/data/provider-cities.ts`
  - Single source of truth for landing-page cities (separate from the large directory dataset)
  - Extensible `Record<slug, CityConfig>` map with clear documentation on how to add new cities
  - Includes four Florida cities: St. Petersburg, Miami, Orlando, Tampa

- **Utility functions** `src/lib/get-city.ts`
  - `getCity(slug)` — resolve a city by slug or return `null` for 404 handling
  - `getCitySlugs()` — all registered slugs (used by `generateStaticParams()`)
  - `getAllCities()` — fully resolved city list

- **Reusable landing-page components** in `src/components/city-landing/`
  - `CityHero` — dynamic hero with city name, state, and dual CTAs (primary signup + secondary "how it works" anchor)
  - `Benefits` — five-item grid of what providers get (profile, photos, directory listing, inquiries, dashboard)
  - `HowItWorks` — three-step process (account → profile → review)
  - `LocalHighlight` — dark band emphasizing local presence (city name interpolated)
  - `TrustSection` — platform disclaimer and prohibited-activity warning
  - `FAQ` — native `<details>/<summary>` accordion with reusable `FAQ_ITEMS` array (also fed into JSON-LD)
  - `FinalCTA` — closing call-to-action with city name

## Implementation Details

- **No results promised**: All copy avoids guarantees about clients, leads, bookings, income, or licensing verification. Statements are process-focused ("reviewed before going live").
- **Accessibility**: Native `<details>` for FAQ (no JS required), proper ARIA labels, focus rings, keyboard navigation throughout.
- **SEO**: Canonical URLs, structured data, descriptive metadata per city, no indexing for 404 pages.
- **Brand consistency**: Premium icons (lucide-react), sober red/black/white palette, Satoshi font, restrained effects (dot grid, soft glows).
- **Extensibility**: Adding a new city requires only one entry in the `cities` map; page, metadata, and pre-rendering are automatic.

https://claude.ai/code/session_014gWonskGKPJNkJiudW1goj