### PR TITLE
style(marketing): replace ambiguous arbitrary easing with named token

### DIFF
--- a/src/components/marketing/FeaturedTherapistsEditorial.tsx
+++ b/src/components/marketing/FeaturedTherapistsEditorial.tsx
@@ -97,7 +97,7 @@ export function FeaturedTherapistsEditorial({ featuredTherapists }: Props) {
                         src={(therapist.profile_photo || therapist.avatar_url) as string}
                         alt={therapist.display_name || therapist.full_name || "Therapist"}
                         fill
-                        className="object-cover transition-transform duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:scale-[1.08]"
+                        className="object-cover transition-transform duration-700 ease-editorial group-hover:scale-[1.08]"
                         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                       />
                     ) : (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -131,6 +131,7 @@ const config: Config = {
       },
       transitionTimingFunction: {
         "smooth-out": "cubic-bezier(0.16, 1, 0.3, 1)",
+        editorial: "cubic-bezier(0.22, 1, 0.36, 1)",
       },
       transitionDuration: {
         600: "600ms",


### PR DESCRIPTION
## Summary

Clears the Tailwind build warning `The class ease-[cubic-bezier(0.22,1,0.36,1)] is ambiguous and matches multiple utilities` surfaced during `next build`.

## Changes

- Register the easing as a named `editorial` token in `transitionTimingFunction` (`tailwind.config.ts`): `cubic-bezier(0.22, 1, 0.36, 1)`.
- Use `ease-editorial` instead of the arbitrary `ease-[cubic-bezier(0.22,1,0.36,1)]` class in `FeaturedTherapistsEditorial.tsx`.

No visual change — identical easing curve, just no longer expressed as an ambiguous arbitrary class.

## Verification

Local run of the full CI-equivalent suite is green: typecheck, 126/126 unit tests, eslint, DB contract, API smoke tests, and `next build` (262 pages, warning gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnUeUUxumjjFkfeVzBJzbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnUeUUxumjjFkfeVzBJzbT)_