### PR TITLE
Fix React hydration error #418 at the document root

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={satoshi.variable}>
+    <html lang="en-US" className={satoshi.variable} suppressHydrationWarning>
       <body className="theme-masseurmatch min-h-screen overflow-x-hidden font-sans text-foreground antialiased">
         <GoogleTagManager />
         <GoogleAnalytics />

--- a/tests/audit/hydration.spec.ts
+++ b/tests/audit/hydration.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test, type ConsoleMessage, type Page } from "@playwright/test";
+
+const ROUTES = ["/", "/free?city=Dallas", "/therapists"] as const;
+const HYDRATION_ERROR = /(?:minified react error\s*#418|hydration|hydrating|server rendered html|did(?: not|n't) match)/i;
+
+function collectHydrationErrors(page: Page): string[] {
+  const errors: string[] = [];
+
+  page.on("console", (message: ConsoleMessage) => {
+    if (message.type() !== "error") return;
+
+    const text = message.text();
+    if (HYDRATION_ERROR.test(text)) {
+      errors.push(text);
+    }
+  });
+
+  page.on("pageerror", (error) => {
+    const text = String(error?.message ?? error);
+    if (HYDRATION_ERROR.test(text)) {
+      errors.push(`pageerror: ${text}`);
+    }
+  });
+
+  return errors;
+}
+
+test.describe("React hydration", () => {
+  for (const route of ROUTES) {
+    test(`${route} hydrates without React mismatch errors`, async ({ page }) => {
+      const hydrationErrors = collectHydrationErrors(page);
+      const response = await page.goto(route, { waitUntil: "domcontentloaded" });
+
+      expect(response?.status() ?? 0, `HTTP status for ${route}`).toBeLessThan(400);
+      await expect(page.locator("body")).toBeVisible();
+      await page.waitForTimeout(1_000);
+
+      expect(
+        hydrationErrors,
+        `Hydration errors on ${route}: ${hydrationErrors.join(" | ")}`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## What changed
- Align the server-rendered root language with the client i18n default (`en-US`).
- Add `suppressHydrationWarning` to the root `<html>` element because the language provider intentionally synchronizes that attribute client-side and browser extensions may also inject root attributes before React hydrates.
- Add a focused Playwright audit that fails on React hydration messages, including minified error `#418`, across `/`, `/free?city=Dallas`, and `/therapists`.

## Why
Production reported `Uncaught Error: Minified React error #418` with the mismatch anchored at `HTML`. The existing broad public audit explicitly ignores messages containing `hydrat`, so this regression could pass CI unnoticed.

## Risk
Low. The application markup and behavior are unchanged. The suppression is limited to the document root and does not hide mismatches deeper in the component tree. The new test adds regression coverage for app-level hydration failures.