### PR TITLE
fix: resolve duplicate default export breaking main build (/auth/confirm)

### DIFF
--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -5,6 +5,20 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/integrations/supabase/client";
 
+function ConfirmShell() {
+  return (
+    <div className="container mx-auto max-w-lg px-4 py-10">
+      <div className="rounded-lg border border-border p-6 text-center text-sm text-muted-foreground">
+        Validating your reset link… If nothing happens, please{" "}
+        <Link href="/forgot-password" className="underline">
+          request a new link
+        </Link>
+        .
+      </div>
+    </div>
+  );
+}
+
 function AuthConfirmInner() {
   const router = useRouter();
   const params = useSearchParams();
@@ -44,22 +58,6 @@ function AuthConfirmInner() {
 export default function AuthConfirmPage() {
   return (
     <Suspense fallback={<ConfirmShell />}>
-      <AuthConfirm />
-    </Suspense>
-  );
-}
-
-export default function AuthConfirmPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="container mx-auto max-w-lg px-4 py-10">
-          <div className="rounded-lg border border-border p-6 text-center text-sm text-muted-foreground">
-            Validating your reset link…
-          </div>
-        </div>
-      }
-    >
       <AuthConfirmInner />
     </Suspense>
   );


### PR DESCRIPTION
## Problem

`main` (commit `aa35485`) fails to build on Vercel:

```
./src/app/auth/confirm/page.tsx
Module parse failed: Duplicate export 'default' (35:7)
> Build failed because of webpack errors
```

When PR #514 was merged, the conflict in `src/app/auth/confirm/page.tsx` was resolved by keeping **both** Suspense fixes — mine and an independent one — leaving two `export default function AuthConfirmPage()` declarations plus references to components (`ConfirmShell`, `AuthConfirm`) that no longer existed in the merged result. This is a merge artifact, not a defect in either original change.

## Fix

Collapse the file to a single, correct implementation:
- one `ConfirmShell` fallback component,
- one `AuthConfirmInner` that reads `useSearchParams()` and runs the OTP verification,
- one default export wrapping `AuthConfirmInner` in a `<Suspense>` boundary (required so the page prerenders without bailing the whole build).

Behavior is unchanged from the intended pre-merge version.

## Verification

- `export default` count in the file: exactly 1
- ESLint: 0 errors (only the pre-existing `react-hooks/exhaustive-deps` warning)
- `pnpm run build`: succeeds (exit 0), all 262 pages generated — `/auth/confirm` prerenders and the `/providers/[citySlug]` pages SSG correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gWonskGKPJNkJiudW1goj

---
_Generated by [Claude Code](https://claude.ai/code/session_014gWonskGKPJNkJiudW1goj)_