### PR TITLE
Add is_demo column to profile database contract validation

### DIFF
--- a/scripts/validate-db-contract.mjs
+++ b/scripts/validate-db-contract.mjs
@@ -65,6 +65,7 @@ const REQUIRED_PROFILE_COLUMNS = [
   "is_featured",
   "is_suspended",
   "is_banned",
+  "is_demo",
   "subscription_tier",
   "subscription_status",
   "stripe_customer_id",


### PR DESCRIPTION
## Summary
Updates the database contract validation script to include the `is_demo` column as a required field in the profiles table schema.

## Changes
- Added `is_demo` to the `REQUIRED_PROFILE_COLUMNS` array in `scripts/validate-db-contract.mjs`

## Details
This change ensures that the database contract validator recognizes `is_demo` as a required column on the profiles table. This aligns the validation script with the actual database schema and prevents contract violations during deployment.

https://claude.ai/code/session_016VrGY2JLGSGKuTNLDvY2FX