### PR TITLE
fix: restore Next.js lockfile consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jose": "^6.2.1",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.577.0",
-    "next": "^16.1.5",
+    "next": "^15.5.18",
     "next-themes": "^0.3.0",
     "postgres": "^3.4.8",
     "react": "^18.3.1",


### PR DESCRIPTION
## What changed

- Restores `next` to `^15.5.18`, matching the committed `pnpm-lock.yaml` and the existing React 18 / Next 15 toolchain.

## Root cause

Snyk PR #527 changed only `package.json` from Next 15.5.18 to 16.1.5. The lockfile remained on 15.5.18, so `pnpm install --frozen-lockfile` failed before lint, tests, or build could run. A complete Next 16 migration would also require coordinated React and ESLint changes.

## Validation

- `pnpm install --frozen-lockfile`
- ESLint: pass
- TypeScript: pass
- Vitest: 126/126 pass
- API smoke tests: 8/8 pass
- DB contract: pass
- release audit: pass
- sitemap audit: 62 canonical URLs, all 200/indexable
- Next.js production build: pass (264 pages)