### PR TITLE
Fix production 404 redirect chains and React hydration mismatch

### DIFF
--- a/src/app/[city]/[segment]/[keyword]/page.tsx
+++ b/src/app/[city]/[segment]/[keyword]/page.tsx
@@ -9,7 +9,6 @@ import {
   resolveDirectoryFilters,
   getSegmentBySlug,
 } from "@/app/_lib/directory-taxonomy";
-import { isLaunchUrl } from "@/app/_lib/launch-urls";
 import { createPageMetadata } from "@/app/_lib/metadata";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd, buildItemListJsonLd } from "@/app/_lib/structured-data";
 
@@ -41,7 +40,10 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
   const keyword = getKeywordBySlug(resolvedParams.keyword);
   const routePath = `/${resolvedParams.city}/${resolvedParams.segment}/${resolvedParams.keyword}`;
 
-  if (!city || !segment || !keyword || !isLaunchUrl(routePath)) {
+  // The launch URL allowlist controls sitemap/discovery exposure only. Valid
+  // canonical city + segment + keyword combinations must render so legacy
+  // redirects never terminate at a 404.
+  if (!city || !segment || !keyword) {
     return createPageMetadata({
       title: "Specialty page",
       description: "Keyword directory page.",
@@ -71,9 +73,8 @@ export default async function CityKeywordPage({ params }: { params: Promise<Para
   const city = getCities().find((entry) => entry.slug === resolvedParams.city);
   const segment = getSegmentBySlug(resolvedParams.segment);
   const keyword = getKeywordBySlug(resolvedParams.keyword);
-  const routePath = `/${resolvedParams.city}/${resolvedParams.segment}/${resolvedParams.keyword}`;
 
-  if (!city || !segment || !keyword || !isLaunchUrl(routePath)) {
+  if (!city || !segment || !keyword) {
     notFound();
   }
 

--- a/src/app/[city]/[segment]/page.tsx
+++ b/src/app/[city]/[segment]/page.tsx
@@ -8,7 +8,7 @@ import {
   getSegmentSearchFilters,
   getSegmentBySlug,
 } from "@/app/_lib/directory-taxonomy";
-import { getLaunchKeywordPaths, getLaunchSegmentPaths, isLaunchUrl } from "@/app/_lib/launch-urls";
+import { getLaunchKeywordPaths } from "@/app/_lib/launch-urls";
 import { createPageMetadata } from "@/app/_lib/metadata";
 import { buildBreadcrumbJsonLd, buildCollectionPageJsonLd, buildItemListJsonLd } from "@/app/_lib/structured-data";
 
@@ -36,7 +36,10 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
   const segment = getSegmentBySlug(resolvedParams.segment);
   const routePath = `/${resolvedParams.city}/${resolvedParams.segment}`;
 
-  if (!city || !segment || !isLaunchUrl(routePath)) {
+  // The launch URL list controls sitemap/discovery exposure only. Any canonical
+  // city + segment combination must remain routable so legacy redirects never
+  // terminate at a 404.
+  if (!city || !segment) {
     return createPageMetadata({
       title: "Directory",
       description: "City segment directory page.",
@@ -86,9 +89,8 @@ export default async function CitySegmentPage({ params }: { params: Promise<Para
   const resolvedParams = await params;
   const city = getCities().find((entry) => entry.slug === resolvedParams.city);
   const segment = getSegmentBySlug(resolvedParams.segment);
-  const routePath = `/${resolvedParams.city}/${resolvedParams.segment}`;
 
-  if (!city || !segment || !isLaunchUrl(routePath)) {
+  if (!city || !segment) {
     notFound();
   }
 

--- a/src/components/motion/BreathingGlow.tsx
+++ b/src/components/motion/BreathingGlow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducedMotion } from "framer-motion";
+import { useHydratedReducedMotion } from "@/hooks/useHydratedReducedMotion";
 
 type BreathingGlowProps = {
   color?: string;
@@ -15,7 +15,7 @@ export function BreathingGlow({
   duration = 5,
   className = "",
 }: BreathingGlowProps) {
-  const reduced = useReducedMotion();
+  const reduced = useHydratedReducedMotion();
 
   if (reduced) return null;
 

--- a/src/components/motion/GrainOverlay.tsx
+++ b/src/components/motion/GrainOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducedMotion } from "framer-motion";
+import { useHydratedReducedMotion } from "@/hooks/useHydratedReducedMotion";
 
 type GrainOverlayProps = {
   opacity?: number;
@@ -8,7 +8,7 @@ type GrainOverlayProps = {
 };
 
 export function GrainOverlay({ opacity = 0.035, className = "" }: GrainOverlayProps) {
-  const reduced = useReducedMotion();
+  const reduced = useHydratedReducedMotion();
 
   if (reduced) return null;
 


### PR DESCRIPTION
## Summary

Fixes the production errors confirmed by the July 22 Vercel log export and the browser console.

## Changes

- Allows valid canonical city + segment routes to render even when they are not in the launch sitemap allowlist.
- Allows valid city + segment + keyword routes to render for the same reason.
- Prevents legacy 301 redirects from terminating at a 404.
- Fixes React hydration error #418 caused by reduced-motion-dependent decorative components rendering differently on the server and first client render.
- Uses the existing hydration-safe reduced-motion hook for `GrainOverlay` and `BreathingGlow`.

## Evidence

The log export showed 11 unique redirect destinations returning 404, including Frisco, Sarasota, Cambridge, Greensboro, Fire Island, Charlotte, Wilton Manors, San Francisco, Lewes, Encinitas, and Homestead.

The browser reproduced React error #418 in Edge InPrivate, confirming it was application-side rather than an extension.

## Not treated as application defects

- Edge lazy-image intervention notice is informational.
- The 401 login request is consistent with an invalid/unconfirmed credential response and the CSV contains no server error message proving an implementation defect.
- The preview 403 login request appears to be a negative auth/CSRF test.
