### PR TITLE
Force dynamic rendering on email confirmation page

### DIFF
--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -5,6 +5,8 @@ import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supabase } from "@/integrations/supabase/client";
 
+export const dynamic = "force-dynamic";
+
 function ConfirmShell() {
   return (
     <div className="container mx-auto max-w-lg px-4 py-10">


### PR DESCRIPTION
## Summary
Added `export const dynamic = "force-dynamic"` to the email confirmation page to ensure it is always rendered dynamically rather than statically cached.

## Key Changes
- Added dynamic rendering directive to `src/app/auth/confirm/page.tsx`
  - This ensures the confirmation page is re-evaluated on each request rather than being statically generated
  - Necessary for proper handling of time-sensitive email verification tokens from Supabase auth

## Implementation Details
The `force-dynamic` export tells Next.js App Router to skip static generation for this route, which is critical for authentication flows where the page must respond to fresh query parameters (the confirmation token) on every visit.

https://claude.ai/code/session_01D2KdmUjmhaDBVi7EvCVxgJ