### PR TITLE
Fix homepage React hydration error #418

### DIFF
--- a/src/components/motion/BreathingGlow.tsx
+++ b/src/components/motion/BreathingGlow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducedMotion } from "framer-motion";
+import { useHydratedReducedMotion } from "@/hooks/useHydratedReducedMotion";
 
 type BreathingGlowProps = {
   color?: string;
@@ -15,7 +15,7 @@ export function BreathingGlow({
   duration = 5,
   className = "",
 }: BreathingGlowProps) {
-  const reduced = useReducedMotion();
+  const reduced = useHydratedReducedMotion();
 
   if (reduced) return null;
 

--- a/src/components/motion/GrainOverlay.tsx
+++ b/src/components/motion/GrainOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducedMotion } from "framer-motion";
+import { useHydratedReducedMotion } from "@/hooks/useHydratedReducedMotion";
 
 type GrainOverlayProps = {
   opacity?: number;
@@ -8,7 +8,7 @@ type GrainOverlayProps = {
 };
 
 export function GrainOverlay({ opacity = 0.035, className = "" }: GrainOverlayProps) {
-  const reduced = useReducedMotion();
+  const reduced = useHydratedReducedMotion();
 
   if (reduced) return null;
 


### PR DESCRIPTION
Superseded. The hydration fix is already present on `main`; keeping this PR open would risk duplicate or conflicting changes. The remaining release work is isolated in #565.