### PR TITLE
Superseded: Vercel to GitHub secrets audit from stale main

### DIFF
--- a/docs/VERCEL_GITHUB_SECRETS_AUDIT.md
+++ b/docs/VERCEL_GITHUB_SECRETS_AUDIT.md
@@ -1,0 +1,80 @@
+# Vercel → GitHub Secrets Audit
+
+Comparison of environment variables configured in the **Vercel** project
+(`prj_ou8HAE72SwYWaB8EQ5rfPpzXvKlu`, team `masseurmatch`) against the secrets
+referenced by GitHub Actions workflows in this repo (`.github/workflows/*`).
+
+- **Vercel:** 71 unique keys (83 entries across production/preview/development).
+- **GitHub:** 21 secrets referenced in CI (+ the auto-provided `GITHUB_TOKEN`).
+
+> The GitHub side is derived from what the workflows **reference**, since the
+> GitHub secrets REST API is not readable from the automation sandbox. A secret
+> configured in GitHub but never referenced by a workflow won't appear here.
+
+## In Vercel, missing from GitHub — candidates to migrate
+
+App/CI secrets that exist in Vercel but are not wired into GitHub Actions:
+
+| Key | Notes |
+|---|---|
+| `DEEPSEEK_API_KEY` | Primary Knotty LLM |
+| `OPENAI_API_KEY` | Knotty fallback LLM |
+| `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` / `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_URL` | Image uploads |
+| `CRON_SECRET` | Protects `/api/migrate/process` cron |
+| `MM_SESSION_SECRET` / `MM_CSRF_SECRET` | Session + CSRF signing |
+| `SUPABASE_URL` | Bare (server-only) variant |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | New-style Supabase key |
+| `SUPABASE_SERVICE_ROLE_KEY` | *(in both, listed for completeness)* |
+| `SERPAPI_API_KEY` | SEO |
+| `SEND_EMAIL_HOOK_SECRET` | Supabase email hook |
+| `RESEND_FROM_EMAIL` / `ADMIN_NOTIFICATION_EMAIL` | Email config |
+| `STRIPE_PUBLISHABLE_KEY` | Non-`NEXT_PUBLIC_` variant |
+| `STRIPE_PRICE_STANDARD` / `STRIPE_PRICE_PRO` / `STRIPE_PRICE_ELITE` | Plan price IDs |
+| `STRIPE_IDENTITY_FLOW_ID` / `STRIPE_IDENTITY_VERIFY_URL` | Stripe Identity |
+| `SEED_ADMIN_PASSWORD` / `SEED_THERAPIST_EMAIL` | Seed scripts |
+| `TWILIO_PHONE_NUMBER` | SMS |
+| `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_BASE_URL` / `NEXT_PUBLIC_SITE_URL` | URLs |
+| `NEXT_PUBLIC_BUGSNAG_API_KEY` / `NEXT_PUBLIC_GA_MEASUREMENT_ID` / `NEXT_PUBLIC_GTM_ID` / `NEXT_PUBLIC_POSTHOG_KEY` | Analytics/monitoring |
+| `PLAYWRIGHT_BASE_URL` | E2E |
+
+## In Vercel — do NOT copy to GitHub (Vercel-managed)
+
+Auto-generated and rotated by Vercel Storage/Marketplace integrations and the
+system. Copying them into GitHub creates duplicates that go stale. The migration
+script skips these by default.
+
+`POSTGRES_DATABASE`, `POSTGRES_HOST`, `POSTGRES_PASSWORD`, `POSTGRES_PRISMA_URL`,
+`POSTGRES_URL`, `POSTGRES_URL_DATABASE_URL`, `POSTGRES_URL_NON_POOLING`,
+`POSTGRES_URL_POSTGRES_URL`, `POSTGRES_URL_PRISMA_DATABASE_URL`, `POSTGRES_USER`,
+`KV_URL`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `KV_REST_API_READ_ONLY_TOKEN`,
+`REDIS_URL`, `VERCEL_OIDC_TOKEN`, `VERCEL_AUTOMATION_BYPASS_SECRET`, `PORT`.
+
+## In Vercel — verify before migrating (possibly legacy)
+
+`AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_DOMAIN`, `AUTH0_SECRET` — the
+app authenticates via Supabase; no `AUTH0_*` reference exists in the codebase.
+Likely leftover from an earlier stack. Confirm before copying.
+
+## Referenced in GitHub, not in Vercel (naming drift)
+
+| GitHub name | Vercel equivalent |
+|---|---|
+| `SUPABASE_SECRET_KEY` | `SUPABASE_SERVICE_ROLE_KEY` |
+| `VERCEL_PROTECTION_BYPASS` | `VERCEL_AUTOMATION_BYPASS_SECRET` |
+| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` / `NEXT_PUBLIC_GOOGLE_MAPS_KEY` | *(not set in Vercel)* |
+| `SITEMAP_SUPABASE_KEY` | *(not set in Vercel)* |
+
+## How to run the migration
+
+The GitHub secrets API is blocked from the automation sandbox, so run this
+**locally**, where `gh` is authenticated:
+
+```bash
+export VERCEL_TOKEN=vcp_xxx          # a Vercel token with read access
+./scripts/migrate-vercel-secrets-to-github.sh          # dry run — prints the plan
+APPLY=1 ./scripts/migrate-vercel-secrets-to-github.sh  # write the missing secrets
+APPLY=1 FORCE=1 ./scripts/migrate-vercel-secrets-to-github.sh  # also overwrite existing
+```
+
+By default it reads the `production` env, skips Vercel-managed vars, and skips
+secrets already present in GitHub. See the script header for all options.

--- a/scripts/migrate-vercel-secrets-to-github.sh
+++ b/scripts/migrate-vercel-secrets-to-github.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Migrate Vercel project environment variables -> GitHub Actions secrets.
+#
+# This reads the decrypted env values from the MasseurMatch Vercel project and
+# writes them as GitHub Actions repository secrets. Values never leave your
+# machine and are never printed.
+#
+# Requirements (run locally, NOT in the Claude sandbox which blocks the GitHub
+# secrets API):
+#   - gh CLI, authenticated:  gh auth login
+#   - curl, jq, base64
+#   - A Vercel token exported as VERCEL_TOKEN
+#
+# Usage:
+#   export VERCEL_TOKEN=vcp_xxx
+#   ./scripts/migrate-vercel-secrets-to-github.sh            # DRY RUN (prints plan)
+#   APPLY=1 ./scripts/migrate-vercel-secrets-to-github.sh    # actually write secrets
+#   APPLY=1 FORCE=1 ...                                      # also overwrite existing ones
+#
+# Knobs (env vars):
+#   TARGET   production | preview | development   (which Vercel env to read; default production)
+#   APPLY    0|1  actually write to GitHub (default 0 = dry run)
+#   FORCE    0|1  overwrite secrets that already exist in GitHub (default 0 = skip existing)
+#
+set -euo pipefail
+
+VERCEL_TEAM_ID="${VERCEL_TEAM_ID:-team_srSjjkFDYeFA6HpxgpvxPgox}"
+VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-prj_ou8HAE72SwYWaB8EQ5rfPpzXvKlu}"
+GH_REPO="${GH_REPO:-X-RANKFLOW-MEDIA-GROUP/masseurmatch}"
+TARGET="${TARGET:-production}"
+APPLY="${APPLY:-0}"
+FORCE="${FORCE:-0}"
+
+# Vercel-managed / auto-injected vars. These are generated and rotated by Vercel
+# (Storage & Marketplace integrations, system vars) — copying them into GitHub
+# just creates duplicates that silently go stale. Skipped by default.
+SKIP_REGEX='^(VERCEL_OIDC_TOKEN|VERCEL_AUTOMATION_BYPASS_SECRET|PORT|KV_.*|POSTGRES_.*|REDIS_URL)$'
+
+: "${VERCEL_TOKEN:?export VERCEL_TOKEN first}"
+command -v gh   >/dev/null || { echo "gh CLI not found"; exit 1; }
+command -v jq   >/dev/null || { echo "jq not found"; exit 1; }
+gh auth status  >/dev/null 2>&1 || { echo "gh not authenticated — run: gh auth login"; exit 1; }
+
+echo "Vercel project : $VERCEL_PROJECT_ID"
+echo "GitHub repo    : $GH_REPO"
+echo "Vercel env     : $TARGET"
+echo "Mode           : $([ "$APPLY" = 1 ] && echo APPLY || echo 'DRY RUN') $([ "$FORCE" = 1 ] && echo '(force overwrite)')"
+echo
+
+# Secrets that already exist in GitHub (so we don't clobber them unless FORCE=1).
+existing="$(gh secret list --repo "$GH_REPO" --json name -q '.[].name' 2>/dev/null || true)"
+
+# Pull decrypted env from Vercel, one row per key: "KEY\tBASE64(value)"
+rows="$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
+  "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}/env?decrypt=true&teamId=${VERCEL_TEAM_ID}" \
+  | jq -r --arg t "$TARGET" '
+      .envs[]
+      | select(.target | index($t))
+      | select(.value != null and .value != "")
+      | .key + "\t" + (.value | @base64)')"
+
+set_n=0; skip_managed=0; skip_exist=0
+while IFS=$'\t' read -r key b64; do
+  [ -z "$key" ] && continue
+  if [[ "$key" =~ $SKIP_REGEX ]]; then
+    printf '  SKIP (vercel-managed)  %s\n' "$key"; skip_managed=$((skip_managed+1)); continue
+  fi
+  if [ "$FORCE" != 1 ] && grep -qxF "$key" <<<"$existing"; then
+    printf '  SKIP (already in gh)   %s\n' "$key"; skip_exist=$((skip_exist+1)); continue
+  fi
+  if [ "$APPLY" = 1 ]; then
+    printf '%s' "$b64" | base64 -d | gh secret set "$key" --repo "$GH_REPO" --body -
+    printf '  SET                    %s\n' "$key"
+  else
+    printf '  WOULD SET              %s\n' "$key"
+  fi
+  set_n=$((set_n+1))
+done <<<"$rows"
+
+echo
+echo "Summary: $([ "$APPLY" = 1 ] && echo set || echo 'would set')=$set_n  skipped-managed=$skip_managed  skipped-existing=$skip_exist"
+[ "$APPLY" != 1 ] && echo "Dry run only. Re-run with APPLY=1 to write."


### PR DESCRIPTION
## Superseded — do not merge

This pull request was created from an outdated `main` snapshot. Its failed CI runs compile the old Profile CMS implementation and therefore do not represent the current production branch.

The relevant TypeScript and lint failures were corrected on `main`, including Supabase `Json` normalization, typed dynamic profile updates, and safe React rendering of unknown values.

Current verified production baseline:

- Main commit: `54328376c7ccbabce7cd3d45dc40e8a58ac52977`
- Vercel deployment: `dpl_GuAqxKcfFhx41YV4iqg683wvtbBN`
- Deployment state: `READY`

The secrets audit or migration script may be recreated later from the latest `main` in a clean branch. Re-running this PR's failed jobs would continue testing its stale SHA and is not useful.