### PR TITLE
Replace ★ glyph with lucide Star on featured homepage cards

### DIFF
--- a/src/components/marketing/FeaturedTherapistsEditorial.tsx
+++ b/src/components/marketing/FeaturedTherapistsEditorial.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ArrowRight, BadgeCheck } from "lucide-react";
+import { ArrowRight, BadgeCheck, Star } from "lucide-react";
 import { GrainOverlay } from "@/components/motion/GrainOverlay";
 import type { PublicTherapist } from "@/app/_lib/directory";
 
@@ -112,7 +112,8 @@ export function FeaturedTherapistsEditorial({ featuredTherapists }: Props) {
                       </div>
                     )}
                     <div className="absolute right-4 top-4 flex items-center gap-1 rounded-full bg-gradient-to-r from-[#8B1E2D] to-[#A82E3D] px-3 py-1.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-lg">
-                      ★ Featured
+                      <Star size={11} className="fill-white" strokeWidth={2.5} />
+                      Featured
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary

Swaps the literal `★ Featured` text glyph on the featured-therapist homepage cards for a filled `lucide-react` `<Star>`, per the project design standard ("premium icons everywhere — no text-glyph or emoji icons").

## Context

This branch came out of an investigation into the homepage `smoke › loads /` React #418 hydration mismatch seen on PR #512's reopened preview. That error could **not** be reproduced locally (clean hydration in both `next dev` and a production `next build` with real data) and showed no code-level hydration hazards; evidence points to it being specific to that preview branch's seed data (it passed on the identical commit's other deployment and auto-recovers). No speculative changes were made to the working homepage code. This PR ships only the one concrete, safe cleanup found along the way.

## Changes

- `FeaturedTherapistsEditorial`: `★ Featured` → `<Star size={11} className="fill-white" strokeWidth={2.5} />` + `Featured` label; added `Star` to the existing `lucide-react` import.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on the changed file — clean
- Production build renders the badge with the icon; homepage hydrates with zero console errors locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GF1jarNdKkBA6ecamjKry)_