### PR TITLE
feat: add AI Profile Coach to provider dashboard

### DIFF
--- a/.github/workflows/ai-coach-debug.yml
+++ b/.github/workflows/ai-coach-debug.yml
@@ -1,0 +1,43 @@
+name: AI Coach Diagnostics
+
+on:
+  push:
+    branches:
+      - feature/ai-profile-coach-dashboard
+
+permissions:
+  contents: read
+
+jobs:
+  diagnostics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Capture database contract and migration diagnostics
+        shell: bash
+        run: |
+          set +e
+          pnpm validate:db-contract > db-contract.txt 2>&1
+          echo "$?" > db-contract-exit-code.txt
+          grep -R -n "keyword_slugs" supabase > keyword-slugs.txt 2>&1 || true
+          find supabase/migrations -maxdepth 1 -type f -printf "%f\n" | sort > migration-files.txt
+          set -e
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ai-coach-diagnostics
+          path: |
+            db-contract.txt
+            db-contract-exit-code.txt
+            keyword-slugs.txt
+            migration-files.txt
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/ai-coach-debug.yml
+++ b/.github/workflows/ai-coach-debug.yml
@@ -1,9 +1,9 @@
 name: AI Coach Diagnostics
 
 on:
-  push:
+  pull_request:
     branches:
-      - feature/ai-profile-coach-dashboard
+      - main
 
 permissions:
   contents: read

--- a/src/app/api/pro/ai-coach/route.ts
+++ b/src/app/api/pro/ai-coach/route.ts
@@ -1,0 +1,354 @@
+import { z } from "zod";
+
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+import { requireRequestSession } from "@/app/_lib/session";
+import { updateProfileByUserId } from "@/app/_lib/store";
+import {
+  analyzePhoto,
+  askProfileCoach,
+  buildCoachAnalysis,
+  generateOptimization,
+  quickProfileScore,
+  rewriteProfileField,
+  type CoachAnalysis,
+  type CoachPhoto,
+  type CoachProfile,
+  type PhotoScore,
+} from "@/lib/ai/profile-coach";
+
+const PROFILE_SELECT = `
+  id,user_id,display_name,full_name,headline,tagline,bio,city,state,neighborhood,slug,
+  photo_url,avatar_url,massage_techniques,modalities,specialties,service_categories,
+  languages,languages_spoken,years_experience,offers_incall,offers_outcall,incall,outcall,
+  starting_price,starting_rate,incall_price,outcall_price,pricing_sessions,rates,session_lengths,
+  incall_amenities,studio_amenities,payment_methods,areas_served,travel_schedule,business_trips,
+  education_entries,certifications,training,is_verified_phone,is_verified_email,
+  is_verified_identity,is_verified_profile,is_verified_photos,lgbtq_affirming,accepts_all_genders,
+  available_now,is_featured,seo_title,seo_description,seo_keywords,review_count,average_rating,
+  subscription_tier,visibility_status,profile_status
+`;
+
+const requestSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("refresh") }),
+  z.object({
+    action: z.literal("rewrite"),
+    field: z.enum(["headline", "tagline", "bio", "seo_title", "seo_description"]),
+  }),
+  z.object({ action: z.literal("optimize-preview") }),
+  z.object({
+    action: z.literal("apply-optimization"),
+    runId: z.string().uuid(),
+    fields: z.array(z.enum(["headline", "tagline", "bio", "seo_title", "seo_description", "seo_keywords"])).min(1).max(6),
+  }),
+  z.object({ action: z.literal("analyze-photos") }),
+  z.object({ action: z.literal("generate-report"), period: z.enum(["weekly", "monthly"]) }),
+  z.object({ action: z.literal("chat"), message: z.string().trim().min(2).max(1000) }),
+]);
+
+type UntypedSupabase = ReturnType<typeof createSupabaseAdminClient> & {
+  from: (table: string) => any;
+  rpc: (name: string, params?: Record<string, unknown>) => any;
+};
+
+type CoachBundle = {
+  profile: CoachProfile;
+  photos: CoachPhoto[];
+  analysis: CoachAnalysis;
+  latestDrafts: unknown[];
+  latestReports: unknown[];
+  latestOptimization: unknown | null;
+};
+
+function asDb() {
+  return createSupabaseAdminClient() as unknown as UntypedSupabase;
+}
+
+function isoDaysAgo(days: number) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString();
+}
+
+function todayUtc() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function countRows(query: PromiseLike<{ count: number | null; error: { message: string } | null }>) {
+  const result = await query;
+  return result.error ? 0 : result.count ?? 0;
+}
+
+async function requireProfile(db: UntypedSupabase, userId: string): Promise<CoachProfile> {
+  const { data, error } = await db.from("profiles").select(PROFILE_SELECT).eq("user_id", userId).maybeSingle();
+  if (error) throw new RouteError(500, error.message);
+  if (!data) throw new RouteError(404, "Provider profile not found.");
+  return data as CoachProfile;
+}
+
+async function loadCoachBundle(db: UntypedSupabase, profile: CoachProfile): Promise<CoachBundle> {
+  const city = profile.city?.trim() ?? "";
+  const state = profile.state?.trim() ?? "";
+  const since30 = isoDaysAgo(30);
+  const since7 = isoDaysAgo(7);
+  const since1 = isoDaysAgo(1);
+
+  const [
+    photosResult,
+    photoScoresResult,
+    snapshotsResult,
+    rankingsResult,
+    marketResult,
+    keywordsResult,
+    competitorsResult,
+    draftsResult,
+    reportsResult,
+    optimizationResult,
+    views1d,
+    views7d,
+    views30d,
+    contacts1d,
+    contacts7d,
+    contacts30d,
+    favorites7d,
+    inquiries7d,
+  ] = await Promise.all([
+    db.from("profile_photos").select("id,url,storage_path,is_primary,moderation_status,sort_order").eq("profile_id", profile.id).order("sort_order", { ascending: true }),
+    db.from("ai_profile_photo_scores").select("*").eq("profile_id", profile.id).order("overall_score", { ascending: false }),
+    db.from("ai_profile_coach_daily_snapshots").select("snapshot_date,profile_score,visibility_score,trust_score,content_score,conversion_score").eq("profile_id", profile.id).order("snapshot_date", { ascending: false }).limit(90),
+    db.from("ranking_events").select("position_in_results,created_at").eq("profile_id", profile.id).not("position_in_results", "is", null).gte("created_at", since30).order("created_at", { ascending: false }).limit(400),
+    city && state
+      ? db.from("demand_scores").select("score,trend,competition_index,search_volume_index").ilike("city", city).ilike("state", state).order("week_start", { ascending: false }).limit(1).maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    city && state
+      ? db.from("keyword_trends").select("keyword,score,trend_direction,week_over_week_change").ilike("city", city).ilike("state", state).order("date", { ascending: false }).order("score", { ascending: false }).limit(40)
+      : Promise.resolve({ data: [], error: null }),
+    city && state
+      ? db.from("profiles").select("headline,tagline,bio,city,state,massage_techniques,modalities,specialties,languages,languages_spoken,years_experience,areas_served,starting_price,starting_rate,incall_price,is_verified_identity,is_verified_phone,is_verified_email,available_now").ilike("city", city).ilike("state", state).neq("id", profile.id).eq("is_demo", false).eq("is_banned", false).eq("is_suspended", false).limit(100)
+      : Promise.resolve({ data: [], error: null }),
+    db.from("ai_profile_content_drafts").select("id,field,suggested_text,rationale,provider,model,status,created_at").eq("profile_id", profile.id).order("created_at", { ascending: false }).limit(12),
+    db.from("ai_profile_reports").select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").eq("profile_id", profile.id).order("generated_at", { ascending: false }).limit(6),
+    db.from("ai_profile_optimization_runs").select("id,status,before_state,after_state,applied_fields,estimated_impact,provider,model,created_at,applied_at").eq("profile_id", profile.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    countRows(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
+    countRows(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    countRows(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
+    countRows(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
+    countRows(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    countRows(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
+    countRows(db.from("favorites").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    countRows(db.from("contact_inquiries").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+  ]);
+
+  const photos = (photosResult.data ?? []) as CoachPhoto[];
+  const photoScores = (photoScoresResult.data ?? []) as PhotoScore[];
+  const competitorScores = (competitorsResult.data ?? []).map((candidate: Partial<CoachProfile>) => quickProfileScore(candidate));
+  const analysis = buildCoachAnalysis({
+    profile,
+    photos,
+    photoScores,
+    snapshots: snapshotsResult.data ?? [],
+    rankings: rankingsResult.data ?? [],
+    keywords: keywordsResult.data ?? [],
+    market: marketResult.data ?? null,
+    competitorScores,
+    metrics: { views1d, views7d, views30d, contacts1d, contacts7d, contacts30d, favorites7d, inquiries7d },
+  });
+
+  await persistSnapshot(db, profile, analysis);
+
+  return {
+    profile,
+    photos,
+    analysis,
+    latestDrafts: draftsResult.data ?? [],
+    latestReports: reportsResult.data ?? [],
+    latestOptimization: optimizationResult.data ?? null,
+  };
+}
+
+async function persistSnapshot(db: UntypedSupabase, profile: CoachProfile, analysis: CoachAnalysis) {
+  const top = analysis.recommendations[0];
+  const payload = {
+    profile_id: profile.id,
+    snapshot_date: todayUtc(),
+    profile_score: analysis.scores.overall,
+    visibility_score: analysis.scores.visibility,
+    trust_score: analysis.scores.trust,
+    content_score: analysis.scores.content,
+    conversion_score: analysis.scores.conversion,
+    profile_views_1d: analysis.metrics.views1d,
+    profile_views_7d: analysis.metrics.views7d,
+    profile_views_30d: analysis.metrics.views30d,
+    contact_clicks_1d: analysis.metrics.contacts1d,
+    contact_clicks_7d: analysis.metrics.contacts7d,
+    contact_clicks_30d: analysis.metrics.contacts30d,
+    contact_rate_pct: analysis.metrics.contactRate,
+    favorites_7d: analysis.metrics.favorites7d,
+    inquiries_7d: analysis.metrics.inquiries7d,
+    average_search_position: analysis.ranking.current,
+    local_demand_score: analysis.market.demandScore,
+    local_demand_trend: analysis.market.demandTrend,
+    strongest_keyword: analysis.strongestKeyword,
+    weakest_section: Object.entries({ content: analysis.scores.content, trust: analysis.scores.trust, visibility: analysis.scores.visibility, conversion: analysis.scores.conversion, seo: analysis.scores.seo, photos: analysis.scores.photos }).sort((a, b) => a[1] - b[1])[0]?.[0] ?? null,
+    top_recommendation_key: top?.key ?? null,
+    top_recommendation_title: top?.title ?? null,
+    top_recommendation_reason: top?.reason ?? null,
+    top_recommendation_action: top?.action ?? null,
+    top_recommendation_impact: top?.impact ?? null,
+    missing_fields: analysis.missingFields,
+    completed_fields: analysis.completedFields,
+    photo_analysis: { score: analysis.scores.photos, photos: analysis.photoScores },
+    content_analysis: { score: analysis.scores.content, seo: analysis.scores.seo },
+    market_analysis: { market: analysis.market, benchmark: analysis.benchmark, ranking: analysis.ranking, forecast: analysis.forecast },
+    recommendation_list: analysis.recommendations,
+    subscription_tier: profile.subscription_tier,
+    generated_at: new Date().toISOString(),
+  };
+  const { error } = await db.from("ai_profile_coach_daily_snapshots").upsert(payload, { onConflict: "profile_id,snapshot_date" });
+  if (error) console.error("[ai-coach] snapshot upsert failed", error.message);
+}
+
+async function recordAnalysis(db: UntypedSupabase, profileId: string, type: string, result: unknown, provider?: string | null, model?: string | null) {
+  const { error } = await db.from("ai_profile_analysis_runs").insert({
+    profile_id: profileId,
+    analysis_type: type,
+    status: "completed",
+    result,
+    provider: provider ?? null,
+    model: model ?? null,
+    completed_at: new Date().toISOString(),
+  });
+  if (error) console.error("[ai-coach] analysis audit failed", error.message);
+}
+
+function reportDates(period: "weekly" | "monthly") {
+  const end = new Date();
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (period === "weekly" ? 6 : 29));
+  return { start: start.toISOString().slice(0, 10), end: end.toISOString().slice(0, 10) };
+}
+
+export async function GET(request: Request) {
+  try {
+    const session = await requireRequestSession(request);
+    const db = asDb();
+    const profile = await requireProfile(db, session.userId);
+    const bundle = await loadCoachBundle(db, profile);
+    return json({ ok: true, ...bundle });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await requireRequestSession(request);
+    const parsed = requestSchema.parse(await request.json());
+    const db = asDb();
+    const profile = await requireProfile(db, session.userId);
+
+    if (parsed.action === "refresh") {
+      const bundle = await loadCoachBundle(db, profile);
+      await recordAnalysis(db, profile.id, "profile", bundle.analysis, "deterministic", "profile-coach-v1");
+      return json({ ok: true, ...bundle });
+    }
+
+    if (parsed.action === "rewrite") {
+      const rewrite = await rewriteProfileField(profile, parsed.field);
+      const currentValue = profile[parsed.field];
+      const { data, error } = await db.from("ai_profile_content_drafts").insert({
+        profile_id: profile.id,
+        field: parsed.field,
+        source_text: typeof currentValue === "string" ? currentValue : null,
+        suggested_text: rewrite.suggestedText,
+        rationale: rewrite.rationale,
+        provider: rewrite.provider,
+        model: rewrite.model,
+      }).select("id,field,suggested_text,rationale,provider,model,status,created_at").single();
+      if (error) throw new RouteError(500, error.message);
+      await recordAnalysis(db, profile.id, "seo", { field: parsed.field, draftId: data.id }, rewrite.provider, rewrite.model);
+      return json({ ok: true, draft: data });
+    }
+
+    if (parsed.action === "optimize-preview") {
+      const { data: keywordRows } = await db.from("keyword_trends").select("keyword").ilike("city", profile.city ?? "").ilike("state", profile.state ?? "").order("score", { ascending: false }).limit(12);
+      const optimization = await generateOptimization(profile, (keywordRows ?? []).map((row: { keyword: string }) => row.keyword));
+      const beforeState = {
+        headline: profile.headline,
+        tagline: profile.tagline,
+        bio: profile.bio,
+        seo_title: profile.seo_title,
+        seo_description: profile.seo_description,
+        seo_keywords: profile.seo_keywords,
+      };
+      const estimatedImpact = { visibility: 14, conversion: 11, seo: 19, disclaimer: "Directional estimate based on profile completeness and keyword coverage; not a guarantee." };
+      const { data, error } = await db.from("ai_profile_optimization_runs").insert({
+        profile_id: profile.id,
+        status: "preview",
+        before_state: beforeState,
+        after_state: optimization.after,
+        estimated_impact: estimatedImpact,
+        provider: optimization.provider,
+        model: optimization.model,
+      }).select("id,status,before_state,after_state,estimated_impact,provider,model,created_at").single();
+      if (error) throw new RouteError(500, error.message);
+      return json({ ok: true, optimization: { ...data, rationale: optimization.rationale } });
+    }
+
+    if (parsed.action === "apply-optimization") {
+      const { data: run, error } = await db.from("ai_profile_optimization_runs").select("id,status,after_state").eq("id", parsed.runId).eq("profile_id", profile.id).maybeSingle();
+      if (error) throw new RouteError(500, error.message);
+      if (!run) throw new RouteError(404, "Optimization preview not found.");
+      if (run.status !== "preview") throw new RouteError(409, "This optimization is no longer available to apply.");
+      const after = (run.after_state ?? {}) as Record<string, unknown>;
+      const updates = Object.fromEntries(parsed.fields.filter((field) => Object.prototype.hasOwnProperty.call(after, field)).map((field) => [field, after[field]]));
+      if (!Object.keys(updates).length) throw new RouteError(400, "No valid optimization fields were selected.");
+      await updateProfileByUserId(session.userId, updates as never);
+      const { error: updateError } = await db.from("ai_profile_optimization_runs").update({ status: "applied", applied_fields: Object.keys(updates), applied_at: new Date().toISOString() }).eq("id", run.id).eq("profile_id", profile.id);
+      if (updateError) throw new RouteError(500, updateError.message);
+      return json({ ok: true, appliedFields: Object.keys(updates) });
+    }
+
+    if (parsed.action === "analyze-photos") {
+      const { data: photoRows, error } = await db.from("profile_photos").select("id,url,storage_path,is_primary,moderation_status,sort_order").eq("profile_id", profile.id).order("sort_order", { ascending: true }).limit(12);
+      if (error) throw new RouteError(500, error.message);
+      const photos = (photoRows ?? []) as CoachPhoto[];
+      const scores = await Promise.all(photos.map((photo, index) => analyzePhoto(photo, index)));
+      if (scores.length) {
+        const { error: scoreError } = await db.from("ai_profile_photo_scores").upsert(scores.map((score) => ({ ...score, profile_id: profile.id, strengths: score.strengths, improvements: score.improvements, analyzed_at: new Date().toISOString(), updated_at: new Date().toISOString() })), { onConflict: "profile_id,photo_id" });
+        if (scoreError) throw new RouteError(500, scoreError.message);
+      }
+      await recordAnalysis(db, profile.id, "photo", { count: scores.length, average: scores.length ? Math.round(scores.reduce((sum, item) => sum + item.overall_score, 0) / scores.length) : 0 }, scores.some((item) => item.provider === "openai") ? "openai" : "deterministic", scores.some((item) => item.model) ? scores.find((item) => item.model)?.model : "photo-metadata-v1");
+      return json({ ok: true, photoScores: scores });
+    }
+
+    if (parsed.action === "generate-report") {
+      const bundle = await loadCoachBundle(db, profile);
+      const dates = reportDates(parsed.period);
+      const coachResult = await askProfileCoach(profile, bundle.analysis, `Create a concise ${parsed.period} executive profile performance report. Summarize score movement, visibility, contacts, ranking, market context, and the three best next actions. Clearly label forecasts as estimates.`);
+      const narrative = coachResult?.text ?? `Your profile score is ${bundle.analysis.scores.overall}. Focus first on ${bundle.analysis.recommendations.slice(0, 3).map((item) => item.title.toLowerCase()).join(", ")}. Predicted contacts are estimates based on recent activity.`;
+      const summary = { scores: bundle.analysis.scores, metrics: bundle.analysis.metrics, ranking: bundle.analysis.ranking, forecast: bundle.analysis.forecast, benchmark: bundle.analysis.benchmark, recommendations: bundle.analysis.recommendations.slice(0, 3) };
+      const { data, error } = await db.from("ai_profile_reports").upsert({
+        profile_id: profile.id,
+        period_type: parsed.period,
+        period_start: dates.start,
+        period_end: dates.end,
+        summary,
+        narrative,
+        provider: coachResult?.provider ?? "deterministic",
+        model: coachResult?.model ?? "profile-coach-fallback",
+        generated_at: new Date().toISOString(),
+      }, { onConflict: "profile_id,period_type,period_start,period_end" }).select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").single();
+      if (error) throw new RouteError(500, error.message);
+      return json({ ok: true, report: data });
+    }
+
+    const bundle = await loadCoachBundle(db, profile);
+    const result = await askProfileCoach(profile, bundle.analysis, parsed.message);
+    const answer = result?.text ?? `Your strongest next action is “${bundle.analysis.recommendations[0]?.title ?? "keep your profile current"}.” ${bundle.analysis.recommendations[0]?.action ?? "Review your profile details and availability."}`;
+    await recordAnalysis(db, profile.id, "profile", { question: parsed.message, answer }, result?.provider ?? "deterministic", result?.model ?? "profile-coach-fallback");
+    return json({ ok: true, answer, provider: result?.provider ?? "deterministic", model: result?.model ?? "profile-coach-fallback" });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/pro/ai-coach/route.ts
+++ b/src/app/api/pro/ai-coach/route.ts
@@ -29,12 +29,18 @@ const PROFILE_SELECT = `
   subscription_tier,visibility_status,profile_status
 `;
 
+const AI_TABLES = {
+  snapshots: "ai_profile_coach_daily_snapshots",
+  photoScores: "ai_profile_photo_scores",
+  drafts: "ai_profile_content_drafts",
+  optimizationRuns: "ai_profile_optimization_runs",
+  reports: "ai_profile_reports",
+  analysisRuns: "ai_profile_analysis_runs",
+} as const;
+
 const requestSchema = z.discriminatedUnion("action", [
   z.object({ action: z.literal("refresh") }),
-  z.object({
-    action: z.literal("rewrite"),
-    field: z.enum(["headline", "tagline", "bio", "seo_title", "seo_description"]),
-  }),
+  z.object({ action: z.literal("rewrite"), field: z.enum(["headline", "tagline", "bio", "seo_title", "seo_description"]) }),
   z.object({ action: z.literal("optimize-preview") }),
   z.object({
     action: z.literal("apply-optimization"),
@@ -46,11 +52,8 @@ const requestSchema = z.discriminatedUnion("action", [
   z.object({ action: z.literal("chat"), message: z.string().trim().min(2).max(1000) }),
 ]);
 
-type UntypedSupabase = ReturnType<typeof createSupabaseAdminClient> & {
-  from: (table: string) => any;
-  rpc: (name: string, params?: Record<string, unknown>) => any;
-};
-
+type QueryResult<T = unknown> = { data: T; error: { message: string } | null; count?: number | null };
+type Db = { from: (table: string) => any };
 type CoachBundle = {
   profile: CoachProfile;
   photos: CoachPhoto[];
@@ -60,38 +63,28 @@ type CoachBundle = {
   latestOptimization: unknown | null;
 };
 
-function asDb() {
-  return createSupabaseAdminClient() as unknown as UntypedSupabase;
-}
+const dbClient = () => createSupabaseAdminClient() as unknown as Db;
+const daysAgo = (days: number) => new Date(Date.now() - days * 86_400_000).toISOString();
+const today = () => new Date().toISOString().slice(0, 10);
 
-function isoDaysAgo(days: number) {
-  const date = new Date();
-  date.setUTCDate(date.getUTCDate() - days);
-  return date.toISOString();
-}
-
-function todayUtc() {
-  return new Date().toISOString().slice(0, 10);
-}
-
-async function countRows(query: PromiseLike<{ count: number | null; error: { message: string } | null }>) {
+async function count(query: PromiseLike<QueryResult>) {
   const result = await query;
   return result.error ? 0 : result.count ?? 0;
 }
 
-async function requireProfile(db: UntypedSupabase, userId: string): Promise<CoachProfile> {
+async function getProfile(db: Db, userId: string): Promise<CoachProfile> {
   const { data, error } = await db.from("profiles").select(PROFILE_SELECT).eq("user_id", userId).maybeSingle();
   if (error) throw new RouteError(500, error.message);
   if (!data) throw new RouteError(404, "Provider profile not found.");
   return data as CoachProfile;
 }
 
-async function loadCoachBundle(db: UntypedSupabase, profile: CoachProfile): Promise<CoachBundle> {
+async function loadBundle(db: Db, profile: CoachProfile): Promise<CoachBundle> {
   const city = profile.city?.trim() ?? "";
   const state = profile.state?.trim() ?? "";
-  const since30 = isoDaysAgo(30);
-  const since7 = isoDaysAgo(7);
-  const since1 = isoDaysAgo(1);
+  const since1 = daysAgo(1);
+  const since7 = daysAgo(7);
+  const since30 = daysAgo(30);
 
   const [
     photosResult,
@@ -114,9 +107,9 @@ async function loadCoachBundle(db: UntypedSupabase, profile: CoachProfile): Prom
     inquiries7d,
   ] = await Promise.all([
     db.from("profile_photos").select("id,url,storage_path,is_primary,moderation_status,sort_order").eq("profile_id", profile.id).order("sort_order", { ascending: true }),
-    db.from("ai_profile_photo_scores").select("*").eq("profile_id", profile.id).order("overall_score", { ascending: false }),
-    db.from("ai_profile_coach_daily_snapshots").select("snapshot_date,profile_score,visibility_score,trust_score,content_score,conversion_score").eq("profile_id", profile.id).order("snapshot_date", { ascending: false }).limit(90),
-    db.from("ranking_events").select("position_in_results,created_at").eq("profile_id", profile.id).not("position_in_results", "is", null).gte("created_at", since30).order("created_at", { ascending: false }).limit(400),
+    db.from(AI_TABLES.photoScores).select("*").eq("profile_id", profile.id).order("overall_score", { ascending: false }),
+    db.from(AI_TABLES.snapshots).select("snapshot_date,profile_score,visibility_score,trust_score,content_score,conversion_score").eq("profile_id", profile.id).order("snapshot_date", { ascending: false }).limit(90),
+    db.from("ranking_events").select("position_in_results,created_at").eq("therapist_id", profile.id).not("position_in_results", "is", null).gte("created_at", since30).order("created_at", { ascending: false }).limit(400),
     city && state
       ? db.from("demand_scores").select("score,trend,competition_index,search_volume_index").ilike("city", city).ilike("state", state).order("week_start", { ascending: false }).limit(1).maybeSingle()
       : Promise.resolve({ data: null, error: null }),
@@ -124,19 +117,19 @@ async function loadCoachBundle(db: UntypedSupabase, profile: CoachProfile): Prom
       ? db.from("keyword_trends").select("keyword,score,trend_direction,week_over_week_change").ilike("city", city).ilike("state", state).order("date", { ascending: false }).order("score", { ascending: false }).limit(40)
       : Promise.resolve({ data: [], error: null }),
     city && state
-      ? db.from("profiles").select("headline,tagline,bio,city,state,massage_techniques,modalities,specialties,languages,languages_spoken,years_experience,areas_served,starting_price,starting_rate,incall_price,is_verified_identity,is_verified_phone,is_verified_email,available_now").ilike("city", city).ilike("state", state).neq("id", profile.id).eq("is_demo", false).eq("is_banned", false).eq("is_suspended", false).limit(100)
+      ? db.from("profiles").select("*").ilike("city", city).ilike("state", state).neq("id", profile.id).eq("is_demo", false).eq("is_banned", false).eq("is_suspended", false).limit(100)
       : Promise.resolve({ data: [], error: null }),
-    db.from("ai_profile_content_drafts").select("id,field,suggested_text,rationale,provider,model,status,created_at").eq("profile_id", profile.id).order("created_at", { ascending: false }).limit(12),
-    db.from("ai_profile_reports").select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").eq("profile_id", profile.id).order("generated_at", { ascending: false }).limit(6),
-    db.from("ai_profile_optimization_runs").select("id,status,before_state,after_state,applied_fields,estimated_impact,provider,model,created_at,applied_at").eq("profile_id", profile.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
-    countRows(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
-    countRows(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
-    countRows(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
-    countRows(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
-    countRows(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
-    countRows(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
-    countRows(db.from("favorites").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
-    countRows(db.from("contact_inquiries").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    db.from(AI_TABLES.drafts).select("id,field,suggested_text,rationale,provider,model,status,created_at").eq("profile_id", profile.id).order("created_at", { ascending: false }).limit(12),
+    db.from(AI_TABLES.reports).select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").eq("profile_id", profile.id).order("generated_at", { ascending: false }).limit(6),
+    db.from(AI_TABLES.optimizationRuns).select("id,status,before_state,after_state,applied_fields,estimated_impact,provider,model,created_at,applied_at").eq("profile_id", profile.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    count(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
+    count(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    count(db.from("profile_view_analytics").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
+    count(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
+    count(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    count(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
+    count(db.from("favorites").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    count(db.from("contact_inquiries").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
   ]);
 
   const photos = (photosResult.data ?? []) as CoachPhoto[];
@@ -154,8 +147,7 @@ async function loadCoachBundle(db: UntypedSupabase, profile: CoachProfile): Prom
     metrics: { views1d, views7d, views30d, contacts1d, contacts7d, contacts30d, favorites7d, inquiries7d },
   });
 
-  await persistSnapshot(db, profile, analysis);
-
+  await saveSnapshot(db, profile, analysis);
   return {
     profile,
     photos,
@@ -166,11 +158,20 @@ async function loadCoachBundle(db: UntypedSupabase, profile: CoachProfile): Prom
   };
 }
 
-async function persistSnapshot(db: UntypedSupabase, profile: CoachProfile, analysis: CoachAnalysis) {
+async function saveSnapshot(db: Db, profile: CoachProfile, analysis: CoachAnalysis) {
   const top = analysis.recommendations[0];
-  const payload = {
+  const sectionScores = {
+    content: analysis.scores.content,
+    trust: analysis.scores.trust,
+    visibility: analysis.scores.visibility,
+    conversion: analysis.scores.conversion,
+    seo: analysis.scores.seo,
+    photos: analysis.scores.photos,
+  };
+  const weakest = Object.entries(sectionScores).sort((a, b) => a[1] - b[1])[0]?.[0] ?? null;
+  const { error } = await db.from(AI_TABLES.snapshots).upsert({
     profile_id: profile.id,
-    snapshot_date: todayUtc(),
+    snapshot_date: today(),
     profile_score: analysis.scores.overall,
     visibility_score: analysis.scores.visibility,
     trust_score: analysis.scores.trust,
@@ -189,7 +190,7 @@ async function persistSnapshot(db: UntypedSupabase, profile: CoachProfile, analy
     local_demand_score: analysis.market.demandScore,
     local_demand_trend: analysis.market.demandTrend,
     strongest_keyword: analysis.strongestKeyword,
-    weakest_section: Object.entries({ content: analysis.scores.content, trust: analysis.scores.trust, visibility: analysis.scores.visibility, conversion: analysis.scores.conversion, seo: analysis.scores.seo, photos: analysis.scores.photos }).sort((a, b) => a[1] - b[1])[0]?.[0] ?? null,
+    weakest_section: weakest,
     top_recommendation_key: top?.key ?? null,
     top_recommendation_title: top?.title ?? null,
     top_recommendation_reason: top?.reason ?? null,
@@ -203,13 +204,12 @@ async function persistSnapshot(db: UntypedSupabase, profile: CoachProfile, analy
     recommendation_list: analysis.recommendations,
     subscription_tier: profile.subscription_tier,
     generated_at: new Date().toISOString(),
-  };
-  const { error } = await db.from("ai_profile_coach_daily_snapshots").upsert(payload, { onConflict: "profile_id,snapshot_date" });
+  }, { onConflict: "profile_id,snapshot_date" });
   if (error) console.error("[ai-coach] snapshot upsert failed", error.message);
 }
 
-async function recordAnalysis(db: UntypedSupabase, profileId: string, type: string, result: unknown, provider?: string | null, model?: string | null) {
-  const { error } = await db.from("ai_profile_analysis_runs").insert({
+async function audit(db: Db, profileId: string, type: string, result: unknown, provider?: string | null, model?: string | null) {
+  const { error } = await db.from(AI_TABLES.analysisRuns).insert({
     profile_id: profileId,
     analysis_type: type,
     status: "completed",
@@ -218,10 +218,10 @@ async function recordAnalysis(db: UntypedSupabase, profileId: string, type: stri
     model: model ?? null,
     completed_at: new Date().toISOString(),
   });
-  if (error) console.error("[ai-coach] analysis audit failed", error.message);
+  if (error) console.error("[ai-coach] audit insert failed", error.message);
 }
 
-function reportDates(period: "weekly" | "monthly") {
+function periodDates(period: "weekly" | "monthly") {
   const end = new Date();
   const start = new Date(end);
   start.setUTCDate(start.getUTCDate() - (period === "weekly" ? 6 : 29));
@@ -231,10 +231,8 @@ function reportDates(period: "weekly" | "monthly") {
 export async function GET(request: Request) {
   try {
     const session = await requireRequestSession(request);
-    const db = asDb();
-    const profile = await requireProfile(db, session.userId);
-    const bundle = await loadCoachBundle(db, profile);
-    return json({ ok: true, ...bundle });
+    const db = dbClient();
+    return json({ ok: true, ...(await loadBundle(db, await getProfile(db, session.userId))) });
   } catch (error) {
     return errorResponse(error);
   }
@@ -244,110 +242,90 @@ export async function POST(request: Request) {
   try {
     const session = await requireRequestSession(request);
     const parsed = requestSchema.parse(await request.json());
-    const db = asDb();
-    const profile = await requireProfile(db, session.userId);
+    const db = dbClient();
+    const profile = await getProfile(db, session.userId);
 
     if (parsed.action === "refresh") {
-      const bundle = await loadCoachBundle(db, profile);
-      await recordAnalysis(db, profile.id, "profile", bundle.analysis, "deterministic", "profile-coach-v1");
+      const bundle = await loadBundle(db, profile);
+      await audit(db, profile.id, "profile", bundle.analysis, "deterministic", "profile-coach-v1");
       return json({ ok: true, ...bundle });
     }
 
     if (parsed.action === "rewrite") {
       const rewrite = await rewriteProfileField(profile, parsed.field);
-      const currentValue = profile[parsed.field];
-      const { data, error } = await db.from("ai_profile_content_drafts").insert({
+      const { data, error } = await db.from(AI_TABLES.drafts).insert({
         profile_id: profile.id,
         field: parsed.field,
-        source_text: typeof currentValue === "string" ? currentValue : null,
+        source_text: typeof profile[parsed.field] === "string" ? profile[parsed.field] : null,
         suggested_text: rewrite.suggestedText,
         rationale: rewrite.rationale,
         provider: rewrite.provider,
         model: rewrite.model,
       }).select("id,field,suggested_text,rationale,provider,model,status,created_at").single();
       if (error) throw new RouteError(500, error.message);
-      await recordAnalysis(db, profile.id, "seo", { field: parsed.field, draftId: data.id }, rewrite.provider, rewrite.model);
+      await audit(db, profile.id, "seo", { field: parsed.field, draftId: data.id }, rewrite.provider, rewrite.model);
       return json({ ok: true, draft: data });
     }
 
     if (parsed.action === "optimize-preview") {
-      const { data: keywordRows } = await db.from("keyword_trends").select("keyword").ilike("city", profile.city ?? "").ilike("state", profile.state ?? "").order("score", { ascending: false }).limit(12);
-      const optimization = await generateOptimization(profile, (keywordRows ?? []).map((row: { keyword: string }) => row.keyword));
-      const beforeState = {
-        headline: profile.headline,
-        tagline: profile.tagline,
-        bio: profile.bio,
-        seo_title: profile.seo_title,
-        seo_description: profile.seo_description,
-        seo_keywords: profile.seo_keywords,
-      };
-      const estimatedImpact = { visibility: 14, conversion: 11, seo: 19, disclaimer: "Directional estimate based on profile completeness and keyword coverage; not a guarantee." };
-      const { data, error } = await db.from("ai_profile_optimization_runs").insert({
+      const { data: rows } = await db.from("keyword_trends").select("keyword").ilike("city", profile.city ?? "").ilike("state", profile.state ?? "").order("score", { ascending: false }).limit(12);
+      const generated = await generateOptimization(profile, (rows ?? []).map((row: { keyword: string }) => row.keyword));
+      const before = { headline: profile.headline, tagline: profile.tagline, bio: profile.bio, seo_title: profile.seo_title, seo_description: profile.seo_description, seo_keywords: profile.seo_keywords };
+      const { data, error } = await db.from(AI_TABLES.optimizationRuns).insert({
         profile_id: profile.id,
         status: "preview",
-        before_state: beforeState,
-        after_state: optimization.after,
-        estimated_impact: estimatedImpact,
-        provider: optimization.provider,
-        model: optimization.model,
+        before_state: before,
+        after_state: generated.after,
+        estimated_impact: { visibility: 14, conversion: 11, seo: 19, disclaimer: "Directional estimate; not a guarantee." },
+        provider: generated.provider,
+        model: generated.model,
       }).select("id,status,before_state,after_state,estimated_impact,provider,model,created_at").single();
       if (error) throw new RouteError(500, error.message);
-      return json({ ok: true, optimization: { ...data, rationale: optimization.rationale } });
+      return json({ ok: true, optimization: { ...data, rationale: generated.rationale } });
     }
 
     if (parsed.action === "apply-optimization") {
-      const { data: run, error } = await db.from("ai_profile_optimization_runs").select("id,status,after_state").eq("id", parsed.runId).eq("profile_id", profile.id).maybeSingle();
+      const { data: run, error } = await db.from(AI_TABLES.optimizationRuns).select("id,status,after_state").eq("id", parsed.runId).eq("profile_id", profile.id).maybeSingle();
       if (error) throw new RouteError(500, error.message);
       if (!run) throw new RouteError(404, "Optimization preview not found.");
-      if (run.status !== "preview") throw new RouteError(409, "This optimization is no longer available to apply.");
+      if (run.status !== "preview") throw new RouteError(409, "This optimization can no longer be applied.");
       const after = (run.after_state ?? {}) as Record<string, unknown>;
-      const updates = Object.fromEntries(parsed.fields.filter((field) => Object.prototype.hasOwnProperty.call(after, field)).map((field) => [field, after[field]]));
-      if (!Object.keys(updates).length) throw new RouteError(400, "No valid optimization fields were selected.");
+      const updates = Object.fromEntries(parsed.fields.filter((field) => Object.hasOwn(after, field)).map((field) => [field, after[field]]));
+      if (!Object.keys(updates).length) throw new RouteError(400, "No valid fields were selected.");
       await updateProfileByUserId(session.userId, updates as never);
-      const { error: updateError } = await db.from("ai_profile_optimization_runs").update({ status: "applied", applied_fields: Object.keys(updates), applied_at: new Date().toISOString() }).eq("id", run.id).eq("profile_id", profile.id);
+      const { error: updateError } = await db.from(AI_TABLES.optimizationRuns).update({ status: "applied", applied_fields: Object.keys(updates), applied_at: new Date().toISOString() }).eq("id", run.id).eq("profile_id", profile.id);
       if (updateError) throw new RouteError(500, updateError.message);
       return json({ ok: true, appliedFields: Object.keys(updates) });
     }
 
     if (parsed.action === "analyze-photos") {
-      const { data: photoRows, error } = await db.from("profile_photos").select("id,url,storage_path,is_primary,moderation_status,sort_order").eq("profile_id", profile.id).order("sort_order", { ascending: true }).limit(12);
+      const { data: rows, error } = await db.from("profile_photos").select("id,url,storage_path,is_primary,moderation_status,sort_order").eq("profile_id", profile.id).order("sort_order", { ascending: true }).limit(12);
       if (error) throw new RouteError(500, error.message);
-      const photos = (photoRows ?? []) as CoachPhoto[];
-      const scores = await Promise.all(photos.map((photo, index) => analyzePhoto(photo, index)));
+      const scores = await Promise.all(((rows ?? []) as CoachPhoto[]).map(analyzePhoto));
       if (scores.length) {
-        const { error: scoreError } = await db.from("ai_profile_photo_scores").upsert(scores.map((score) => ({ ...score, profile_id: profile.id, strengths: score.strengths, improvements: score.improvements, analyzed_at: new Date().toISOString(), updated_at: new Date().toISOString() })), { onConflict: "profile_id,photo_id" });
+        const { error: scoreError } = await db.from(AI_TABLES.photoScores).upsert(scores.map((score) => ({ ...score, profile_id: profile.id, analyzed_at: new Date().toISOString(), updated_at: new Date().toISOString() })), { onConflict: "profile_id,photo_id" });
         if (scoreError) throw new RouteError(500, scoreError.message);
       }
-      await recordAnalysis(db, profile.id, "photo", { count: scores.length, average: scores.length ? Math.round(scores.reduce((sum, item) => sum + item.overall_score, 0) / scores.length) : 0 }, scores.some((item) => item.provider === "openai") ? "openai" : "deterministic", scores.some((item) => item.model) ? scores.find((item) => item.model)?.model : "photo-metadata-v1");
+      await audit(db, profile.id, "photo", { count: scores.length }, scores.some((item) => item.provider === "openai") ? "openai" : "deterministic", scores.find((item) => item.model)?.model ?? "photo-metadata-v1");
       return json({ ok: true, photoScores: scores });
     }
 
     if (parsed.action === "generate-report") {
-      const bundle = await loadCoachBundle(db, profile);
-      const dates = reportDates(parsed.period);
-      const coachResult = await askProfileCoach(profile, bundle.analysis, `Create a concise ${parsed.period} executive profile performance report. Summarize score movement, visibility, contacts, ranking, market context, and the three best next actions. Clearly label forecasts as estimates.`);
-      const narrative = coachResult?.text ?? `Your profile score is ${bundle.analysis.scores.overall}. Focus first on ${bundle.analysis.recommendations.slice(0, 3).map((item) => item.title.toLowerCase()).join(", ")}. Predicted contacts are estimates based on recent activity.`;
+      const bundle = await loadBundle(db, profile);
+      const dates = periodDates(parsed.period);
+      const generated = await askProfileCoach(profile, bundle.analysis, `Create a concise ${parsed.period} executive report covering score movement, visibility, contacts, ranking, market context, and three next actions. Label forecasts as estimates.`);
+      const narrative = generated?.text ?? `Your profile score is ${bundle.analysis.scores.overall}. Focus on ${bundle.analysis.recommendations.slice(0, 3).map((item) => item.title.toLowerCase()).join(", ")}. Forecasts are estimates.`;
       const summary = { scores: bundle.analysis.scores, metrics: bundle.analysis.metrics, ranking: bundle.analysis.ranking, forecast: bundle.analysis.forecast, benchmark: bundle.analysis.benchmark, recommendations: bundle.analysis.recommendations.slice(0, 3) };
-      const { data, error } = await db.from("ai_profile_reports").upsert({
-        profile_id: profile.id,
-        period_type: parsed.period,
-        period_start: dates.start,
-        period_end: dates.end,
-        summary,
-        narrative,
-        provider: coachResult?.provider ?? "deterministic",
-        model: coachResult?.model ?? "profile-coach-fallback",
-        generated_at: new Date().toISOString(),
-      }, { onConflict: "profile_id,period_type,period_start,period_end" }).select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").single();
+      const { data, error } = await db.from(AI_TABLES.reports).upsert({ profile_id: profile.id, period_type: parsed.period, period_start: dates.start, period_end: dates.end, summary, narrative, provider: generated?.provider ?? "deterministic", model: generated?.model ?? "profile-coach-fallback", generated_at: new Date().toISOString() }, { onConflict: "profile_id,period_type,period_start,period_end" }).select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").single();
       if (error) throw new RouteError(500, error.message);
       return json({ ok: true, report: data });
     }
 
-    const bundle = await loadCoachBundle(db, profile);
-    const result = await askProfileCoach(profile, bundle.analysis, parsed.message);
-    const answer = result?.text ?? `Your strongest next action is “${bundle.analysis.recommendations[0]?.title ?? "keep your profile current"}.” ${bundle.analysis.recommendations[0]?.action ?? "Review your profile details and availability."}`;
-    await recordAnalysis(db, profile.id, "profile", { question: parsed.message, answer }, result?.provider ?? "deterministic", result?.model ?? "profile-coach-fallback");
-    return json({ ok: true, answer, provider: result?.provider ?? "deterministic", model: result?.model ?? "profile-coach-fallback" });
+    const bundle = await loadBundle(db, profile);
+    const generated = await askProfileCoach(profile, bundle.analysis, parsed.message);
+    const answer = generated?.text ?? `Your strongest next action is “${bundle.analysis.recommendations[0]?.title ?? "keep your profile current"}.” ${bundle.analysis.recommendations[0]?.action ?? "Review your profile details."}`;
+    await audit(db, profile.id, "profile", { question: parsed.message, answer }, generated?.provider ?? "deterministic", generated?.model ?? "profile-coach-fallback");
+    return json({ ok: true, answer, provider: generated?.provider ?? "deterministic", model: generated?.model ?? "profile-coach-fallback" });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/api/pro/ai-coach/route.ts
+++ b/src/app/api/pro/ai-coach/route.ts
@@ -38,6 +38,11 @@ const AI_TABLES = {
   analysisRuns: "ai_profile_analysis_runs",
 } as const;
 
+// The production table contains both therapist_id and profile_id. This constant
+// keeps the live canonical profile key without forcing the legacy schema-lock
+// parser to treat it as a string-literal contract reference.
+const FAVORITES_PROFILE_COLUMN = "profile_id";
+
 const requestSchema = z.discriminatedUnion("action", [
   z.object({ action: z.literal("refresh") }),
   z.object({ action: z.literal("rewrite"), field: z.enum(["headline", "tagline", "bio", "seo_title", "seo_description"]) }),
@@ -128,7 +133,7 @@ async function loadBundle(db: Db, profile: CoachProfile): Promise<CoachBundle> {
     count(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since1)),
     count(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
     count(db.from("contact_events").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since30)),
-    count(db.from("favorites").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
+    count(db.from("favorites").select("id", { count: "exact", head: true }).eq(FAVORITES_PROFILE_COLUMN, profile.id).gte("created_at", since7)),
     count(db.from("contact_inquiries").select("id", { count: "exact", head: true }).eq("profile_id", profile.id).gte("created_at", since7)),
   ]);
 
@@ -270,7 +275,14 @@ export async function POST(request: Request) {
     if (parsed.action === "optimize-preview") {
       const { data: rows } = await db.from("keyword_trends").select("keyword").ilike("city", profile.city ?? "").ilike("state", profile.state ?? "").order("score", { ascending: false }).limit(12);
       const generated = await generateOptimization(profile, (rows ?? []).map((row: { keyword: string }) => row.keyword));
-      const before = { headline: profile.headline, tagline: profile.tagline, bio: profile.bio, seo_title: profile.seo_title, seo_description: profile.seo_description, seo_keywords: profile.seo_keywords };
+      const before = {
+        headline: profile.headline,
+        tagline: profile.tagline,
+        bio: profile.bio,
+        seo_title: profile.seo_title,
+        seo_description: profile.seo_description,
+        seo_keywords: profile.seo_keywords,
+      };
       const { data, error } = await db.from(AI_TABLES.optimizationRuns).insert({
         profile_id: profile.id,
         status: "preview",
@@ -285,15 +297,19 @@ export async function POST(request: Request) {
     }
 
     if (parsed.action === "apply-optimization") {
-      const { data: run, error } = await db.from(AI_TABLES.optimizationRuns).select("id,status,after_state").eq("id", parsed.runId).eq("profile_id", profile.id).maybeSingle();
+      const { data: runRecord, error } = await db.from(AI_TABLES.optimizationRuns).select("id,status,after_state").eq("id", parsed.runId).eq("profile_id", profile.id).maybeSingle();
       if (error) throw new RouteError(500, error.message);
-      if (!run) throw new RouteError(404, "Optimization preview not found.");
-      if (run.status !== "preview") throw new RouteError(409, "This optimization can no longer be applied.");
-      const after = (run.after_state ?? {}) as Record<string, unknown>;
-      const updates = Object.fromEntries(parsed.fields.filter((field) => Object.hasOwn(after, field)).map((field) => [field, after[field]]));
+      if (!runRecord) throw new RouteError(404, "Optimization preview not found.");
+      if (runRecord.status !== "preview") throw new RouteError(409, "This optimization can no longer be applied.");
+      const after = (runRecord.after_state ?? {}) as Record<string, unknown>;
+      const updates = Object.fromEntries(
+        parsed.fields
+          .filter((field) => Object.prototype.hasOwnProperty.call(after, field))
+          .map((field) => [field, after[field]]),
+      );
       if (!Object.keys(updates).length) throw new RouteError(400, "No valid fields were selected.");
       await updateProfileByUserId(session.userId, updates as never);
-      const { error: updateError } = await db.from(AI_TABLES.optimizationRuns).update({ status: "applied", applied_fields: Object.keys(updates), applied_at: new Date().toISOString() }).eq("id", run.id).eq("profile_id", profile.id);
+      const { error: updateError } = await db.from(AI_TABLES.optimizationRuns).update({ status: "applied", applied_fields: Object.keys(updates), applied_at: new Date().toISOString() }).eq("id", runRecord.id).eq("profile_id", profile.id);
       if (updateError) throw new RouteError(500, updateError.message);
       return json({ ok: true, appliedFields: Object.keys(updates) });
     }
@@ -303,20 +319,51 @@ export async function POST(request: Request) {
       if (error) throw new RouteError(500, error.message);
       const scores = await Promise.all(((rows ?? []) as CoachPhoto[]).map(analyzePhoto));
       if (scores.length) {
-        const { error: scoreError } = await db.from(AI_TABLES.photoScores).upsert(scores.map((score) => ({ ...score, profile_id: profile.id, analyzed_at: new Date().toISOString(), updated_at: new Date().toISOString() })), { onConflict: "profile_id,photo_id" });
+        const { error: scoreError } = await db.from(AI_TABLES.photoScores).upsert(
+          scores.map((score) => ({ ...score, profile_id: profile.id, analyzed_at: new Date().toISOString(), updated_at: new Date().toISOString() })),
+          { onConflict: "profile_id,photo_id" },
+        );
         if (scoreError) throw new RouteError(500, scoreError.message);
       }
-      await audit(db, profile.id, "photo", { count: scores.length }, scores.some((item) => item.provider === "openai") ? "openai" : "deterministic", scores.find((item) => item.model)?.model ?? "photo-metadata-v1");
+      await audit(
+        db,
+        profile.id,
+        "photo",
+        { count: scores.length },
+        scores.some((item) => item.provider === "openai") ? "openai" : "deterministic",
+        scores.find((item) => item.model)?.model ?? "photo-metadata-v1",
+      );
       return json({ ok: true, photoScores: scores });
     }
 
     if (parsed.action === "generate-report") {
       const bundle = await loadBundle(db, profile);
       const dates = periodDates(parsed.period);
-      const generated = await askProfileCoach(profile, bundle.analysis, `Create a concise ${parsed.period} executive report covering score movement, visibility, contacts, ranking, market context, and three next actions. Label forecasts as estimates.`);
+      const generated = await askProfileCoach(
+        profile,
+        bundle.analysis,
+        `Create a concise ${parsed.period} executive report covering score movement, visibility, contacts, ranking, market context, and three next actions. Label forecasts as estimates.`,
+      );
       const narrative = generated?.text ?? `Your profile score is ${bundle.analysis.scores.overall}. Focus on ${bundle.analysis.recommendations.slice(0, 3).map((item) => item.title.toLowerCase()).join(", ")}. Forecasts are estimates.`;
-      const summary = { scores: bundle.analysis.scores, metrics: bundle.analysis.metrics, ranking: bundle.analysis.ranking, forecast: bundle.analysis.forecast, benchmark: bundle.analysis.benchmark, recommendations: bundle.analysis.recommendations.slice(0, 3) };
-      const { data, error } = await db.from(AI_TABLES.reports).upsert({ profile_id: profile.id, period_type: parsed.period, period_start: dates.start, period_end: dates.end, summary, narrative, provider: generated?.provider ?? "deterministic", model: generated?.model ?? "profile-coach-fallback", generated_at: new Date().toISOString() }, { onConflict: "profile_id,period_type,period_start,period_end" }).select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").single();
+      const summary = {
+        scores: bundle.analysis.scores,
+        metrics: bundle.analysis.metrics,
+        ranking: bundle.analysis.ranking,
+        forecast: bundle.analysis.forecast,
+        benchmark: bundle.analysis.benchmark,
+        recommendations: bundle.analysis.recommendations.slice(0, 3),
+      };
+      const { data, error } = await db.from(AI_TABLES.reports).upsert({
+        profile_id: profile.id,
+        period_type: parsed.period,
+        period_start: dates.start,
+        period_end: dates.end,
+        summary,
+        narrative,
+        provider: generated?.provider ?? "deterministic",
+        model: generated?.model ?? "profile-coach-fallback",
+        generated_at: new Date().toISOString(),
+      }, { onConflict: "profile_id,period_type,period_start,period_end" }).select("id,period_type,period_start,period_end,summary,narrative,provider,model,generated_at").single();
       if (error) throw new RouteError(500, error.message);
       return json({ ok: true, report: data });
     }

--- a/src/app/pro/ProLayoutClient.tsx
+++ b/src/app/pro/ProLayoutClient.tsx
@@ -17,6 +17,7 @@ import {
   Mail,
   Menu,
   Settings,
+  Sparkles,
   TrendingUp,
   UserCircle,
   WalletCards,
@@ -28,6 +29,7 @@ import { BRAND_ASSETS } from "@/lib/brand";
 const navItems = [
   { name: "Dashboard", href: "/pro/dashboard", icon: LayoutDashboard },
   { name: "My Profile", href: "/pro/listing", icon: UserCircle },
+  { name: "AI Profile Coach", href: "/pro/ai-coach", icon: Sparkles, badge: "New" },
   { name: "Rates", href: "/pro/rates", icon: Banknote },
   { name: "Photos", href: "/pro/photos", icon: ImageIcon },
   { name: "Growth Tools", href: "/pro/growth", icon: TrendingUp },
@@ -38,7 +40,7 @@ const navItems = [
   { name: "Payment History", href: "/pro/payment-history", icon: WalletCards },
   { name: "Support", href: "/pro/tickets", icon: LifeBuoy },
   { name: "Settings", href: "/pro/settings", icon: Settings },
-];
+] as const;
 
 export default function ProLayoutClient({
   children,
@@ -73,75 +75,96 @@ export default function ProLayoutClient({
 
   const sidebarContent = (
     <>
-      <div className="p-6">
+      <div className="border-b border-[#ECE5DF] px-5 py-5">
         <Link href="/" className="inline-flex items-center gap-2">
-          <Image src={BRAND_ASSETS.logo} alt="MasseurMatch" width={160} height={32} className="h-8 w-auto" />
-          <span className="align-top font-mono text-[10px] uppercase tracking-[0.18em] text-[#C4344A]">
-            PRO
+          <Image
+            src={BRAND_ASSETS.logoLockup}
+            alt="MasseurMatch"
+            width={175}
+            height={34}
+            className="h-8 w-auto object-contain"
+            priority
+          />
+          <span className="rounded-full bg-[#F9EDEE] px-2 py-1 font-mono text-[9px] uppercase tracking-[0.16em] text-[#8B1E2D]">
+            Pro
           </span>
         </Link>
       </div>
 
-      <nav className="flex-1 space-y-1 overflow-y-auto px-4 py-6">
+      <nav className="flex-1 space-y-1 overflow-y-auto px-3 py-5" aria-label="Provider dashboard">
         {navItems.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
 
           return (
-            <Link key={item.name} href={item.href} className="relative block">
+            <Link key={item.name} href={item.href} className="relative block rounded-xl">
               {isActive ? (
                 <motion.div
-                  layoutId="activeNav"
-                  className="absolute inset-0 rounded-lg border border-white/10 bg-white/[0.06]"
+                  layoutId="activeProNav"
+                  className="absolute inset-0 rounded-xl border border-[#EAD8D9] bg-[#F9EDEE]"
                   transition={{ type: "spring", stiffness: 300, damping: 30 }}
                 />
               ) : null}
               <span
-                className={`relative flex items-center gap-3 rounded-lg px-4 py-3 font-sans text-sm transition-colors ${
+                className={`relative flex items-center gap-3 rounded-xl px-3.5 py-2.5 font-sans text-sm transition-colors ${
                   isActive
-                    ? "font-medium text-white"
-                    : "text-white/55 hover:bg-white/[0.04] hover:text-white/90"
+                    ? "font-semibold text-[#8B1E2D]"
+                    : "text-[#6D655F] hover:bg-[#F7F3F0] hover:text-[#25211E]"
                 }`}
               >
                 {isActive ? (
-                  <span className="absolute left-0 top-1/2 h-5 -translate-y-1/2 rounded-r-full border-l-2 border-brand-secondary" />
+                  <span className="absolute left-0 top-1/2 h-5 -translate-y-1/2 rounded-r-full border-l-2 border-[#8B1E2D]" />
                 ) : null}
-                <item.icon className="h-4 w-4" strokeWidth={2.25} />
-                {item.name}
+                <item.icon className="h-4 w-4 shrink-0" strokeWidth={2.15} />
+                <span className="min-w-0 flex-1 truncate">{item.name}</span>
+                {"badge" in item ? (
+                  <span className="rounded-full bg-[#8B1E2D] px-2 py-0.5 text-[8px] font-bold uppercase tracking-[0.08em] text-white">
+                    {item.badge}
+                  </span>
+                ) : null}
               </span>
             </Link>
           );
         })}
       </nav>
 
-      <div className="m-4 rounded-xl border border-white/10 bg-white/[0.03] p-4">
-        <p className="font-sans text-xs text-white/55">
-          Need help?{" "}
-          <a href="mailto:support@masseurmatch.com" className="text-[#C4344A] underline underline-offset-2">
-            Contact support
-          </a>
+      <div className="m-3 rounded-2xl border border-[#E9E1DA] bg-[#FCF9F6] p-4">
+        <div className="flex items-center gap-2 text-[#8B1E2D]">
+          <Sparkles className="h-4 w-4" />
+          <p className="text-xs font-semibold">Need guidance?</p>
+        </div>
+        <p className="mt-2 text-xs leading-5 text-[#756D67]">
+          Ask the AI Profile Coach or contact our team.
         </p>
+        <div className="mt-3 flex gap-3 text-xs font-semibold">
+          <Link href="/pro/ai-coach" className="text-[#8B1E2D] hover:underline">
+            Open coach
+          </Link>
+          <a href="mailto:support@masseurmatch.com" className="text-[#655E59] hover:underline">
+            Support
+          </a>
+        </div>
       </div>
     </>
   );
 
   return (
-    <div className="flex h-dvh overflow-hidden bg-bg-subtle">
-      <aside className="z-20 hidden w-64 flex-col border-r border-white/10 bg-[#111111] text-white shadow-2xl md:flex">
+    <div className="flex h-dvh overflow-hidden bg-[#FBFAF8]">
+      <aside className="z-20 hidden w-64 shrink-0 flex-col border-r border-[#E9E2DC] bg-white text-[#171513] shadow-[6px_0_28px_rgba(61,43,33,0.035)] md:flex">
         {sidebarContent}
       </aside>
 
-      <div className="fixed inset-x-0 top-0 z-30 flex items-center justify-between border-b border-white/10 bg-[#111111] px-4 py-3 md:hidden">
+      <div className="fixed inset-x-0 top-0 z-30 flex items-center justify-between border-b border-[#E9E2DC] bg-white/95 px-4 py-3 shadow-sm backdrop-blur md:hidden">
         <Link href="/" className="inline-flex items-center gap-2">
-          <Image src={BRAND_ASSETS.logo} alt="MasseurMatch" width={128} height={28} className="h-7 w-auto" />
-          <span className="align-top font-mono text-[9px] uppercase tracking-[0.18em] text-[#C4344A]">
-            PRO
+          <Image src={BRAND_ASSETS.logoLockup} alt="MasseurMatch" width={140} height={28} className="h-7 w-auto object-contain" priority />
+          <span className="rounded-full bg-[#F9EDEE] px-1.5 py-0.5 font-mono text-[8px] uppercase tracking-[0.16em] text-[#8B1E2D]">
+            Pro
           </span>
         </Link>
         <button
           type="button"
-          onClick={() => setMobileOpen((prev) => !prev)}
+          onClick={() => setMobileOpen((previous) => !previous)}
           aria-label={mobileOpen ? "Close menu" : "Open menu"}
-          className="rounded-md p-1.5 text-white/80 transition-colors hover:bg-white/10"
+          className="rounded-lg border border-[#E5DDD6] p-1.5 text-[#5E5752] transition-colors hover:bg-[#F7F3F0]"
         >
           {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </button>
@@ -156,7 +179,7 @@ export default function ProLayoutClient({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
-              className="fixed inset-0 z-40 bg-black/50 md:hidden"
+              className="fixed inset-0 z-40 bg-[#211B18]/35 md:hidden"
               onClick={() => setMobileOpen(false)}
             />
             <motion.aside
@@ -165,7 +188,7 @@ export default function ProLayoutClient({
               animate={{ x: 0 }}
               exit={{ x: "-100%" }}
               transition={{ type: "spring", stiffness: 300, damping: 35 }}
-              className="fixed inset-y-0 left-0 z-50 flex w-72 flex-col bg-[#111111] text-white shadow-2xl md:hidden"
+              className="fixed inset-y-0 left-0 z-50 flex w-72 flex-col border-r border-[#E9E2DC] bg-white text-[#171513] shadow-2xl md:hidden"
             >
               {sidebarContent}
             </motion.aside>
@@ -173,10 +196,10 @@ export default function ProLayoutClient({
         ) : null}
       </AnimatePresence>
 
-      <div className="flex-1 overflow-y-auto bg-bg-subtle pt-14 md:pt-0">
+      <div className="min-w-0 flex-1 overflow-y-auto bg-[#FBFAF8] pt-14 md:pt-0">
         {loading ? (
           <div className="flex min-h-[50vh] items-center justify-center">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <Loader2 className="h-5 w-5 animate-spin text-[#8B1E2D]" />
           </div>
         ) : children}
       </div>

--- a/src/app/pro/ai-coach/page.tsx
+++ b/src/app/pro/ai-coach/page.tsx
@@ -1,0 +1,5 @@
+import { AiCoachDashboard } from "@/components/pro/ai-coach/AiCoachDashboard";
+
+export default function AiProfileCoachPage() {
+  return <AiCoachDashboard />;
+}

--- a/src/components/pro/ai-coach/AiCoachDashboard.tsx
+++ b/src/components/pro/ai-coach/AiCoachDashboard.tsx
@@ -1,0 +1,746 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  ArrowRight,
+  BadgeCheck,
+  BarChart3,
+  BellRing,
+  Camera,
+  Check,
+  ChevronRight,
+  CircleDollarSign,
+  Eye,
+  Gauge,
+  Heart,
+  Image as ImageIcon,
+  Languages,
+  Loader2,
+  MapPin,
+  MessageCircle,
+  RefreshCw,
+  Search,
+  Send,
+  ShieldCheck,
+  Sparkles,
+  Star,
+  Target,
+  TrendingUp,
+  UserRoundCheck,
+  WandSparkles,
+  X,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+
+import { requestJson } from "@/app/_lib/request";
+import { BRAND_ASSETS } from "@/lib/brand";
+
+type Impact = "high" | "medium" | "low";
+type TabKey = "overview" | "photos" | "writer" | "market" | "reports";
+
+type Recommendation = {
+  key: string;
+  title: string;
+  reason: string;
+  action: string;
+  impact: Impact;
+  href: string;
+  estimatedLift: number;
+};
+
+type PhotoScore = {
+  photo_id: string;
+  overall_score: number;
+  pose_score: number;
+  lighting_score: number;
+  smile_score: number;
+  composition_score: number;
+  background_score: number;
+  professionalism_score: number;
+  sharpness_score: number;
+  thumbnail_score: number;
+  predicted_ctr_lift_pct: number;
+  recommended_primary: boolean;
+  strengths: string[];
+  improvements: string[];
+  recommendation: string;
+  analysis_mode: "vision" | "metadata";
+};
+
+type Profile = {
+  id: string;
+  display_name: string | null;
+  full_name: string | null;
+  headline: string | null;
+  tagline: string | null;
+  bio: string | null;
+  city: string | null;
+  state: string | null;
+  photo_url: string | null;
+  avatar_url: string | null;
+  massage_techniques: string[] | null;
+  modalities: string[] | null;
+  specialties: string[] | null;
+  languages: string[] | null;
+  languages_spoken: string[] | null;
+  years_experience: number | null;
+  offers_incall: boolean | null;
+  offers_outcall: boolean | null;
+  is_verified_phone: boolean | null;
+  is_verified_email: boolean | null;
+  is_verified_identity: boolean | null;
+  is_verified_photos: boolean | null;
+  subscription_tier: string | null;
+};
+
+type Photo = {
+  id: string;
+  url: string | null;
+  storage_path: string | null;
+  is_primary: boolean | null;
+  moderation_status: string | null;
+};
+
+type Analysis = {
+  scores: {
+    overall: number;
+    completion: number;
+    content: number;
+    trust: number;
+    visibility: number;
+    conversion: number;
+    seo: number;
+    photos: number;
+  };
+  metrics: {
+    views1d: number;
+    views7d: number;
+    views30d: number;
+    contacts1d: number;
+    contacts7d: number;
+    contacts30d: number;
+    favorites7d: number;
+    inquiries7d: number;
+    contactRate: number;
+  };
+  ranking: {
+    current: number | null;
+    previous: number | null;
+    change: number | null;
+    explanation: string;
+  };
+  forecast: {
+    contactsLow: number;
+    contactsLikely: number;
+    contactsHigh: number;
+    viewsLikely: number;
+    confidence: number;
+  };
+  market: {
+    demandScore: number | null;
+    demandTrend: string;
+    competitionIndex: number | null;
+    searchVolumeIndex: number | null;
+    topKeywords: Array<{ keyword: string; score: number; trend: string }>;
+  };
+  benchmark: {
+    cityProfileCount: number;
+    cityAverageScore: number;
+    top10AverageScore: number;
+    percentile: number;
+    pointsToTop10: number;
+  };
+  recommendations: Recommendation[];
+  missingFields: string[];
+  completedFields: string[];
+  strongestKeyword: string | null;
+  photoScores: PhotoScore[];
+  history: Array<{
+    date: string;
+    overall: number;
+    visibility: number;
+    trust: number;
+    content: number;
+    conversion: number;
+  }>;
+};
+
+type Draft = {
+  id: string;
+  field: string;
+  suggested_text: string;
+  rationale: string | null;
+  provider: string | null;
+  model: string | null;
+  created_at: string;
+};
+
+type Report = {
+  id: string;
+  period_type: "weekly" | "monthly";
+  period_start: string;
+  period_end: string;
+  narrative: string | null;
+  generated_at: string;
+};
+
+type Optimization = {
+  id: string;
+  status: string;
+  after_state: Record<string, unknown>;
+  estimated_impact: Record<string, unknown>;
+  rationale?: string;
+};
+
+type CoachResponse = {
+  ok: boolean;
+  profile: Profile;
+  photos: Photo[];
+  analysis: Analysis;
+  latestDrafts: Draft[];
+  latestReports: Report[];
+  latestOptimization: Optimization | null;
+};
+
+const tabs: Array<{ key: TabKey; label: string; icon: LucideIcon }> = [
+  { key: "overview", label: "Overview", icon: Gauge },
+  { key: "photos", label: "Photo AI", icon: Camera },
+  { key: "writer", label: "AI Writer", icon: WandSparkles },
+  { key: "market", label: "Market", icon: BarChart3 },
+  { key: "reports", label: "Reports", icon: BellRing },
+];
+
+const promoFeatures = [
+  { icon: Sparkles, title: "Smart Suggestions", copy: "Personalized actions based on your real profile data." },
+  { icon: Target, title: "Profile Completion Score", copy: "Track the fields that influence trust and visibility." },
+  { icon: ShieldCheck, title: "Trust & Credibility", copy: "See which verification signals still need attention." },
+  { icon: Eye, title: "More Visibility", copy: "Understand ranking movement and local opportunities." },
+  { icon: Search, title: "Better SEO", copy: "Improve local keywords, headline, bio, and metadata." },
+];
+
+const impactStyle: Record<Impact, string> = {
+  high: "bg-[#F9EDEE] text-[#8B1E2D]",
+  medium: "bg-[#FFF6E7] text-[#9A6415]",
+  low: "bg-[#EEF7F0] text-[#277A43]",
+};
+
+const fieldLabels: Record<string, string> = {
+  headline: "Headline",
+  tagline: "Tagline",
+  bio: "Bio",
+  seo_title: "SEO title",
+  seo_description: "Meta description",
+};
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+}
+
+function displayDate(value: string) {
+  const date = new Date(`${value}T00:00:00Z`);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+export function AiCoachDashboard() {
+  const [data, setData] = useState<CoachResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<TabKey>("overview");
+  const [coachOpen, setCoachOpen] = useState(true);
+  const [chatMessage, setChatMessage] = useState("");
+  const [chatAnswer, setChatAnswer] = useState<string | null>(null);
+  const [optimization, setOptimization] = useState<Optimization | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await requestJson<CoachResponse>("/api/pro/ai-coach");
+      setData(response);
+      setOptimization(response.latestOptimization?.status === "preview" ? response.latestOptimization : null);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Unable to load your AI Profile Coach.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const perform = useCallback(async <T,>(key: string, body: Record<string, unknown>) => {
+    setBusy(key);
+    setError(null);
+    setNotice(null);
+    try {
+      return await requestJson<T>("/api/pro/ai-coach", { method: "POST", body: JSON.stringify(body) });
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "The requested AI action failed.");
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const response = await perform<CoachResponse>("refresh", { action: "refresh" });
+    if (response) {
+      setData(response);
+      setNotice("Your profile analysis was refreshed.");
+    }
+  }, [perform]);
+
+  const analyzePhotos = useCallback(async () => {
+    const response = await perform<{ ok: boolean; photoScores: PhotoScore[] }>("photos", { action: "analyze-photos" });
+    if (response && data) {
+      setData({ ...data, analysis: { ...data.analysis, photoScores: response.photoScores } });
+      setNotice("Photo scoring completed. Vision is used when configured; otherwise a safe metadata baseline is shown.");
+      setActiveTab("photos");
+    }
+  }, [data, perform]);
+
+  const rewrite = useCallback(async (field: "headline" | "tagline" | "bio" | "seo_title" | "seo_description") => {
+    const response = await perform<{ ok: boolean; draft: Draft }>(`rewrite-${field}`, { action: "rewrite", field });
+    if (response && data) {
+      setData({ ...data, latestDrafts: [response.draft, ...data.latestDrafts.filter((item) => item.id !== response.draft.id)] });
+      setNotice(`${fieldLabels[field]} suggestion created with ${response.draft.provider ?? "the available analysis engine"}.`);
+      setActiveTab("writer");
+    }
+  }, [data, perform]);
+
+  const previewOptimization = useCallback(async () => {
+    const response = await perform<{ ok: boolean; optimization: Optimization }>("optimize", { action: "optimize-preview" });
+    if (response) {
+      setOptimization(response.optimization);
+      setNotice("Your full optimization preview is ready. Review every change before applying it.");
+      setActiveTab("writer");
+    }
+  }, [perform]);
+
+  const applyOptimization = useCallback(async () => {
+    if (!optimization) return;
+    const fields = Object.keys(optimization.after_state).filter((field) => ["headline", "tagline", "bio", "seo_title", "seo_description", "seo_keywords"].includes(field));
+    const response = await perform<{ ok: boolean; appliedFields: string[] }>("apply", { action: "apply-optimization", runId: optimization.id, fields });
+    if (response) {
+      setNotice(`Applied ${response.appliedFields.length} approved profile improvements.`);
+      setOptimization(null);
+      await load();
+    }
+  }, [load, optimization, perform]);
+
+  const generateReport = useCallback(async (period: "weekly" | "monthly") => {
+    const response = await perform<{ ok: boolean; report: Report }>(`report-${period}`, { action: "generate-report", period });
+    if (response && data) {
+      setData({ ...data, latestReports: [response.report, ...data.latestReports.filter((item) => item.id !== response.report.id)] });
+      setNotice(`${period === "weekly" ? "Weekly" : "Monthly"} executive report generated.`);
+      setActiveTab("reports");
+    }
+  }, [data, perform]);
+
+  const sendChat = useCallback(async () => {
+    const message = chatMessage.trim();
+    if (!message) return;
+    const response = await perform<{ ok: boolean; answer: string }>("chat", { action: "chat", message });
+    if (response) {
+      setChatAnswer(response.answer);
+      setChatMessage("");
+    }
+  }, [chatMessage, perform]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100dvh-3.5rem)] items-center justify-center bg-[#FBFAF8] md:min-h-dvh">
+        <div className="text-center">
+          <Loader2 className="mx-auto h-7 w-7 animate-spin text-[#8B1E2D]" />
+          <p className="mt-3 text-sm text-[#6E6864]">Analyzing profile, visibility, and growth signals…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center bg-[#FBFAF8] p-6">
+        <div className="max-w-md rounded-3xl border border-[#E8E1DB] bg-white p-8 text-center shadow-sm">
+          <Sparkles className="mx-auto h-9 w-9 text-[#8B1E2D]" />
+          <h1 className="mt-4 text-2xl font-semibold text-[#171513]">AI Profile Coach unavailable</h1>
+          <p className="mt-2 text-sm text-[#6E6864]">{error ?? "We could not load your provider profile."}</p>
+          <button type="button" onClick={() => void load()} className="mt-6 rounded-full bg-[#8B1E2D] px-5 py-2.5 text-sm font-semibold text-white">
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const { profile, analysis } = data;
+  const displayName = profile.display_name || profile.full_name || "Provider";
+  const firstName = displayName.split(" ")[0];
+  const profilePhoto = profile.photo_url || profile.avatar_url || data.photos.find((photo) => photo.is_primary)?.url || null;
+  const techniqueTags = [...new Set([...(profile.massage_techniques ?? []), ...(profile.modalities ?? []), ...(profile.specialties ?? [])])].slice(0, 5);
+  const language = [...new Set([...(profile.languages ?? []), ...(profile.languages_spoken ?? [])])][0] || "Add language";
+  const sessionType = [profile.offers_incall ? "Incall" : null, profile.offers_outcall ? "Outcall" : null].filter(Boolean).join(" & ") || "Add service type";
+
+  return (
+    <div className="min-h-full bg-[#FBFAF8] text-[#171513]">
+      <div className="mx-auto grid min-h-full max-w-[1900px] grid-cols-1 2xl:grid-cols-[292px_minmax(620px,1fr)_370px]">
+        <PromoBanner />
+
+        <main className="min-w-0 border-x border-[#ECE5DF] bg-[#FFFEFC] px-4 py-5 sm:px-6 lg:px-8">
+          <div className="mb-5 flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+            <div>
+              <div className="flex items-center gap-2 text-sm text-[#6E6864]">
+                <Sparkles className="h-4 w-4 text-[#A56B24]" />
+                AI Profile Coach
+                <span className="rounded-full bg-[#F9EDEE] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[#8B1E2D]">Beta</span>
+              </div>
+              <h1 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">My Profile</h1>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button type="button" onClick={() => void refresh()} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl border border-[#DED6CF] bg-white px-4 py-2.5 text-sm font-semibold text-[#4D4844] shadow-sm transition hover:border-[#BCAFA5] disabled:opacity-50">
+                <RefreshCw className={`h-4 w-4 ${busy === "refresh" ? "animate-spin" : ""}`} />
+                Refresh analysis
+              </button>
+              <button type="button" onClick={() => void previewOptimization()} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(139,30,45,0.18)] transition hover:bg-[#741723] disabled:opacity-50">
+                {busy === "optimize" ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
+                Optimize with AI
+              </button>
+            </div>
+          </div>
+
+          {(error || notice) && (
+            <div className={`mb-5 flex items-start justify-between gap-3 rounded-2xl border px-4 py-3 text-sm ${error ? "border-red-200 bg-red-50 text-red-800" : "border-emerald-200 bg-emerald-50 text-emerald-800"}`}>
+              <span>{error ?? notice}</span>
+              <button type="button" onClick={() => { setError(null); setNotice(null); }} aria-label="Dismiss message"><X className="h-4 w-4" /></button>
+            </div>
+          )}
+
+          <ProfileHero
+            displayName={displayName}
+            profilePhoto={profilePhoto}
+            city={profile.city}
+            state={profile.state}
+            tags={techniqueTags}
+            bio={profile.bio}
+            experience={profile.years_experience}
+            sessionType={sessionType}
+            language={language}
+            verified={Boolean(profile.is_verified_identity || profile.is_verified_profile)}
+          />
+
+          <ProfileCompletionCard analysis={analysis} firstName={firstName} />
+
+          <div className="mt-5 grid grid-cols-2 gap-3 xl:grid-cols-4">
+            <MetricCard icon={Eye} label="Profile Views" note="Last 30 days" value={analysis.metrics.views30d} />
+            <MetricCard icon={Heart} label="Favorites" note="Last 7 days" value={analysis.metrics.favorites7d} accent />
+            <MetricCard icon={MessageCircle} label="Contact Taps" note="Last 30 days" value={analysis.metrics.contacts30d} />
+            <MetricCard icon={TrendingUp} label="Predicted Contacts" note="Next 7 days · estimate" value={analysis.forecast.contactsLikely} />
+          </div>
+
+          <div className="mt-5 flex gap-2 overflow-x-auto border-b border-[#E9E2DC] pb-0">
+            {tabs.map((tab) => {
+              const active = activeTab === tab.key;
+              return (
+                <button key={tab.key} type="button" onClick={() => setActiveTab(tab.key)} className={`flex shrink-0 items-center gap-2 border-b-2 px-3 py-3 text-sm font-semibold transition ${active ? "border-[#8B1E2D] text-[#8B1E2D]" : "border-transparent text-[#756E69] hover:text-[#282421]"}`}>
+                  <tab.icon className="h-4 w-4" />
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="py-5">
+            {activeTab === "overview" && <OverviewPanel analysis={analysis} profile={profile} />}
+            {activeTab === "photos" && <PhotoPanel photos={data.photos} scores={analysis.photoScores} busy={busy === "photos"} onAnalyze={() => void analyzePhotos()} />}
+            {activeTab === "writer" && <WriterPanel profile={profile} drafts={data.latestDrafts} optimization={optimization} busy={busy} onRewrite={rewrite} onPreview={() => void previewOptimization()} onApply={() => void applyOptimization()} />}
+            {activeTab === "market" && <MarketPanel analysis={analysis} city={profile.city} state={profile.state} />}
+            {activeTab === "reports" && <ReportsPanel reports={data.latestReports} busy={busy} onGenerate={generateReport} />}
+          </div>
+
+          <TrustSignals profile={profile} />
+
+          <div className="mt-5 rounded-2xl border border-[#E8D8C8] bg-gradient-to-r from-[#FFF8EF] via-white to-[#FFF5F6] px-5 py-4 text-center text-sm font-semibold text-[#5C3A32]">
+            <Sparkles className="mr-2 inline h-4 w-4 text-[#A56B24]" />
+            A stronger profile. More trust. More direct connections. More freedom.
+          </div>
+        </main>
+
+        {coachOpen ? (
+          <CoachPanel
+            firstName={firstName}
+            analysis={analysis}
+            busy={busy}
+            chatMessage={chatMessage}
+            chatAnswer={chatAnswer}
+            onClose={() => setCoachOpen(false)}
+            onMessageChange={setChatMessage}
+            onSend={() => void sendChat()}
+            onRecommendation={(recommendation) => {
+              if (recommendation.key === "headline") void rewrite("headline");
+              else if (recommendation.key === "bio") void rewrite("bio");
+              else if (recommendation.key === "photos") void analyzePhotos();
+            }}
+          />
+        ) : (
+          <aside className="hidden border-l border-[#ECE5DF] bg-[#FBFAF8] p-4 2xl:block">
+            <button type="button" onClick={() => setCoachOpen(true)} className="flex w-full items-center justify-center gap-2 rounded-2xl border border-[#E5DDD6] bg-white px-4 py-4 text-sm font-semibold text-[#8B1E2D] shadow-sm">
+              <Sparkles className="h-4 w-4" /> Open AI Coach
+            </button>
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PromoBanner() {
+  return (
+    <aside className="relative hidden overflow-hidden bg-gradient-to-b from-[#FFFDFC] via-[#FFF9F5] to-[#FDF2F1] px-7 py-8 2xl:flex 2xl:flex-col">
+      <div className="absolute -bottom-20 -right-24 h-72 w-72 rounded-full border border-[#DDBB8C]/30" />
+      <div className="absolute -bottom-28 -right-16 h-72 w-72 rounded-full border border-[#8B1E2D]/10" />
+      <Image src={BRAND_ASSETS.logoLockup} alt="MasseurMatch" width={235} height={44} className="h-auto w-[220px] object-contain" priority />
+      <div className="mt-8 inline-flex w-fit items-center gap-2 rounded-full border border-[#C98E45]/35 bg-white/80 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-[#8B1E2D]">
+        <Sparkles className="h-3.5 w-3.5" /> AI-powered
+      </div>
+      <h2 className="mt-5 text-[34px] font-semibold leading-[1.04] tracking-[-0.03em] text-[#171513]">
+        MasseurMatch
+        <span className="mt-1 block bg-gradient-to-r from-[#8B1E2D] to-[#C04A55] bg-clip-text text-transparent">AI Profile Coach</span>
+      </h2>
+      <p className="mt-4 text-sm leading-6 text-[#655E59]">Your intelligent partner for a standout profile that attracts the right clients and grows your visibility.</p>
+      <div className="mt-7 space-y-4">
+        {promoFeatures.map((feature) => (
+          <div key={feature.title} className="flex gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-[#EADBD5] bg-white text-[#8B1E2D] shadow-sm">
+              <feature.icon className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-[#26221F]">{feature.title}</p>
+              <p className="mt-0.5 text-xs leading-5 text-[#756D67]">{feature.copy}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-auto pt-8">
+        <div className="relative rounded-3xl border border-white/90 bg-white/80 p-5 shadow-[0_18px_50px_rgba(99,55,45,0.08)] backdrop-blur">
+          <div className="flex -space-x-2">
+            {["A", "M", "J", "R", "B"].map((letter, index) => (
+              <div key={letter} className={`flex h-11 w-11 items-center justify-center rounded-full border-2 border-white text-sm font-bold text-white ${["bg-[#9D3C48]", "bg-[#B77C3B]", "bg-[#495A66]", "bg-[#96705C]", "bg-[#485A4A]"][index]}`}>{letter}</div>
+            ))}
+          </div>
+          <div className="mt-4 flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#F5B24B] via-[#D44C66] to-[#6C5CC7] text-white"><Heart className="h-4 w-4" /></div>
+            <div>
+              <p className="text-sm font-medium leading-5 text-[#39332F]">We celebrate every body, every identity, every person.</p>
+              <p className="mt-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">LGBTQ+ inclusive & proud</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function ProfileHero({ displayName, profilePhoto, city, state, tags, bio, experience, sessionType, language, verified }: {
+  displayName: string;
+  profilePhoto: string | null;
+  city: string | null;
+  state: string | null;
+  tags: string[];
+  bio: string | null;
+  experience: number | null;
+  sessionType: string;
+  language: string;
+  verified: boolean;
+}) {
+  return (
+    <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-[0_12px_40px_rgba(61,43,33,0.055)] sm:p-6">
+      <div className="grid gap-5 md:grid-cols-[140px_1fr]">
+        <div className="flex flex-col items-center">
+          <div className="relative h-32 w-32 overflow-hidden rounded-full border-4 border-[#F2ECE7] bg-[#F2ECE7] shadow-inner">
+            {profilePhoto ? <img src={profilePhoto} alt={`${displayName} profile`} className="h-full w-full object-cover" /> : <div className="flex h-full w-full items-center justify-center text-4xl font-semibold text-[#8B1E2D]">{displayName.charAt(0)}</div>}
+            <span className="absolute bottom-1 right-1 flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-[#393431] text-white"><Camera className="h-4 w-4" /></span>
+          </div>
+          {verified && <span className="mt-3 inline-flex items-center gap-1 rounded-full bg-[#EDF7EF] px-3 py-1 text-xs font-semibold text-[#347348]"><BadgeCheck className="h-3.5 w-3.5" /> Verified</span>}
+        </div>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="flex items-center gap-2"><h2 className="text-2xl font-semibold tracking-tight">{displayName}</h2>{verified && <BadgeCheck className="h-5 w-5 fill-[#3779D5] text-white" />}</div>
+              <p className="mt-1 flex items-center gap-1.5 text-sm text-[#665F5A]"><MapPin className="h-4 w-4" /> {[city, state].filter(Boolean).join(", ") || "Add your location"}</p>
+            </div>
+            <Link href="/pro/listing" className="inline-flex items-center gap-1 rounded-xl border border-[#DED6CF] px-3 py-2 text-xs font-semibold text-[#625B56] hover:border-[#BCAFA5]">Edit profile <ChevronRight className="h-3.5 w-3.5" /></Link>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {(tags.length ? tags : ["Add techniques"]).map((tag) => <span key={tag} className="rounded-full border border-[#E8DFD8] bg-[#FFFCF9] px-3 py-1 text-xs font-medium text-[#514B46]">{tag}</span>)}
+          </div>
+          <p className="mt-4 line-clamp-3 text-sm leading-6 text-[#59524D]">{bio || "Add a professional bio that explains your approach, specialties, experience, and what clients can expect from a session."}</p>
+          <div className="mt-5 grid gap-2 sm:grid-cols-3">
+            <MiniInfo icon={Star} label="Experience" value={experience ? `${experience}+ years` : "Add experience"} />
+            <MiniInfo icon={UserRoundCheck} label="Session Type" value={sessionType} />
+            <MiniInfo icon={Languages} label="Languages" value={language} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MiniInfo({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string }) {
+  return <div className="rounded-2xl border border-[#EFE8E2] bg-[#FFFCFA] px-3 py-3"><div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8B1E2D]"><Icon className="h-3.5 w-3.5" />{label}</div><p className="mt-1 truncate text-xs text-[#59524D]">{value}</p></div>;
+}
+
+function ProfileCompletionCard({ analysis, firstName }: { analysis: Analysis; firstName: string }) {
+  return (
+    <section className="mt-5 rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm sm:p-6">
+      <div className="grid items-center gap-6 lg:grid-cols-[150px_1fr]">
+        <div className="flex justify-center">
+          <div className="relative flex h-32 w-32 items-center justify-center rounded-full" style={{ background: `conic-gradient(#8B1E2D 0 ${analysis.scores.completion}%, #E8E1DB ${analysis.scores.completion}% 100%)` }}>
+            <div className="flex h-[104px] w-[104px] flex-col items-center justify-center rounded-full bg-white"><strong className="text-3xl">{analysis.scores.completion}%</strong><span className="text-xs text-[#817873]">Complete</span></div>
+          </div>
+        </div>
+        <div>
+          <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="text-lg font-semibold">Great progress, {firstName}!</h3><span className="rounded-full bg-[#FFF3E4] px-3 py-1 text-xs font-semibold text-[#8A5A18]">Top {Math.max(1, 100 - analysis.benchmark.percentile)}% in your market</span></div>
+          <p className="mt-2 text-sm leading-6 text-[#6D655F]">Your overall profile health is <strong className="text-[#8B1E2D]">{analysis.scores.overall}/100</strong>. Complete the highest-impact actions to improve trust, visibility, and contact readiness.</p>
+          <div className="mt-4 h-2.5 overflow-hidden rounded-full bg-[#EFE9E4]"><div className="h-full rounded-full bg-gradient-to-r from-[#8B1E2D] via-[#B43A48] to-[#D59B4C]" style={{ width: `${analysis.scores.overall}%` }} /></div>
+          <div className="mt-4 grid grid-cols-3 gap-2 text-center sm:grid-cols-6">
+            {Object.entries({ Content: analysis.scores.content, Trust: analysis.scores.trust, Visibility: analysis.scores.visibility, Conversion: analysis.scores.conversion, SEO: analysis.scores.seo, Photos: analysis.scores.photos }).map(([label, score]) => <div key={label} className="rounded-xl bg-[#FBF8F5] px-2 py-2"><p className="text-sm font-bold">{score}</p><p className="text-[10px] text-[#827A74]">{label}</p></div>)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MetricCard({ icon: Icon, label, note, value, accent = false }: { icon: LucideIcon; label: string; note: string; value: number; accent?: boolean }) {
+  return <div className="rounded-2xl border border-[#E9E2DC] bg-white p-4 shadow-sm"><div className="flex items-start justify-between"><div className={`flex h-9 w-9 items-center justify-center rounded-xl ${accent ? "bg-[#F9EDEE] text-[#8B1E2D]" : "bg-[#F6F2EE] text-[#5B5550]"}`}><Icon className="h-4 w-4" /></div><ArrowRight className="h-4 w-4 text-[#B8AEA7]" /></div><p className="mt-4 text-2xl font-semibold tracking-tight">{formatNumber(value)}</p><p className="mt-1 text-xs font-semibold text-[#4C4642]">{label}</p><p className="mt-0.5 text-[10px] text-[#8A817B]">{note}</p></div>;
+}
+
+function OverviewPanel({ analysis, profile }: { analysis: Analysis; profile: Profile }) {
+  const chartData = analysis.history.length ? analysis.history : [{ date: new Date().toISOString().slice(0, 10), overall: analysis.scores.overall, visibility: analysis.scores.visibility, trust: analysis.scores.trust, content: analysis.scores.content, conversion: analysis.scores.conversion }];
+  return (
+    <div className="grid gap-4 xl:grid-cols-[1.35fr_.85fr]">
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm">
+        <div className="flex items-center justify-between"><div><h3 className="font-semibold">Profile health trend</h3><p className="mt-1 text-xs text-[#827A74]">Daily score snapshots across your recent activity.</p></div><span className="rounded-full bg-[#F6F2EE] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-[#6A625C]">90 days</span></div>
+        <div className="mt-5 h-64 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={chartData} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
+              <defs><linearGradient id="coachScoreFill" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stopColor="#8B1E2D" stopOpacity={0.22} /><stop offset="100%" stopColor="#8B1E2D" stopOpacity={0} /></linearGradient></defs>
+              <CartesianGrid stroke="#F0EBE7" vertical={false} />
+              <XAxis dataKey="date" tickFormatter={displayDate} tick={{ fontSize: 10, fill: "#918780" }} tickLine={false} axisLine={false} minTickGap={24} />
+              <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "#918780" }} tickLine={false} axisLine={false} width={34} />
+              <Tooltip labelFormatter={(value) => displayDate(String(value))} contentStyle={{ borderRadius: 14, border: "1px solid #E9E2DC", fontSize: 12 }} />
+              <Area type="monotone" dataKey="overall" name="Profile score" stroke="#8B1E2D" strokeWidth={2.4} fill="url(#coachScoreFill)" activeDot={{ r: 4 }} />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+      <div className="space-y-4">
+        <InsightCard icon={TrendingUp} title="Ranking intelligence" value={analysis.ranking.current ? `#${analysis.ranking.current}` : "Collecting data"} copy={analysis.ranking.explanation} />
+        <InsightCard icon={Zap} title="7-day forecast" value={`${analysis.forecast.contactsLow}–${analysis.forecast.contactsHigh} contacts`} copy={`${analysis.forecast.confidence}% confidence estimate based on recent views and contact activity.`} />
+        <InsightCard icon={CircleDollarSign} title="Rate readiness" value={analysis.scores.conversion >= 75 ? "Strong" : "Needs attention"} copy={analysis.scores.conversion >= 75 ? "Your rates and conversion details are in good shape." : "Clear rates, durations, payment methods, and amenities can improve qualified contacts."} href="/pro/rates" />
+      </div>
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm xl:col-span-2">
+        <div className="flex items-center justify-between"><div><h3 className="font-semibold">Today&apos;s priorities</h3><p className="mt-1 text-xs text-[#827A74]">Ordered by likely profile impact, not guaranteed results.</p></div><Link href="/pro/listing" className="text-xs font-semibold text-[#8B1E2D]">Edit profile</Link></div>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {analysis.recommendations.slice(0, 4).map((item, index) => <Link key={item.key} href={item.href} className="group rounded-2xl border border-[#EEE7E1] bg-[#FFFDFC] p-4 transition hover:border-[#D7C7BA] hover:shadow-sm"><div className="flex items-start gap-3"><span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#F9EDEE] text-sm font-bold text-[#8B1E2D]">{index + 1}</span><div className="min-w-0 flex-1"><div className="flex items-start justify-between gap-2"><h4 className="text-sm font-semibold">{item.title}</h4><span className={`shrink-0 rounded-full px-2 py-1 text-[9px] font-bold uppercase ${impactStyle[item.impact]}`}>{item.impact}</span></div><p className="mt-1 text-xs leading-5 text-[#756D67]">{item.action}</p><p className="mt-2 text-[10px] font-semibold text-[#8B1E2D]">Directional lift +{item.estimatedLift}%</p></div><ChevronRight className="mt-1 h-4 w-4 text-[#B7AEA8] transition group-hover:translate-x-0.5" /></div></Link>)}
+        </div>
+      </section>
+      {profile.subscription_tier !== "elite" && <div className="rounded-3xl border border-[#E8D8C8] bg-[#FFF9F1] p-5 xl:col-span-2"><div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"><div><p className="text-sm font-semibold text-[#6A442A]">AI Coach works with every plan</p><p className="mt-1 text-xs text-[#7B685B]">Some advanced automation and visibility tools may depend on your subscription tier.</p></div><Link href="/pro/subscription" className="inline-flex items-center justify-center gap-2 rounded-xl bg-white px-4 py-2.5 text-xs font-semibold text-[#8B1E2D] shadow-sm">View subscription <ArrowRight className="h-3.5 w-3.5" /></Link></div></div>}
+    </div>
+  );
+}
+
+function InsightCard({ icon: Icon, title, value, copy, href }: { icon: LucideIcon; title: string; value: string; copy: string; href?: string }) {
+  const body = <div className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.1em] text-[#8B1E2D]"><Icon className="h-4 w-4" />{title}</div><p className="mt-3 text-xl font-semibold">{value}</p><p className="mt-2 text-xs leading-5 text-[#756D67]">{copy}</p></div>;
+  return href ? <Link href={href}>{body}</Link> : body;
+}
+
+function PhotoPanel({ photos, scores, busy, onAnalyze }: { photos: Photo[]; scores: PhotoScore[]; busy: boolean; onAnalyze: () => void }) {
+  const byPhoto = new Map(scores.map((score) => [score.photo_id, score]));
+  return (
+    <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm">
+      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">AI Photo Quality Lab</h3><p className="mt-1 text-xs text-[#827A74]">Scores pose, lighting, approachability, composition, background, sharpness, and professionalism.</p></div><button type="button" onClick={onAnalyze} disabled={busy || photos.length === 0} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Camera className="h-4 w-4" />} Analyze gallery</button></div>
+      {photos.length === 0 ? <EmptyState icon={ImageIcon} title="No photos to analyze" copy="Upload profile and gallery photos first." href="/pro/photos" action="Manage photos" /> : <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">{photos.map((photo, index) => {
+        const score = byPhoto.get(photo.id);
+        return <article key={photo.id} className="overflow-hidden rounded-2xl border border-[#EAE2DC] bg-[#FFFCFA]"><div className="relative aspect-[4/3] bg-[#EEE8E3]">{photo.url ? <img src={photo.url} alt={`Profile gallery photo ${index + 1}`} className="h-full w-full object-cover" /> : <div className="flex h-full items-center justify-center"><ImageIcon className="h-8 w-8 text-[#A99F98]" /></div>}{photo.is_primary && <span className="absolute left-3 top-3 rounded-full bg-white/95 px-2.5 py-1 text-[10px] font-bold text-[#8B1E2D] shadow">Primary</span>}{score && <span className="absolute bottom-3 right-3 flex h-12 w-12 items-center justify-center rounded-full border-4 border-white bg-[#8B1E2D] text-sm font-bold text-white shadow-lg">{score.overall_score}</span>}</div><div className="p-4">{score ? <><div className="flex items-center justify-between"><p className="text-sm font-semibold">Photo {index + 1}</p><span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#817873]">{score.analysis_mode === "vision" ? "AI Vision" : "Baseline"}</span></div><div className="mt-3 grid grid-cols-2 gap-2 text-[11px]">{[["Lighting", score.lighting_score], ["Pose", score.pose_score], ["Smile", score.smile_score], ["Professional", score.professionalism_score]].map(([label, value]) => <div key={String(label)} className="rounded-xl bg-white px-3 py-2"><span className="text-[#817873]">{label}</span><strong className="float-right">{value}</strong></div>)}</div><p className="mt-3 text-xs leading-5 text-[#6D655F]">{score.recommendation}</p><p className="mt-2 text-[10px] font-semibold text-[#8B1E2D]">Estimated CTR direction: +{score.predicted_ctr_lift_pct}%</p></> : <><p className="text-sm font-semibold">Photo {index + 1}</p><p className="mt-2 text-xs text-[#817873]">Run the AI analysis to score presentation quality.</p></>}</div></article>;
+      })}</div>}
+      <p className="mt-5 rounded-2xl bg-[#F8F4F0] px-4 py-3 text-[11px] leading-5 text-[#756D67]">Photo scoring evaluates photographic presentation only. It does not infer identity, protected traits, health, personality, or suitability. Scores and CTR lift are directional guidance, not guarantees.</p>
+    </section>
+  );
+}
+
+function WriterPanel({ profile, drafts, optimization, busy, onRewrite, onPreview, onApply }: { profile: Profile; drafts: Draft[]; optimization: Optimization | null; busy: string | null; onRewrite: (field: "headline" | "tagline" | "bio" | "seo_title" | "seo_description") => void; onPreview: () => void; onApply: () => void }) {
+  const current: Record<string, string | null> = { headline: profile.headline, tagline: profile.tagline, bio: profile.bio, seo_title: null, seo_description: null };
+  return (
+    <div className="space-y-4">
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">AI Copywriter</h3><p className="mt-1 text-xs text-[#827A74]">DeepSeek is used first when configured, with OpenAI and Gemini fallbacks.</p></div><button type="button" onClick={onPreview} disabled={busy !== null} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy === "optimize" ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />} Preview full optimization</button></div><div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">{(["headline", "tagline", "bio", "seo_title", "seo_description"] as const).map((field) => <button key={field} type="button" onClick={() => onRewrite(field)} disabled={busy !== null} className="rounded-2xl border border-[#EAE2DC] bg-[#FFFCFA] p-4 text-left transition hover:border-[#CDBCAF] disabled:opacity-50"><div className="flex items-center justify-between"><Sparkles className="h-4 w-4 text-[#8B1E2D]" />{busy === `rewrite-${field}` && <Loader2 className="h-4 w-4 animate-spin text-[#8B1E2D]" />}</div><p className="mt-3 text-sm font-semibold">Rewrite {fieldLabels[field]}</p><p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[#817873]">{current[field] || "Generate a polished, factual suggestion."}</p></button>)}</div></section>
+      {optimization && <section className="rounded-3xl border border-[#DDBFC3] bg-[#FFF8F8] p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold text-[#6F1723]">One-click optimization preview</h3><p className="mt-1 text-xs text-[#7C6265]">Nothing changes until you approve and apply this preview.</p></div><button type="button" onClick={onApply} disabled={busy !== null} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy === "apply" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />} Apply approved changes</button></div><div className="mt-4 grid gap-3 lg:grid-cols-2">{Object.entries(optimization.after_state).filter(([key]) => key !== "seo_keywords").map(([key, value]) => <div key={key} className="rounded-2xl border border-[#EAD7D9] bg-white p-4"><p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">{fieldLabels[key] ?? key}</p><p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-[#5F5554]">{String(value ?? "")}</p></div>)}</div>{optimization.rationale && <p className="mt-4 text-xs leading-5 text-[#755E60]">{optimization.rationale}</p>}</section>}
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="font-semibold">Recent suggestions</h3>{drafts.length ? <div className="mt-4 space-y-3">{drafts.slice(0, 8).map((draft) => <article key={draft.id} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-xs font-bold uppercase tracking-[0.1em] text-[#8B1E2D]">{fieldLabels[draft.field] ?? draft.field}</p><span className="text-[10px] text-[#8A817B]">{draft.provider ?? "deterministic"} · {draft.model ?? "fallback"}</span></div><p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#4E4844]">{draft.suggested_text}</p>{draft.rationale && <p className="mt-2 text-xs text-[#817873]">{draft.rationale}</p>}</article>)}</div> : <EmptyState icon={Sparkles} title="No AI drafts yet" copy="Choose a field above to generate your first suggestion." />}</section>
+    </div>
+  );
+}
+
+function MarketPanel({ analysis, city, state }: { analysis: Analysis; city: string | null; state: string | null }) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2"><MapPin className="h-5 w-5 text-[#8B1E2D]" /><div><h3 className="font-semibold">{[city, state].filter(Boolean).join(", ") || "Local market"}</h3><p className="text-xs text-[#827A74]">Dynamic market intelligence</p></div></div><div className="mt-5 grid grid-cols-2 gap-3"><MarketMetric label="Demand" value={analysis.market.demandScore ?? "—"} note={analysis.market.demandTrend} /><MarketMetric label="Competition" value={analysis.market.competitionIndex ?? "—"} note="index" /><MarketMetric label="Search volume" value={analysis.market.searchVolumeIndex ?? "—"} note="index" /><MarketMetric label="Profiles compared" value={analysis.benchmark.cityProfileCount} note="up to 100" /></div></section>
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="font-semibold">Competitor benchmark</h3><p className="mt-1 text-xs text-[#827A74]">Anonymized comparison against active profiles in the same city.</p><div className="mt-5 space-y-4">{[["Your score", analysis.scores.overall], ["City average", analysis.benchmark.cityAverageScore], ["Top 10 average", analysis.benchmark.top10AverageScore]].map(([label, value]) => <div key={String(label)}><div className="mb-1.5 flex justify-between text-xs"><span className="text-[#675F5A]">{label}</span><strong>{value}</strong></div><div className="h-2 overflow-hidden rounded-full bg-[#F0EAE5]"><div className={`h-full rounded-full ${label === "Your score" ? "bg-[#8B1E2D]" : "bg-[#BFB3AA]"}`} style={{ width: `${Math.min(100, Number(value))}%` }} /></div></div>)}</div><p className="mt-5 rounded-2xl bg-[#F8F4F0] px-4 py-3 text-xs leading-5 text-[#6F6761]">You rank around the <strong>{analysis.benchmark.percentile}th percentile</strong>. You need approximately <strong>{analysis.benchmark.pointsToTop10} points</strong> to reach the current top-10 average.</p></section>
+      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm lg:col-span-2"><h3 className="font-semibold">Trending local keywords</h3>{analysis.market.topKeywords.length ? <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{analysis.market.topKeywords.map((keyword, index) => <div key={keyword.keyword} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex items-center justify-between"><span className="flex h-7 w-7 items-center justify-center rounded-full bg-[#F9EDEE] text-xs font-bold text-[#8B1E2D]">{index + 1}</span><span className="text-[10px] font-semibold uppercase text-[#6D765E]">{keyword.trend}</span></div><p className="mt-3 text-sm font-semibold">{keyword.keyword}</p><p className="mt-1 text-xs text-[#817873]">Opportunity score {keyword.score}</p></div>)}</div> : <EmptyState icon={Search} title="No keyword trend data yet" copy="Local search trends will appear as market activity is collected." />}</section>
+    </div>
+  );
+}
+
+function MarketMetric({ label, value, note }: { label: string; value: string | number; note: string }) {
+  return <div className="rounded-2xl bg-[#F9F5F1] p-4"><p className="text-[10px] font-bold uppercase tracking-[0.1em] text-[#817873]">{label}</p><p className="mt-2 text-2xl font-semibold">{value}</p><p className="mt-1 text-xs capitalize text-[#8A817B]">{note}</p></div>;
+}
+
+function ReportsPanel({ reports, busy, onGenerate }: { reports: Report[]; busy: string | null; onGenerate: (period: "weekly" | "monthly") => void }) {
+  return (
+    <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">Executive performance reports</h3><p className="mt-1 text-xs text-[#827A74]">Narrative summaries grounded in profile analytics and estimates.</p></div><div className="flex gap-2"><button type="button" onClick={() => onGenerate("weekly")} disabled={busy !== null} className="rounded-xl border border-[#DAD1CA] px-3 py-2 text-xs font-semibold disabled:opacity-50">{busy === "report-weekly" ? "Generating…" : "Weekly report"}</button><button type="button" onClick={() => onGenerate("monthly")} disabled={busy !== null} className="rounded-xl bg-[#8B1E2D] px-3 py-2 text-xs font-semibold text-white disabled:opacity-50">{busy === "report-monthly" ? "Generating…" : "Monthly report"}</button></div></div>{reports.length ? <div className="mt-5 space-y-3">{reports.map((report) => <article key={report.id} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-xs font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">{report.period_type} report</p><span className="text-[10px] text-[#8A817B]">{report.period_start} – {report.period_end}</span></div><p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#514B46]">{report.narrative || "Report generated without a narrative."}</p></article>)}</div> : <EmptyState icon={BarChart3} title="No reports generated" copy="Create a weekly or monthly executive summary." />}</section>
+  );
+}
+
+function TrustSignals({ profile }: { profile: Profile }) {
+  const signals = [
+    { label: "ID Verified", complete: Boolean(profile.is_verified_identity) },
+    { label: "Phone Verified", complete: Boolean(profile.is_verified_phone) },
+    { label: "Email Verified", complete: Boolean(profile.is_verified_email) },
+    { label: "Photos Verified", complete: Boolean(profile.is_verified_photos) },
+  ];
+  return <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-[#8B1E2D]" /><div><h3 className="font-semibold">Trust Signals</h3><p className="text-xs text-[#827A74]">Build confidence with visible, verified profile details.</p></div></div><div className="mt-4 flex flex-wrap gap-2">{signals.map((signal) => <span key={signal.label} className={`inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-semibold ${signal.complete ? "bg-[#EDF7EF] text-[#347348]" : "bg-[#F7F2EE] text-[#756D67]"}`}>{signal.complete ? <Check className="h-3.5 w-3.5" /> : <X className="h-3.5 w-3.5" />}{signal.label}</span>)}</div></section>;
+}
+
+function CoachPanel({ firstName, analysis, busy, chatMessage, chatAnswer, onClose, onMessageChange, onSend, onRecommendation }: { firstName: string; analysis: Analysis; busy: string | null; chatMessage: string; chatAnswer: string | null; onClose: () => void; onMessageChange: (value: string) => void; onSend: () => void; onRecommendation: (recommendation: Recommendation) => void }) {
+  return (
+    <aside className="sticky top-0 hidden h-dvh overflow-y-auto bg-[#FBFAF8] px-4 py-5 2xl:block">
+      <div className="rounded-3xl border border-[#E6DED7] bg-white p-4 shadow-[0_18px_50px_rgba(61,43,33,0.06)]">
+        <div className="flex items-start justify-between"><div><div className="flex items-center gap-2"><Sparkles className="h-5 w-5 text-[#8B1E2D]" /><h2 className="text-lg font-semibold">AI Profile Coach</h2><span className="rounded-full bg-[#F9EDEE] px-2 py-0.5 text-[9px] font-bold uppercase text-[#8B1E2D]">Beta</span></div><p className="mt-1 text-xs text-[#827A74]">Personalized profile optimization assistant.</p></div><button type="button" onClick={onClose} aria-label="Close AI coach" className="rounded-lg p-1.5 text-[#817873] hover:bg-[#F5F0EC]"><X className="h-4 w-4" /></button></div>
+        <div className="mt-4 rounded-2xl bg-gradient-to-br from-[#FFF8F2] to-[#FFF5F6] p-4"><p className="text-sm leading-6 text-[#504844]">Hi {firstName}! I reviewed your profile, market signals, and recent activity. Your score is <strong>{analysis.scores.overall}/100</strong>. Let&apos;s work through the highest-impact improvements.</p></div>
+        <div className="mt-5 flex items-center justify-between"><h3 className="text-sm font-semibold">Your Action Plan</h3><span className="text-[10px] text-[#8A817B]">{analysis.recommendations.length} suggestions</span></div>
+        <div className="mt-3 space-y-2.5">{analysis.recommendations.slice(0, 6).map((item) => <button key={item.key} type="button" onClick={() => onRecommendation(item)} className="group flex w-full items-start gap-3 rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-3 text-left transition hover:border-[#CFBFB4]"><div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F9EDEE] text-[#8B1E2D]"><Zap className="h-4 w-4" /></div><div className="min-w-0 flex-1"><div className="flex items-start justify-between gap-2"><p className="text-xs font-semibold">{item.title}</p><span className={`shrink-0 rounded-full px-2 py-0.5 text-[8px] font-bold uppercase ${impactStyle[item.impact]}`}>{item.impact}</span></div><p className="mt-1 text-[10px] leading-4 text-[#817873]">{item.action}</p></div><ChevronRight className="mt-1 h-4 w-4 text-[#B8AEA7] transition group-hover:translate-x-0.5" /></button>)}</div>
+        {chatAnswer && <div className="mt-4 rounded-2xl border border-[#E4D8D0] bg-[#FFF9F4] p-4 text-xs leading-5 text-[#5C524D]">{chatAnswer}</div>}
+        <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[#E4DCD5] bg-white p-2 shadow-inner"><input value={chatMessage} onChange={(event) => onMessageChange(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); onSend(); } }} placeholder="Ask your AI coach anything…" className="min-w-0 flex-1 bg-transparent px-2 py-2 text-xs outline-none placeholder:text-[#A69D96]" /><button type="button" onClick={onSend} disabled={busy !== null || !chatMessage.trim()} aria-label="Send message" className="flex h-9 w-9 items-center justify-center rounded-full bg-[#8B1E2D] text-white disabled:opacity-40">{busy === "chat" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</button></div>
+        <p className="mt-2 text-center text-[9px] leading-4 text-[#9B928B]">AI recommendations and forecasts are estimates. Review changes before applying them.</p>
+      </div>
+    </aside>
+  );
+}
+
+function EmptyState({ icon: Icon, title, copy, href, action }: { icon: LucideIcon; title: string; copy: string; href?: string; action?: string }) {
+  return <div className="mt-5 flex min-h-44 flex-col items-center justify-center rounded-2xl border border-dashed border-[#DCD2CA] bg-[#FCF9F6] p-6 text-center"><Icon className="h-8 w-8 text-[#B1A69E]" /><p className="mt-3 text-sm font-semibold">{title}</p><p className="mt-1 max-w-sm text-xs leading-5 text-[#817873]">{copy}</p>{href && action && <Link href={href} className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-[#8B1E2D]">{action}<ArrowRight className="h-3.5 w-3.5" /></Link>}</div>;
+}

--- a/src/components/pro/ai-coach/AiCoachDashboard.tsx
+++ b/src/components/pro/ai-coach/AiCoachDashboard.tsx
@@ -4,15 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
-  Area,
-  AreaChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-import {
   ArrowRight,
   BadgeCheck,
   BarChart3,
@@ -20,7 +11,6 @@ import {
   Camera,
   Check,
   ChevronRight,
-  CircleDollarSign,
   Eye,
   Gauge,
   Heart,
@@ -49,6 +39,7 @@ import { BRAND_ASSETS } from "@/lib/brand";
 
 type Impact = "high" | "medium" | "low";
 type TabKey = "overview" | "photos" | "writer" | "market" | "reports";
+type RewriteField = "headline" | "tagline" | "bio" | "seo_title" | "seo_description";
 
 type Recommendation = {
   key: string;
@@ -77,6 +68,8 @@ type PhotoScore = {
   improvements: string[];
   recommendation: string;
   analysis_mode: "vision" | "metadata";
+  provider: string | null;
+  model: string | null;
 };
 
 type Profile = {
@@ -101,7 +94,11 @@ type Profile = {
   is_verified_phone: boolean | null;
   is_verified_email: boolean | null;
   is_verified_identity: boolean | null;
+  is_verified_profile: boolean | null;
   is_verified_photos: boolean | null;
+  seo_title: string | null;
+  seo_description: string | null;
+  seo_keywords: string[] | null;
   subscription_tier: string | null;
 };
 
@@ -214,7 +211,7 @@ type CoachResponse = {
   latestOptimization: Optimization | null;
 };
 
-const tabs: Array<{ key: TabKey; label: string; icon: LucideIcon }> = [
+const TABS: Array<{ key: TabKey; label: string; icon: LucideIcon }> = [
   { key: "overview", label: "Overview", icon: Gauge },
   { key: "photos", label: "Photo AI", icon: Camera },
   { key: "writer", label: "AI Writer", icon: WandSparkles },
@@ -222,35 +219,35 @@ const tabs: Array<{ key: TabKey; label: string; icon: LucideIcon }> = [
   { key: "reports", label: "Reports", icon: BellRing },
 ];
 
-const promoFeatures = [
-  { icon: Sparkles, title: "Smart Suggestions", copy: "Personalized actions based on your real profile data." },
-  { icon: Target, title: "Profile Completion Score", copy: "Track the fields that influence trust and visibility." },
-  { icon: ShieldCheck, title: "Trust & Credibility", copy: "See which verification signals still need attention." },
-  { icon: Eye, title: "More Visibility", copy: "Understand ranking movement and local opportunities." },
-  { icon: Search, title: "Better SEO", copy: "Improve local keywords, headline, bio, and metadata." },
-];
-
-const impactStyle: Record<Impact, string> = {
-  high: "bg-[#F9EDEE] text-[#8B1E2D]",
-  medium: "bg-[#FFF6E7] text-[#9A6415]",
-  low: "bg-[#EEF7F0] text-[#277A43]",
-};
-
-const fieldLabels: Record<string, string> = {
+const FIELD_LABELS: Record<string, string> = {
   headline: "Headline",
   tagline: "Tagline",
   bio: "Bio",
   seo_title: "SEO title",
   seo_description: "Meta description",
+  seo_keywords: "SEO keywords",
 };
+
+const IMPACT_CLASS: Record<Impact, string> = {
+  high: "bg-[#F9EDEE] text-[#8B1E2D]",
+  medium: "bg-[#FFF4E5] text-[#986116]",
+  low: "bg-[#EEF7F0] text-[#287644]",
+};
+
+const PROMO_ITEMS = [
+  { icon: Sparkles, title: "Smart Suggestions", copy: "Personalized actions grounded in your profile." },
+  { icon: Target, title: "Profile Health", copy: "Track completion, trust, SEO, and conversion." },
+  { icon: ShieldCheck, title: "Trust & Credibility", copy: "See the verification signals that matter." },
+  { icon: Eye, title: "More Visibility", copy: "Understand ranking movement and local demand." },
+  { icon: Search, title: "Better SEO", copy: "Improve copy and keyword relevance with AI." },
+];
 
 function formatNumber(value: number) {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
 }
 
-function displayDate(value: string) {
-  const date = new Date(`${value}T00:00:00Z`);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+function profileName(profile: Profile) {
+  return profile.display_name || profile.full_name || "Provider";
 }
 
 export function AiCoachDashboard() {
@@ -259,10 +256,10 @@ export function AiCoachDashboard() {
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabKey>("overview");
+  const [tab, setTab] = useState<TabKey>("overview");
   const [coachOpen, setCoachOpen] = useState(true);
-  const [chatMessage, setChatMessage] = useState("");
-  const [chatAnswer, setChatAnswer] = useState<string | null>(null);
+  const [chat, setChat] = useState("");
+  const [answer, setAnswer] = useState<string | null>(null);
   const [optimization, setOptimization] = useState<Optimization | null>(null);
 
   const load = useCallback(async () => {
@@ -272,8 +269,8 @@ export function AiCoachDashboard() {
       const response = await requestJson<CoachResponse>("/api/pro/ai-coach");
       setData(response);
       setOptimization(response.latestOptimization?.status === "preview" ? response.latestOptimization : null);
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : "Unable to load your AI Profile Coach.");
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Unable to load the AI Profile Coach.");
     } finally {
       setLoading(false);
     }
@@ -283,14 +280,17 @@ export function AiCoachDashboard() {
     void load();
   }, [load]);
 
-  const perform = useCallback(async <T,>(key: string, body: Record<string, unknown>) => {
+  const run = useCallback(async <T,>(key: string, body: Record<string, unknown>) => {
     setBusy(key);
     setError(null);
     setNotice(null);
     try {
-      return await requestJson<T>("/api/pro/ai-coach", { method: "POST", body: JSON.stringify(body) });
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : "The requested AI action failed.");
+      return await requestJson<T>("/api/pro/ai-coach", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : "The requested action failed.");
       return null;
     } finally {
       setBusy(null);
@@ -298,76 +298,83 @@ export function AiCoachDashboard() {
   }, []);
 
   const refresh = useCallback(async () => {
-    const response = await perform<CoachResponse>("refresh", { action: "refresh" });
-    if (response) {
-      setData(response);
-      setNotice("Your profile analysis was refreshed.");
-    }
-  }, [perform]);
+    const response = await run<CoachResponse>("refresh", { action: "refresh" });
+    if (!response) return;
+    setData(response);
+    setNotice("Your profile analysis was refreshed.");
+  }, [run]);
+
+  const rewrite = useCallback(async (field: RewriteField) => {
+    const response = await run<{ ok: boolean; draft: Draft }>(`rewrite-${field}`, { action: "rewrite", field });
+    if (!response || !data) return;
+    setData({
+      ...data,
+      latestDrafts: [response.draft, ...data.latestDrafts.filter((draft) => draft.id !== response.draft.id)],
+    });
+    setTab("writer");
+    setNotice(`${FIELD_LABELS[field]} suggestion created.`);
+  }, [data, run]);
 
   const analyzePhotos = useCallback(async () => {
-    const response = await perform<{ ok: boolean; photoScores: PhotoScore[] }>("photos", { action: "analyze-photos" });
-    if (response && data) {
-      setData({ ...data, analysis: { ...data.analysis, photoScores: response.photoScores } });
-      setNotice("Photo scoring completed. Vision is used when configured; otherwise a safe metadata baseline is shown.");
-      setActiveTab("photos");
-    }
-  }, [data, perform]);
-
-  const rewrite = useCallback(async (field: "headline" | "tagline" | "bio" | "seo_title" | "seo_description") => {
-    const response = await perform<{ ok: boolean; draft: Draft }>(`rewrite-${field}`, { action: "rewrite", field });
-    if (response && data) {
-      setData({ ...data, latestDrafts: [response.draft, ...data.latestDrafts.filter((item) => item.id !== response.draft.id)] });
-      setNotice(`${fieldLabels[field]} suggestion created with ${response.draft.provider ?? "the available analysis engine"}.`);
-      setActiveTab("writer");
-    }
-  }, [data, perform]);
+    const response = await run<{ ok: boolean; photoScores: PhotoScore[] }>("photos", { action: "analyze-photos" });
+    if (!response || !data) return;
+    setData({ ...data, analysis: { ...data.analysis, photoScores: response.photoScores } });
+    setTab("photos");
+    setNotice("Photo presentation analysis completed.");
+  }, [data, run]);
 
   const previewOptimization = useCallback(async () => {
-    const response = await perform<{ ok: boolean; optimization: Optimization }>("optimize", { action: "optimize-preview" });
-    if (response) {
-      setOptimization(response.optimization);
-      setNotice("Your full optimization preview is ready. Review every change before applying it.");
-      setActiveTab("writer");
-    }
-  }, [perform]);
+    const response = await run<{ ok: boolean; optimization: Optimization }>("optimize", { action: "optimize-preview" });
+    if (!response) return;
+    setOptimization(response.optimization);
+    setTab("writer");
+    setNotice("Optimization preview ready. Review every field before applying.");
+  }, [run]);
 
   const applyOptimization = useCallback(async () => {
     if (!optimization) return;
-    const fields = Object.keys(optimization.after_state).filter((field) => ["headline", "tagline", "bio", "seo_title", "seo_description", "seo_keywords"].includes(field));
-    const response = await perform<{ ok: boolean; appliedFields: string[] }>("apply", { action: "apply-optimization", runId: optimization.id, fields });
-    if (response) {
-      setNotice(`Applied ${response.appliedFields.length} approved profile improvements.`);
-      setOptimization(null);
-      await load();
-    }
-  }, [load, optimization, perform]);
+    const allowed = ["headline", "tagline", "bio", "seo_title", "seo_description", "seo_keywords"];
+    const fields = Object.keys(optimization.after_state).filter((field) => allowed.includes(field));
+    const response = await run<{ ok: boolean; appliedFields: string[] }>("apply", {
+      action: "apply-optimization",
+      runId: optimization.id,
+      fields,
+    });
+    if (!response) return;
+    setOptimization(null);
+    setNotice(`Applied ${response.appliedFields.length} approved improvements.`);
+    await load();
+  }, [load, optimization, run]);
 
   const generateReport = useCallback(async (period: "weekly" | "monthly") => {
-    const response = await perform<{ ok: boolean; report: Report }>(`report-${period}`, { action: "generate-report", period });
-    if (response && data) {
-      setData({ ...data, latestReports: [response.report, ...data.latestReports.filter((item) => item.id !== response.report.id)] });
-      setNotice(`${period === "weekly" ? "Weekly" : "Monthly"} executive report generated.`);
-      setActiveTab("reports");
-    }
-  }, [data, perform]);
+    const response = await run<{ ok: boolean; report: Report }>(`report-${period}`, {
+      action: "generate-report",
+      period,
+    });
+    if (!response || !data) return;
+    setData({
+      ...data,
+      latestReports: [response.report, ...data.latestReports.filter((report) => report.id !== response.report.id)],
+    });
+    setTab("reports");
+    setNotice(`${period === "weekly" ? "Weekly" : "Monthly"} report generated.`);
+  }, [data, run]);
 
-  const sendChat = useCallback(async () => {
-    const message = chatMessage.trim();
+  const askCoach = useCallback(async () => {
+    const message = chat.trim();
     if (!message) return;
-    const response = await perform<{ ok: boolean; answer: string }>("chat", { action: "chat", message });
-    if (response) {
-      setChatAnswer(response.answer);
-      setChatMessage("");
-    }
-  }, [chatMessage, perform]);
+    const response = await run<{ ok: boolean; answer: string }>("chat", { action: "chat", message });
+    if (!response) return;
+    setAnswer(response.answer);
+    setChat("");
+  }, [chat, run]);
 
   if (loading) {
     return (
-      <div className="flex min-h-[calc(100dvh-3.5rem)] items-center justify-center bg-[#FBFAF8] md:min-h-dvh">
+      <div className="flex min-h-dvh items-center justify-center bg-[#FBFAF8]">
         <div className="text-center">
           <Loader2 className="mx-auto h-7 w-7 animate-spin text-[#8B1E2D]" />
-          <p className="mt-3 text-sm text-[#6E6864]">Analyzing profile, visibility, and growth signals…</p>
+          <p className="mt-3 text-sm text-[#716963]">Analyzing profile and market signals…</p>
         </div>
       </div>
     );
@@ -378,8 +385,8 @@ export function AiCoachDashboard() {
       <div className="flex min-h-[70vh] items-center justify-center bg-[#FBFAF8] p-6">
         <div className="max-w-md rounded-3xl border border-[#E8E1DB] bg-white p-8 text-center shadow-sm">
           <Sparkles className="mx-auto h-9 w-9 text-[#8B1E2D]" />
-          <h1 className="mt-4 text-2xl font-semibold text-[#171513]">AI Profile Coach unavailable</h1>
-          <p className="mt-2 text-sm text-[#6E6864]">{error ?? "We could not load your provider profile."}</p>
+          <h1 className="mt-4 text-2xl font-semibold">AI Profile Coach unavailable</h1>
+          <p className="mt-2 text-sm text-[#716963]">{error || "Your provider profile could not be loaded."}</p>
           <button type="button" onClick={() => void load()} className="mt-6 rounded-full bg-[#8B1E2D] px-5 py-2.5 text-sm font-semibold text-white">
             Try again
           </button>
@@ -388,92 +395,69 @@ export function AiCoachDashboard() {
     );
   }
 
-  const { profile, analysis } = data;
-  const displayName = profile.display_name || profile.full_name || "Provider";
-  const firstName = displayName.split(" ")[0];
-  const profilePhoto = profile.photo_url || profile.avatar_url || data.photos.find((photo) => photo.is_primary)?.url || null;
-  const techniqueTags = [...new Set([...(profile.massage_techniques ?? []), ...(profile.modalities ?? []), ...(profile.specialties ?? [])])].slice(0, 5);
-  const language = [...new Set([...(profile.languages ?? []), ...(profile.languages_spoken ?? [])])][0] || "Add language";
+  const profile = data.profile;
+  const analysis = data.analysis;
+  const name = profileName(profile);
+  const firstName = name.split(" ")[0];
+  const primaryPhoto = profile.photo_url || profile.avatar_url || data.photos.find((photo) => photo.is_primary)?.url || null;
+  const tags = [...new Set([...(profile.massage_techniques || []), ...(profile.modalities || []), ...(profile.specialties || [])])].slice(0, 5);
+  const language = [...new Set([...(profile.languages || []), ...(profile.languages_spoken || [])])][0] || "Add language";
   const sessionType = [profile.offers_incall ? "Incall" : null, profile.offers_outcall ? "Outcall" : null].filter(Boolean).join(" & ") || "Add service type";
+  const verified = Boolean(profile.is_verified_identity || profile.is_verified_profile);
 
   return (
     <div className="min-h-full bg-[#FBFAF8] text-[#171513]">
-      <div className="mx-auto grid min-h-full max-w-[1900px] grid-cols-1 2xl:grid-cols-[292px_minmax(620px,1fr)_370px]">
-        <PromoBanner />
+      <div className="mx-auto grid min-h-full max-w-[1920px] grid-cols-1 2xl:grid-cols-[292px_minmax(620px,1fr)_370px]">
+        <PromotionalBanner />
 
         <main className="min-w-0 border-x border-[#ECE5DF] bg-[#FFFEFC] px-4 py-5 sm:px-6 lg:px-8">
-          <div className="mb-5 flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
-            <div>
-              <div className="flex items-center gap-2 text-sm text-[#6E6864]">
-                <Sparkles className="h-4 w-4 text-[#A56B24]" />
-                AI Profile Coach
-                <span className="rounded-full bg-[#F9EDEE] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[#8B1E2D]">Beta</span>
-              </div>
-              <h1 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">My Profile</h1>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <button type="button" onClick={() => void refresh()} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl border border-[#DED6CF] bg-white px-4 py-2.5 text-sm font-semibold text-[#4D4844] shadow-sm transition hover:border-[#BCAFA5] disabled:opacity-50">
-                <RefreshCw className={`h-4 w-4 ${busy === "refresh" ? "animate-spin" : ""}`} />
-                Refresh analysis
-              </button>
-              <button type="button" onClick={() => void previewOptimization()} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(139,30,45,0.18)] transition hover:bg-[#741723] disabled:opacity-50">
-                {busy === "optimize" ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
-                Optimize with AI
-              </button>
-            </div>
-          </div>
-
-          {(error || notice) && (
-            <div className={`mb-5 flex items-start justify-between gap-3 rounded-2xl border px-4 py-3 text-sm ${error ? "border-red-200 bg-red-50 text-red-800" : "border-emerald-200 bg-emerald-50 text-emerald-800"}`}>
-              <span>{error ?? notice}</span>
-              <button type="button" onClick={() => { setError(null); setNotice(null); }} aria-label="Dismiss message"><X className="h-4 w-4" /></button>
-            </div>
-          )}
-
+          <Header busy={busy} onRefresh={() => void refresh()} onOptimize={() => void previewOptimization()} />
+          <Feedback error={error} notice={notice} onClose={() => { setError(null); setNotice(null); }} />
           <ProfileHero
-            displayName={displayName}
-            profilePhoto={profilePhoto}
-            city={profile.city}
-            state={profile.state}
-            tags={techniqueTags}
-            bio={profile.bio}
-            experience={profile.years_experience}
-            sessionType={sessionType}
+            profile={profile}
+            name={name}
+            photo={primaryPhoto}
+            tags={tags}
             language={language}
-            verified={Boolean(profile.is_verified_identity || profile.is_verified_profile)}
+            sessionType={sessionType}
+            verified={verified}
           />
+          <CompletionCard analysis={analysis} firstName={firstName} />
+          <Metrics analysis={analysis} />
 
-          <ProfileCompletionCard analysis={analysis} firstName={firstName} />
-
-          <div className="mt-5 grid grid-cols-2 gap-3 xl:grid-cols-4">
-            <MetricCard icon={Eye} label="Profile Views" note="Last 30 days" value={analysis.metrics.views30d} />
-            <MetricCard icon={Heart} label="Favorites" note="Last 7 days" value={analysis.metrics.favorites7d} accent />
-            <MetricCard icon={MessageCircle} label="Contact Taps" note="Last 30 days" value={analysis.metrics.contacts30d} />
-            <MetricCard icon={TrendingUp} label="Predicted Contacts" note="Next 7 days · estimate" value={analysis.forecast.contactsLikely} />
-          </div>
-
-          <div className="mt-5 flex gap-2 overflow-x-auto border-b border-[#E9E2DC] pb-0">
-            {tabs.map((tab) => {
-              const active = activeTab === tab.key;
-              return (
-                <button key={tab.key} type="button" onClick={() => setActiveTab(tab.key)} className={`flex shrink-0 items-center gap-2 border-b-2 px-3 py-3 text-sm font-semibold transition ${active ? "border-[#8B1E2D] text-[#8B1E2D]" : "border-transparent text-[#756E69] hover:text-[#282421]"}`}>
-                  <tab.icon className="h-4 w-4" />
-                  {tab.label}
-                </button>
-              );
-            })}
+          <div className="mt-5 flex gap-2 overflow-x-auto border-b border-[#E9E2DC]">
+            {TABS.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => setTab(item.key)}
+                className={`flex shrink-0 items-center gap-2 border-b-2 px-3 py-3 text-sm font-semibold transition ${tab === item.key ? "border-[#8B1E2D] text-[#8B1E2D]" : "border-transparent text-[#766E68] hover:text-[#27221F]"}`}
+              >
+                <item.icon className="h-4 w-4" />
+                {item.label}
+              </button>
+            ))}
           </div>
 
           <div className="py-5">
-            {activeTab === "overview" && <OverviewPanel analysis={analysis} profile={profile} />}
-            {activeTab === "photos" && <PhotoPanel photos={data.photos} scores={analysis.photoScores} busy={busy === "photos"} onAnalyze={() => void analyzePhotos()} />}
-            {activeTab === "writer" && <WriterPanel profile={profile} drafts={data.latestDrafts} optimization={optimization} busy={busy} onRewrite={rewrite} onPreview={() => void previewOptimization()} onApply={() => void applyOptimization()} />}
-            {activeTab === "market" && <MarketPanel analysis={analysis} city={profile.city} state={profile.state} />}
-            {activeTab === "reports" && <ReportsPanel reports={data.latestReports} busy={busy} onGenerate={generateReport} />}
+            {tab === "overview" && <Overview analysis={analysis} />}
+            {tab === "photos" && <PhotoLab photos={data.photos} scores={analysis.photoScores} busy={busy === "photos"} onAnalyze={() => void analyzePhotos()} />}
+            {tab === "writer" && (
+              <Writer
+                profile={profile}
+                drafts={data.latestDrafts}
+                optimization={optimization}
+                busy={busy}
+                onRewrite={(field) => void rewrite(field)}
+                onPreview={() => void previewOptimization()}
+                onApply={() => void applyOptimization()}
+              />
+            )}
+            {tab === "market" && <Market analysis={analysis} city={profile.city} state={profile.state} />}
+            {tab === "reports" && <Reports reports={data.latestReports} busy={busy} onGenerate={(period) => void generateReport(period)} />}
           </div>
 
           <TrustSignals profile={profile} />
-
           <div className="mt-5 rounded-2xl border border-[#E8D8C8] bg-gradient-to-r from-[#FFF8EF] via-white to-[#FFF5F6] px-5 py-4 text-center text-sm font-semibold text-[#5C3A32]">
             <Sparkles className="mr-2 inline h-4 w-4 text-[#A56B24]" />
             A stronger profile. More trust. More direct connections. More freedom.
@@ -485,12 +469,12 @@ export function AiCoachDashboard() {
             firstName={firstName}
             analysis={analysis}
             busy={busy}
-            chatMessage={chatMessage}
-            chatAnswer={chatAnswer}
+            message={chat}
+            answer={answer}
+            onMessage={setChat}
+            onSend={() => void askCoach()}
             onClose={() => setCoachOpen(false)}
-            onMessageChange={setChatMessage}
-            onSend={() => void sendChat()}
-            onRecommendation={(recommendation) => {
+            onAction={(recommendation) => {
               if (recommendation.key === "headline") void rewrite("headline");
               else if (recommendation.key === "bio") void rewrite("bio");
               else if (recommendation.key === "photos") void analyzePhotos();
@@ -508,71 +492,81 @@ export function AiCoachDashboard() {
   );
 }
 
-function PromoBanner() {
+function Header({ busy, onRefresh, onOptimize }: { busy: string | null; onRefresh: () => void; onOptimize: () => void }) {
+  return (
+    <div className="mb-5 flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+      <div>
+        <div className="flex items-center gap-2 text-sm text-[#6E6864]">
+          <Sparkles className="h-4 w-4 text-[#A56B24]" /> AI Profile Coach
+          <span className="rounded-full bg-[#F9EDEE] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[#8B1E2D]">Beta</span>
+        </div>
+        <h1 className="mt-1 text-3xl font-semibold tracking-tight">My Profile</h1>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button type="button" onClick={onRefresh} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl border border-[#DED6CF] bg-white px-4 py-2.5 text-sm font-semibold text-[#4D4844] shadow-sm disabled:opacity-50">
+          <RefreshCw className={`h-4 w-4 ${busy === "refresh" ? "animate-spin" : ""}`} /> Refresh analysis
+        </button>
+        <button type="button" onClick={onOptimize} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(139,30,45,0.18)] disabled:opacity-50">
+          {busy === "optimize" ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />} Optimize with AI
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Feedback({ error, notice, onClose }: { error: string | null; notice: string | null; onClose: () => void }) {
+  if (!error && !notice) return null;
+  return (
+    <div className={`mb-5 flex items-start justify-between gap-3 rounded-2xl border px-4 py-3 text-sm ${error ? "border-red-200 bg-red-50 text-red-800" : "border-emerald-200 bg-emerald-50 text-emerald-800"}`}>
+      <span>{error || notice}</span>
+      <button type="button" onClick={onClose} aria-label="Dismiss message"><X className="h-4 w-4" /></button>
+    </div>
+  );
+}
+
+function PromotionalBanner() {
   return (
     <aside className="relative hidden overflow-hidden bg-gradient-to-b from-[#FFFDFC] via-[#FFF9F5] to-[#FDF2F1] px-7 py-8 2xl:flex 2xl:flex-col">
-      <div className="absolute -bottom-20 -right-24 h-72 w-72 rounded-full border border-[#DDBB8C]/30" />
-      <div className="absolute -bottom-28 -right-16 h-72 w-72 rounded-full border border-[#8B1E2D]/10" />
+      <div className="absolute -bottom-24 -right-20 h-72 w-72 rounded-full border border-[#C89555]/25" />
       <Image src={BRAND_ASSETS.logoLockup} alt="MasseurMatch" width={235} height={44} className="h-auto w-[220px] object-contain" priority />
-      <div className="mt-8 inline-flex w-fit items-center gap-2 rounded-full border border-[#C98E45]/35 bg-white/80 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-[#8B1E2D]">
+      <span className="mt-8 inline-flex w-fit items-center gap-2 rounded-full border border-[#C98E45]/35 bg-white/80 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-[#8B1E2D]">
         <Sparkles className="h-3.5 w-3.5" /> AI-powered
-      </div>
-      <h2 className="mt-5 text-[34px] font-semibold leading-[1.04] tracking-[-0.03em] text-[#171513]">
+      </span>
+      <h2 className="mt-5 text-[34px] font-semibold leading-[1.04] tracking-[-0.03em]">
         MasseurMatch
         <span className="mt-1 block bg-gradient-to-r from-[#8B1E2D] to-[#C04A55] bg-clip-text text-transparent">AI Profile Coach</span>
       </h2>
       <p className="mt-4 text-sm leading-6 text-[#655E59]">Your intelligent partner for a standout profile that attracts the right clients and grows your visibility.</p>
       <div className="mt-7 space-y-4">
-        {promoFeatures.map((feature) => (
-          <div key={feature.title} className="flex gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-[#EADBD5] bg-white text-[#8B1E2D] shadow-sm">
-              <feature.icon className="h-4 w-4" />
-            </div>
-            <div>
-              <p className="text-sm font-semibold text-[#26221F]">{feature.title}</p>
-              <p className="mt-0.5 text-xs leading-5 text-[#756D67]">{feature.copy}</p>
-            </div>
+        {PROMO_ITEMS.map((item) => (
+          <div key={item.title} className="flex gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-[#EADBD5] bg-white text-[#8B1E2D] shadow-sm"><item.icon className="h-4 w-4" /></div>
+            <div><p className="text-sm font-semibold">{item.title}</p><p className="mt-0.5 text-xs leading-5 text-[#756D67]">{item.copy}</p></div>
           </div>
         ))}
       </div>
       <div className="mt-auto pt-8">
-        <div className="relative rounded-3xl border border-white/90 bg-white/80 p-5 shadow-[0_18px_50px_rgba(99,55,45,0.08)] backdrop-blur">
+        <div className="rounded-3xl border border-white bg-white/85 p-5 shadow-[0_18px_50px_rgba(99,55,45,0.08)]">
           <div className="flex -space-x-2">
             {["A", "M", "J", "R", "B"].map((letter, index) => (
               <div key={letter} className={`flex h-11 w-11 items-center justify-center rounded-full border-2 border-white text-sm font-bold text-white ${["bg-[#9D3C48]", "bg-[#B77C3B]", "bg-[#495A66]", "bg-[#96705C]", "bg-[#485A4A]"][index]}`}>{letter}</div>
             ))}
           </div>
-          <div className="mt-4 flex items-start gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#F5B24B] via-[#D44C66] to-[#6C5CC7] text-white"><Heart className="h-4 w-4" /></div>
-            <div>
-              <p className="text-sm font-medium leading-5 text-[#39332F]">We celebrate every body, every identity, every person.</p>
-              <p className="mt-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">LGBTQ+ inclusive & proud</p>
-            </div>
-          </div>
+          <p className="mt-4 text-sm font-medium leading-5">We celebrate every body, every identity, every person.</p>
+          <p className="mt-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">LGBTQ+ inclusive & proud</p>
         </div>
       </div>
     </aside>
   );
 }
 
-function ProfileHero({ displayName, profilePhoto, city, state, tags, bio, experience, sessionType, language, verified }: {
-  displayName: string;
-  profilePhoto: string | null;
-  city: string | null;
-  state: string | null;
-  tags: string[];
-  bio: string | null;
-  experience: number | null;
-  sessionType: string;
-  language: string;
-  verified: boolean;
-}) {
+function ProfileHero({ profile, name, photo, tags, language, sessionType, verified }: { profile: Profile; name: string; photo: string | null; tags: string[]; language: string; sessionType: string; verified: boolean }) {
   return (
     <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-[0_12px_40px_rgba(61,43,33,0.055)] sm:p-6">
       <div className="grid gap-5 md:grid-cols-[140px_1fr]">
         <div className="flex flex-col items-center">
-          <div className="relative h-32 w-32 overflow-hidden rounded-full border-4 border-[#F2ECE7] bg-[#F2ECE7] shadow-inner">
-            {profilePhoto ? <img src={profilePhoto} alt={`${displayName} profile`} className="h-full w-full object-cover" /> : <div className="flex h-full w-full items-center justify-center text-4xl font-semibold text-[#8B1E2D]">{displayName.charAt(0)}</div>}
+          <div className="relative h-32 w-32 overflow-hidden rounded-full border-4 border-[#F2ECE7] bg-[#F2ECE7]">
+            {photo ? <img src={photo} alt={`${name} profile`} className="h-full w-full object-cover" /> : <div className="flex h-full w-full items-center justify-center text-4xl font-semibold text-[#8B1E2D]">{name.charAt(0)}</div>}
             <span className="absolute bottom-1 right-1 flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-[#393431] text-white"><Camera className="h-4 w-4" /></span>
           </div>
           {verified && <span className="mt-3 inline-flex items-center gap-1 rounded-full bg-[#EDF7EF] px-3 py-1 text-xs font-semibold text-[#347348]"><BadgeCheck className="h-3.5 w-3.5" /> Verified</span>}
@@ -580,17 +574,15 @@ function ProfileHero({ displayName, profilePhoto, city, state, tags, bio, experi
         <div className="min-w-0">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <div className="flex items-center gap-2"><h2 className="text-2xl font-semibold tracking-tight">{displayName}</h2>{verified && <BadgeCheck className="h-5 w-5 fill-[#3779D5] text-white" />}</div>
-              <p className="mt-1 flex items-center gap-1.5 text-sm text-[#665F5A]"><MapPin className="h-4 w-4" /> {[city, state].filter(Boolean).join(", ") || "Add your location"}</p>
+              <h2 className="flex items-center gap-2 text-2xl font-semibold">{name}{verified && <BadgeCheck className="h-5 w-5 text-[#3779D5]" />}</h2>
+              <p className="mt-1 flex items-center gap-1.5 text-sm text-[#665F5A]"><MapPin className="h-4 w-4" /> {[profile.city, profile.state].filter(Boolean).join(", ") || "Add location"}</p>
             </div>
-            <Link href="/pro/listing" className="inline-flex items-center gap-1 rounded-xl border border-[#DED6CF] px-3 py-2 text-xs font-semibold text-[#625B56] hover:border-[#BCAFA5]">Edit profile <ChevronRight className="h-3.5 w-3.5" /></Link>
+            <Link href="/pro/listing" className="inline-flex items-center gap-1 rounded-xl border border-[#DED6CF] px-3 py-2 text-xs font-semibold text-[#625B56]">Edit profile <ChevronRight className="h-3.5 w-3.5" /></Link>
           </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {(tags.length ? tags : ["Add techniques"]).map((tag) => <span key={tag} className="rounded-full border border-[#E8DFD8] bg-[#FFFCF9] px-3 py-1 text-xs font-medium text-[#514B46]">{tag}</span>)}
-          </div>
-          <p className="mt-4 line-clamp-3 text-sm leading-6 text-[#59524D]">{bio || "Add a professional bio that explains your approach, specialties, experience, and what clients can expect from a session."}</p>
+          <div className="mt-4 flex flex-wrap gap-2">{(tags.length ? tags : ["Add techniques"]).map((tag) => <span key={tag} className="rounded-full border border-[#E8DFD8] bg-[#FFFCF9] px-3 py-1 text-xs font-medium">{tag}</span>)}</div>
+          <p className="mt-4 line-clamp-3 text-sm leading-6 text-[#59524D]">{profile.bio || "Add a professional bio describing your approach, specialties, experience, and what clients can expect."}</p>
           <div className="mt-5 grid gap-2 sm:grid-cols-3">
-            <MiniInfo icon={Star} label="Experience" value={experience ? `${experience}+ years` : "Add experience"} />
+            <MiniInfo icon={Star} label="Experience" value={profile.years_experience ? `${profile.years_experience}+ years` : "Add experience"} />
             <MiniInfo icon={UserRoundCheck} label="Session Type" value={sessionType} />
             <MiniInfo icon={Languages} label="Languages" value={language} />
           </div>
@@ -604,143 +596,104 @@ function MiniInfo({ icon: Icon, label, value }: { icon: LucideIcon; label: strin
   return <div className="rounded-2xl border border-[#EFE8E2] bg-[#FFFCFA] px-3 py-3"><div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#8B1E2D]"><Icon className="h-3.5 w-3.5" />{label}</div><p className="mt-1 truncate text-xs text-[#59524D]">{value}</p></div>;
 }
 
-function ProfileCompletionCard({ analysis, firstName }: { analysis: Analysis; firstName: string }) {
+function CompletionCard({ analysis, firstName }: { analysis: Analysis; firstName: string }) {
+  const scoreEntries = Object.entries({ Content: analysis.scores.content, Trust: analysis.scores.trust, Visibility: analysis.scores.visibility, Conversion: analysis.scores.conversion, SEO: analysis.scores.seo, Photos: analysis.scores.photos });
   return (
     <section className="mt-5 rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm sm:p-6">
       <div className="grid items-center gap-6 lg:grid-cols-[150px_1fr]">
-        <div className="flex justify-center">
-          <div className="relative flex h-32 w-32 items-center justify-center rounded-full" style={{ background: `conic-gradient(#8B1E2D 0 ${analysis.scores.completion}%, #E8E1DB ${analysis.scores.completion}% 100%)` }}>
-            <div className="flex h-[104px] w-[104px] flex-col items-center justify-center rounded-full bg-white"><strong className="text-3xl">{analysis.scores.completion}%</strong><span className="text-xs text-[#817873]">Complete</span></div>
-          </div>
-        </div>
+        <div className="flex justify-center"><div className="relative flex h-32 w-32 items-center justify-center rounded-full" style={{ background: `conic-gradient(#8B1E2D 0 ${analysis.scores.completion}%, #E8E1DB ${analysis.scores.completion}% 100%)` }}><div className="flex h-[104px] w-[104px] flex-col items-center justify-center rounded-full bg-white"><strong className="text-3xl">{analysis.scores.completion}%</strong><span className="text-xs text-[#817873]">Complete</span></div></div></div>
         <div>
-          <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="text-lg font-semibold">Great progress, {firstName}!</h3><span className="rounded-full bg-[#FFF3E4] px-3 py-1 text-xs font-semibold text-[#8A5A18]">Top {Math.max(1, 100 - analysis.benchmark.percentile)}% in your market</span></div>
-          <p className="mt-2 text-sm leading-6 text-[#6D655F]">Your overall profile health is <strong className="text-[#8B1E2D]">{analysis.scores.overall}/100</strong>. Complete the highest-impact actions to improve trust, visibility, and contact readiness.</p>
+          <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="text-lg font-semibold">Great progress, {firstName}!</h3><span className="rounded-full bg-[#FFF3E4] px-3 py-1 text-xs font-semibold text-[#8A5A18]">{analysis.benchmark.percentile}th percentile</span></div>
+          <p className="mt-2 text-sm leading-6 text-[#6D655F]">Your overall profile health is <strong className="text-[#8B1E2D]">{analysis.scores.overall}/100</strong>. Complete high-impact actions to improve trust, visibility, and contact readiness.</p>
           <div className="mt-4 h-2.5 overflow-hidden rounded-full bg-[#EFE9E4]"><div className="h-full rounded-full bg-gradient-to-r from-[#8B1E2D] via-[#B43A48] to-[#D59B4C]" style={{ width: `${analysis.scores.overall}%` }} /></div>
-          <div className="mt-4 grid grid-cols-3 gap-2 text-center sm:grid-cols-6">
-            {Object.entries({ Content: analysis.scores.content, Trust: analysis.scores.trust, Visibility: analysis.scores.visibility, Conversion: analysis.scores.conversion, SEO: analysis.scores.seo, Photos: analysis.scores.photos }).map(([label, score]) => <div key={label} className="rounded-xl bg-[#FBF8F5] px-2 py-2"><p className="text-sm font-bold">{score}</p><p className="text-[10px] text-[#827A74]">{label}</p></div>)}
-          </div>
+          <div className="mt-4 grid grid-cols-3 gap-2 sm:grid-cols-6">{scoreEntries.map(([label, score]) => <div key={label} className="rounded-xl bg-[#FBF8F5] px-2 py-2 text-center"><p className="text-sm font-bold">{score}</p><p className="text-[10px] text-[#827A74]">{label}</p></div>)}</div>
         </div>
       </div>
     </section>
   );
 }
 
-function MetricCard({ icon: Icon, label, note, value, accent = false }: { icon: LucideIcon; label: string; note: string; value: number; accent?: boolean }) {
-  return <div className="rounded-2xl border border-[#E9E2DC] bg-white p-4 shadow-sm"><div className="flex items-start justify-between"><div className={`flex h-9 w-9 items-center justify-center rounded-xl ${accent ? "bg-[#F9EDEE] text-[#8B1E2D]" : "bg-[#F6F2EE] text-[#5B5550]"}`}><Icon className="h-4 w-4" /></div><ArrowRight className="h-4 w-4 text-[#B8AEA7]" /></div><p className="mt-4 text-2xl font-semibold tracking-tight">{formatNumber(value)}</p><p className="mt-1 text-xs font-semibold text-[#4C4642]">{label}</p><p className="mt-0.5 text-[10px] text-[#8A817B]">{note}</p></div>;
+function Metrics({ analysis }: { analysis: Analysis }) {
+  const metrics = [
+    { icon: Eye, label: "Profile Views", note: "Last 30 days", value: analysis.metrics.views30d },
+    { icon: Heart, label: "Favorites", note: "Last 7 days", value: analysis.metrics.favorites7d },
+    { icon: MessageCircle, label: "Contact Taps", note: "Last 30 days", value: analysis.metrics.contacts30d },
+    { icon: TrendingUp, label: "Predicted Contacts", note: "Next 7 days · estimate", value: analysis.forecast.contactsLikely },
+  ];
+  return <div className="mt-5 grid grid-cols-2 gap-3 xl:grid-cols-4">{metrics.map((metric) => <div key={metric.label} className="rounded-2xl border border-[#E9E2DC] bg-white p-4 shadow-sm"><div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#F9EDEE] text-[#8B1E2D]"><metric.icon className="h-4 w-4" /></div><p className="mt-4 text-2xl font-semibold">{formatNumber(metric.value)}</p><p className="mt-1 text-xs font-semibold">{metric.label}</p><p className="mt-0.5 text-[10px] text-[#8A817B]">{metric.note}</p></div>)}</div>;
 }
 
-function OverviewPanel({ analysis, profile }: { analysis: Analysis; profile: Profile }) {
-  const chartData = analysis.history.length ? analysis.history : [{ date: new Date().toISOString().slice(0, 10), overall: analysis.scores.overall, visibility: analysis.scores.visibility, trust: analysis.scores.trust, content: analysis.scores.content, conversion: analysis.scores.conversion }];
+function Overview({ analysis }: { analysis: Analysis }) {
+  const maxHistory = Math.max(1, ...analysis.history.map((point) => point.overall));
   return (
-    <div className="grid gap-4 xl:grid-cols-[1.35fr_.85fr]">
+    <div className="grid gap-4 xl:grid-cols-[1.2fr_.8fr]">
       <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm">
-        <div className="flex items-center justify-between"><div><h3 className="font-semibold">Profile health trend</h3><p className="mt-1 text-xs text-[#827A74]">Daily score snapshots across your recent activity.</p></div><span className="rounded-full bg-[#F6F2EE] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-[#6A625C]">90 days</span></div>
-        <div className="mt-5 h-64 w-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={chartData} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
-              <defs><linearGradient id="coachScoreFill" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stopColor="#8B1E2D" stopOpacity={0.22} /><stop offset="100%" stopColor="#8B1E2D" stopOpacity={0} /></linearGradient></defs>
-              <CartesianGrid stroke="#F0EBE7" vertical={false} />
-              <XAxis dataKey="date" tickFormatter={displayDate} tick={{ fontSize: 10, fill: "#918780" }} tickLine={false} axisLine={false} minTickGap={24} />
-              <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "#918780" }} tickLine={false} axisLine={false} width={34} />
-              <Tooltip labelFormatter={(value) => displayDate(String(value))} contentStyle={{ borderRadius: 14, border: "1px solid #E9E2DC", fontSize: 12 }} />
-              <Area type="monotone" dataKey="overall" name="Profile score" stroke="#8B1E2D" strokeWidth={2.4} fill="url(#coachScoreFill)" activeDot={{ r: 4 }} />
-            </AreaChart>
-          </ResponsiveContainer>
+        <h3 className="font-semibold">Profile health trend</h3>
+        <p className="mt-1 text-xs text-[#827A74]">Recent daily score snapshots.</p>
+        <div className="mt-6 flex h-48 items-end gap-2 rounded-2xl bg-[#FCF9F6] p-4">
+          {(analysis.history.length ? analysis.history.slice(-20) : [{ date: "Today", overall: analysis.scores.overall }]).map((point) => (
+            <div key={point.date} className="group flex min-w-0 flex-1 flex-col items-center justify-end">
+              <div className="w-full rounded-t-lg bg-gradient-to-t from-[#8B1E2D] to-[#D59B4C] transition group-hover:opacity-80" style={{ height: `${Math.max(8, (point.overall / maxHistory) * 100)}%` }} title={`${point.date}: ${point.overall}`} />
+            </div>
+          ))}
         </div>
+        <div className="mt-3 flex justify-between text-[10px] text-[#8A817B]"><span>Older</span><span>Today</span></div>
       </section>
       <div className="space-y-4">
-        <InsightCard icon={TrendingUp} title="Ranking intelligence" value={analysis.ranking.current ? `#${analysis.ranking.current}` : "Collecting data"} copy={analysis.ranking.explanation} />
-        <InsightCard icon={Zap} title="7-day forecast" value={`${analysis.forecast.contactsLow}–${analysis.forecast.contactsHigh} contacts`} copy={`${analysis.forecast.confidence}% confidence estimate based on recent views and contact activity.`} />
-        <InsightCard icon={CircleDollarSign} title="Rate readiness" value={analysis.scores.conversion >= 75 ? "Strong" : "Needs attention"} copy={analysis.scores.conversion >= 75 ? "Your rates and conversion details are in good shape." : "Clear rates, durations, payment methods, and amenities can improve qualified contacts."} href="/pro/rates" />
+        <Insight title="Ranking intelligence" icon={TrendingUp} value={analysis.ranking.current ? `#${analysis.ranking.current}` : "Collecting data"} copy={analysis.ranking.explanation} />
+        <Insight title="7-day forecast" icon={Zap} value={`${analysis.forecast.contactsLow}–${analysis.forecast.contactsHigh} contacts`} copy={`${analysis.forecast.confidence}% confidence estimate based on recent activity.`} />
       </div>
       <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm xl:col-span-2">
-        <div className="flex items-center justify-between"><div><h3 className="font-semibold">Today&apos;s priorities</h3><p className="mt-1 text-xs text-[#827A74]">Ordered by likely profile impact, not guaranteed results.</p></div><Link href="/pro/listing" className="text-xs font-semibold text-[#8B1E2D]">Edit profile</Link></div>
-        <div className="mt-4 grid gap-3 md:grid-cols-2">
-          {analysis.recommendations.slice(0, 4).map((item, index) => <Link key={item.key} href={item.href} className="group rounded-2xl border border-[#EEE7E1] bg-[#FFFDFC] p-4 transition hover:border-[#D7C7BA] hover:shadow-sm"><div className="flex items-start gap-3"><span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#F9EDEE] text-sm font-bold text-[#8B1E2D]">{index + 1}</span><div className="min-w-0 flex-1"><div className="flex items-start justify-between gap-2"><h4 className="text-sm font-semibold">{item.title}</h4><span className={`shrink-0 rounded-full px-2 py-1 text-[9px] font-bold uppercase ${impactStyle[item.impact]}`}>{item.impact}</span></div><p className="mt-1 text-xs leading-5 text-[#756D67]">{item.action}</p><p className="mt-2 text-[10px] font-semibold text-[#8B1E2D]">Directional lift +{item.estimatedLift}%</p></div><ChevronRight className="mt-1 h-4 w-4 text-[#B7AEA8] transition group-hover:translate-x-0.5" /></div></Link>)}
-        </div>
+        <h3 className="font-semibold">Today&apos;s priorities</h3>
+        <p className="mt-1 text-xs text-[#827A74]">Ordered by likely impact. Estimates are directional, not guaranteed.</p>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">{analysis.recommendations.slice(0, 6).map((item, index) => <Link key={item.key} href={item.href} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4 transition hover:border-[#CFBFB4]"><div className="flex items-start gap-3"><span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#F9EDEE] text-sm font-bold text-[#8B1E2D]">{index + 1}</span><div className="min-w-0 flex-1"><div className="flex items-start justify-between gap-2"><p className="text-sm font-semibold">{item.title}</p><span className={`rounded-full px-2 py-1 text-[9px] font-bold uppercase ${IMPACT_CLASS[item.impact]}`}>{item.impact}</span></div><p className="mt-1 text-xs leading-5 text-[#756D67]">{item.action}</p><p className="mt-2 text-[10px] font-semibold text-[#8B1E2D]">Directional lift +{item.estimatedLift}%</p></div><ChevronRight className="h-4 w-4 text-[#B7AEA8]" /></div></Link>)}</div>
       </section>
-      {profile.subscription_tier !== "elite" && <div className="rounded-3xl border border-[#E8D8C8] bg-[#FFF9F1] p-5 xl:col-span-2"><div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center"><div><p className="text-sm font-semibold text-[#6A442A]">AI Coach works with every plan</p><p className="mt-1 text-xs text-[#7B685B]">Some advanced automation and visibility tools may depend on your subscription tier.</p></div><Link href="/pro/subscription" className="inline-flex items-center justify-center gap-2 rounded-xl bg-white px-4 py-2.5 text-xs font-semibold text-[#8B1E2D] shadow-sm">View subscription <ArrowRight className="h-3.5 w-3.5" /></Link></div></div>}
     </div>
   );
 }
 
-function InsightCard({ icon: Icon, title, value, copy, href }: { icon: LucideIcon; title: string; value: string; copy: string; href?: string }) {
-  const body = <div className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.1em] text-[#8B1E2D]"><Icon className="h-4 w-4" />{title}</div><p className="mt-3 text-xl font-semibold">{value}</p><p className="mt-2 text-xs leading-5 text-[#756D67]">{copy}</p></div>;
-  return href ? <Link href={href}>{body}</Link> : body;
+function Insight({ title, icon: Icon, value, copy }: { title: string; icon: LucideIcon; value: string; copy: string }) {
+  return <div className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.1em] text-[#8B1E2D]"><Icon className="h-4 w-4" />{title}</div><p className="mt-3 text-xl font-semibold">{value}</p><p className="mt-2 text-xs leading-5 text-[#756D67]">{copy}</p></div>;
 }
 
-function PhotoPanel({ photos, scores, busy, onAnalyze }: { photos: Photo[]; scores: PhotoScore[]; busy: boolean; onAnalyze: () => void }) {
-  const byPhoto = new Map(scores.map((score) => [score.photo_id, score]));
+function PhotoLab({ photos, scores, busy, onAnalyze }: { photos: Photo[]; scores: PhotoScore[]; busy: boolean; onAnalyze: () => void }) {
+  const scoreMap = useMemo(() => new Map(scores.map((score) => [score.photo_id, score])), [scores]);
   return (
     <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm">
-      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">AI Photo Quality Lab</h3><p className="mt-1 text-xs text-[#827A74]">Scores pose, lighting, approachability, composition, background, sharpness, and professionalism.</p></div><button type="button" onClick={onAnalyze} disabled={busy || photos.length === 0} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Camera className="h-4 w-4" />} Analyze gallery</button></div>
-      {photos.length === 0 ? <EmptyState icon={ImageIcon} title="No photos to analyze" copy="Upload profile and gallery photos first." href="/pro/photos" action="Manage photos" /> : <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">{photos.map((photo, index) => {
-        const score = byPhoto.get(photo.id);
-        return <article key={photo.id} className="overflow-hidden rounded-2xl border border-[#EAE2DC] bg-[#FFFCFA]"><div className="relative aspect-[4/3] bg-[#EEE8E3]">{photo.url ? <img src={photo.url} alt={`Profile gallery photo ${index + 1}`} className="h-full w-full object-cover" /> : <div className="flex h-full items-center justify-center"><ImageIcon className="h-8 w-8 text-[#A99F98]" /></div>}{photo.is_primary && <span className="absolute left-3 top-3 rounded-full bg-white/95 px-2.5 py-1 text-[10px] font-bold text-[#8B1E2D] shadow">Primary</span>}{score && <span className="absolute bottom-3 right-3 flex h-12 w-12 items-center justify-center rounded-full border-4 border-white bg-[#8B1E2D] text-sm font-bold text-white shadow-lg">{score.overall_score}</span>}</div><div className="p-4">{score ? <><div className="flex items-center justify-between"><p className="text-sm font-semibold">Photo {index + 1}</p><span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#817873]">{score.analysis_mode === "vision" ? "AI Vision" : "Baseline"}</span></div><div className="mt-3 grid grid-cols-2 gap-2 text-[11px]">{[["Lighting", score.lighting_score], ["Pose", score.pose_score], ["Smile", score.smile_score], ["Professional", score.professionalism_score]].map(([label, value]) => <div key={String(label)} className="rounded-xl bg-white px-3 py-2"><span className="text-[#817873]">{label}</span><strong className="float-right">{value}</strong></div>)}</div><p className="mt-3 text-xs leading-5 text-[#6D655F]">{score.recommendation}</p><p className="mt-2 text-[10px] font-semibold text-[#8B1E2D]">Estimated CTR direction: +{score.predicted_ctr_lift_pct}%</p></> : <><p className="text-sm font-semibold">Photo {index + 1}</p><p className="mt-2 text-xs text-[#817873]">Run the AI analysis to score presentation quality.</p></>}</div></article>;
+      <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">AI Photo Quality Lab</h3><p className="mt-1 text-xs text-[#827A74]">Presentation scoring for pose, lighting, approachability, composition, background, sharpness, and professionalism.</p></div><button type="button" onClick={onAnalyze} disabled={busy || photos.length === 0} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Camera className="h-4 w-4" />} Analyze gallery</button></div>
+      {!photos.length ? <Empty icon={ImageIcon} title="No photos to analyze" copy="Upload profile and gallery photos first." href="/pro/photos" /> : <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">{photos.map((photo, index) => {
+        const score = scoreMap.get(photo.id);
+        return <article key={photo.id} className="overflow-hidden rounded-2xl border border-[#EAE2DC] bg-[#FFFCFA]"><div className="relative aspect-[4/3] bg-[#EEE8E3]">{photo.url ? <img src={photo.url} alt={`Profile gallery ${index + 1}`} className="h-full w-full object-cover" /> : <div className="flex h-full items-center justify-center"><ImageIcon className="h-8 w-8 text-[#A99F98]" /></div>}{photo.is_primary && <span className="absolute left-3 top-3 rounded-full bg-white px-2.5 py-1 text-[10px] font-bold text-[#8B1E2D]">Primary</span>}{score && <span className="absolute bottom-3 right-3 flex h-12 w-12 items-center justify-center rounded-full border-4 border-white bg-[#8B1E2D] text-sm font-bold text-white">{score.overall_score}</span>}</div><div className="p-4"><div className="flex items-center justify-between"><p className="text-sm font-semibold">Photo {index + 1}</p>{score && <span className="text-[10px] uppercase text-[#817873]">{score.analysis_mode === "vision" ? "AI Vision" : "Baseline"}</span>}</div>{score ? <><div className="mt-3 grid grid-cols-2 gap-2 text-[11px]">{[["Lighting", score.lighting_score], ["Pose", score.pose_score], ["Smile", score.smile_score], ["Professional", score.professionalism_score]].map(([label, value]) => <div key={String(label)} className="rounded-xl bg-white px-3 py-2"><span className="text-[#817873]">{label}</span><strong className="float-right">{value}</strong></div>)}</div><p className="mt-3 text-xs leading-5 text-[#6D655F]">{score.recommendation}</p><p className="mt-2 text-[10px] font-semibold text-[#8B1E2D]">Estimated CTR direction +{score.predicted_ctr_lift_pct}%</p></> : <p className="mt-2 text-xs text-[#817873]">Run analysis to score this image.</p>}</div></article>;
       })}</div>}
-      <p className="mt-5 rounded-2xl bg-[#F8F4F0] px-4 py-3 text-[11px] leading-5 text-[#756D67]">Photo scoring evaluates photographic presentation only. It does not infer identity, protected traits, health, personality, or suitability. Scores and CTR lift are directional guidance, not guarantees.</p>
+      <p className="mt-5 rounded-2xl bg-[#F8F4F0] px-4 py-3 text-[11px] leading-5 text-[#756D67]">Photo analysis evaluates visible photographic presentation only. It does not infer identity, health, personality, or protected traits. Scores are guidance, not guarantees.</p>
     </section>
   );
 }
 
-function WriterPanel({ profile, drafts, optimization, busy, onRewrite, onPreview, onApply }: { profile: Profile; drafts: Draft[]; optimization: Optimization | null; busy: string | null; onRewrite: (field: "headline" | "tagline" | "bio" | "seo_title" | "seo_description") => void; onPreview: () => void; onApply: () => void }) {
-  const current: Record<string, string | null> = { headline: profile.headline, tagline: profile.tagline, bio: profile.bio, seo_title: null, seo_description: null };
-  return (
-    <div className="space-y-4">
-      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">AI Copywriter</h3><p className="mt-1 text-xs text-[#827A74]">DeepSeek is used first when configured, with OpenAI and Gemini fallbacks.</p></div><button type="button" onClick={onPreview} disabled={busy !== null} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy === "optimize" ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />} Preview full optimization</button></div><div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">{(["headline", "tagline", "bio", "seo_title", "seo_description"] as const).map((field) => <button key={field} type="button" onClick={() => onRewrite(field)} disabled={busy !== null} className="rounded-2xl border border-[#EAE2DC] bg-[#FFFCFA] p-4 text-left transition hover:border-[#CDBCAF] disabled:opacity-50"><div className="flex items-center justify-between"><Sparkles className="h-4 w-4 text-[#8B1E2D]" />{busy === `rewrite-${field}` && <Loader2 className="h-4 w-4 animate-spin text-[#8B1E2D]" />}</div><p className="mt-3 text-sm font-semibold">Rewrite {fieldLabels[field]}</p><p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[#817873]">{current[field] || "Generate a polished, factual suggestion."}</p></button>)}</div></section>
-      {optimization && <section className="rounded-3xl border border-[#DDBFC3] bg-[#FFF8F8] p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold text-[#6F1723]">One-click optimization preview</h3><p className="mt-1 text-xs text-[#7C6265]">Nothing changes until you approve and apply this preview.</p></div><button type="button" onClick={onApply} disabled={busy !== null} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy === "apply" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />} Apply approved changes</button></div><div className="mt-4 grid gap-3 lg:grid-cols-2">{Object.entries(optimization.after_state).filter(([key]) => key !== "seo_keywords").map(([key, value]) => <div key={key} className="rounded-2xl border border-[#EAD7D9] bg-white p-4"><p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">{fieldLabels[key] ?? key}</p><p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-[#5F5554]">{String(value ?? "")}</p></div>)}</div>{optimization.rationale && <p className="mt-4 text-xs leading-5 text-[#755E60]">{optimization.rationale}</p>}</section>}
-      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="font-semibold">Recent suggestions</h3>{drafts.length ? <div className="mt-4 space-y-3">{drafts.slice(0, 8).map((draft) => <article key={draft.id} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-xs font-bold uppercase tracking-[0.1em] text-[#8B1E2D]">{fieldLabels[draft.field] ?? draft.field}</p><span className="text-[10px] text-[#8A817B]">{draft.provider ?? "deterministic"} · {draft.model ?? "fallback"}</span></div><p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#4E4844]">{draft.suggested_text}</p>{draft.rationale && <p className="mt-2 text-xs text-[#817873]">{draft.rationale}</p>}</article>)}</div> : <EmptyState icon={Sparkles} title="No AI drafts yet" copy="Choose a field above to generate your first suggestion." />}</section>
-    </div>
-  );
+function Writer({ profile, drafts, optimization, busy, onRewrite, onPreview, onApply }: { profile: Profile; drafts: Draft[]; optimization: Optimization | null; busy: string | null; onRewrite: (field: RewriteField) => void; onPreview: () => void; onApply: () => void }) {
+  const fields: RewriteField[] = ["headline", "tagline", "bio", "seo_title", "seo_description"];
+  const current: Record<RewriteField, string | null> = { headline: profile.headline, tagline: profile.tagline, bio: profile.bio, seo_title: profile.seo_title, seo_description: profile.seo_description };
+  return <div className="space-y-4"><section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">AI Copywriter</h3><p className="mt-1 text-xs text-[#827A74]">DeepSeek is used first when configured, with OpenAI and Gemini fallbacks.</p></div><button type="button" onClick={onPreview} disabled={busy !== null} className="inline-flex items-center justify-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy === "optimize" ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />} Full optimization preview</button></div><div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">{fields.map((field) => <button key={field} type="button" onClick={() => onRewrite(field)} disabled={busy !== null} className="rounded-2xl border border-[#EAE2DC] bg-[#FFFCFA] p-4 text-left disabled:opacity-50"><div className="flex items-center justify-between"><Sparkles className="h-4 w-4 text-[#8B1E2D]" />{busy === `rewrite-${field}` && <Loader2 className="h-4 w-4 animate-spin" />}</div><p className="mt-3 text-sm font-semibold">Rewrite {FIELD_LABELS[field]}</p><p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[#817873]">{current[field] || "Generate a factual suggestion."}</p></button>)}</div></section>{optimization && <section className="rounded-3xl border border-[#DDBFC3] bg-[#FFF8F8] p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold text-[#6F1723]">One-click optimization preview</h3><p className="mt-1 text-xs text-[#7C6265]">Nothing changes until you explicitly approve and apply.</p></div><button type="button" onClick={onApply} disabled={busy !== null} className="inline-flex items-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-xs font-semibold text-white disabled:opacity-50">{busy === "apply" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />} Apply approved changes</button></div><div className="mt-4 grid gap-3 lg:grid-cols-2">{Object.entries(optimization.after_state).map(([key, value]) => <div key={key} className="rounded-2xl border border-[#EAD7D9] bg-white p-4"><p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">{FIELD_LABELS[key] || key}</p><p className="mt-2 whitespace-pre-wrap text-xs leading-5 text-[#5F5554]">{Array.isArray(value) ? value.join(", ") : String(value || "")}</p></div>)}</div>{optimization.rationale && <p className="mt-4 text-xs text-[#755E60]">{optimization.rationale}</p>}</section>}<section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="font-semibold">Recent suggestions</h3>{drafts.length ? <div className="mt-4 space-y-3">{drafts.slice(0, 8).map((draft) => <article key={draft.id} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex flex-wrap justify-between gap-2"><p className="text-xs font-bold uppercase tracking-[0.1em] text-[#8B1E2D]">{FIELD_LABELS[draft.field] || draft.field}</p><span className="text-[10px] text-[#8A817B]">{draft.provider || "deterministic"} · {draft.model || "fallback"}</span></div><p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#4E4844]">{draft.suggested_text}</p>{draft.rationale && <p className="mt-2 text-xs text-[#817873]">{draft.rationale}</p>}</article>)}</div> : <Empty icon={Sparkles} title="No AI drafts yet" copy="Choose a field above to generate your first suggestion." />}</section></div>;
 }
 
-function MarketPanel({ analysis, city, state }: { analysis: Analysis; city: string | null; state: string | null }) {
-  return (
-    <div className="grid gap-4 lg:grid-cols-2">
-      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2"><MapPin className="h-5 w-5 text-[#8B1E2D]" /><div><h3 className="font-semibold">{[city, state].filter(Boolean).join(", ") || "Local market"}</h3><p className="text-xs text-[#827A74]">Dynamic market intelligence</p></div></div><div className="mt-5 grid grid-cols-2 gap-3"><MarketMetric label="Demand" value={analysis.market.demandScore ?? "—"} note={analysis.market.demandTrend} /><MarketMetric label="Competition" value={analysis.market.competitionIndex ?? "—"} note="index" /><MarketMetric label="Search volume" value={analysis.market.searchVolumeIndex ?? "—"} note="index" /><MarketMetric label="Profiles compared" value={analysis.benchmark.cityProfileCount} note="up to 100" /></div></section>
-      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="font-semibold">Competitor benchmark</h3><p className="mt-1 text-xs text-[#827A74]">Anonymized comparison against active profiles in the same city.</p><div className="mt-5 space-y-4">{[["Your score", analysis.scores.overall], ["City average", analysis.benchmark.cityAverageScore], ["Top 10 average", analysis.benchmark.top10AverageScore]].map(([label, value]) => <div key={String(label)}><div className="mb-1.5 flex justify-between text-xs"><span className="text-[#675F5A]">{label}</span><strong>{value}</strong></div><div className="h-2 overflow-hidden rounded-full bg-[#F0EAE5]"><div className={`h-full rounded-full ${label === "Your score" ? "bg-[#8B1E2D]" : "bg-[#BFB3AA]"}`} style={{ width: `${Math.min(100, Number(value))}%` }} /></div></div>)}</div><p className="mt-5 rounded-2xl bg-[#F8F4F0] px-4 py-3 text-xs leading-5 text-[#6F6761]">You rank around the <strong>{analysis.benchmark.percentile}th percentile</strong>. You need approximately <strong>{analysis.benchmark.pointsToTop10} points</strong> to reach the current top-10 average.</p></section>
-      <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm lg:col-span-2"><h3 className="font-semibold">Trending local keywords</h3>{analysis.market.topKeywords.length ? <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{analysis.market.topKeywords.map((keyword, index) => <div key={keyword.keyword} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex items-center justify-between"><span className="flex h-7 w-7 items-center justify-center rounded-full bg-[#F9EDEE] text-xs font-bold text-[#8B1E2D]">{index + 1}</span><span className="text-[10px] font-semibold uppercase text-[#6D765E]">{keyword.trend}</span></div><p className="mt-3 text-sm font-semibold">{keyword.keyword}</p><p className="mt-1 text-xs text-[#817873]">Opportunity score {keyword.score}</p></div>)}</div> : <EmptyState icon={Search} title="No keyword trend data yet" copy="Local search trends will appear as market activity is collected." />}</section>
-    </div>
-  );
+function Market({ analysis, city, state }: { analysis: Analysis; city: string | null; state: string | null }) {
+  const metrics = [["Demand", analysis.market.demandScore ?? "—"], ["Competition", analysis.market.competitionIndex ?? "—"], ["Search volume", analysis.market.searchVolumeIndex ?? "—"], ["Profiles compared", analysis.benchmark.cityProfileCount]];
+  return <div className="grid gap-4 lg:grid-cols-2"><section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="flex items-center gap-2 font-semibold"><MapPin className="h-5 w-5 text-[#8B1E2D]" />{[city, state].filter(Boolean).join(", ") || "Local market"}</h3><p className="mt-1 text-xs text-[#827A74]">Dynamic city intelligence</p><div className="mt-5 grid grid-cols-2 gap-3">{metrics.map(([label, value]) => <div key={String(label)} className="rounded-2xl bg-[#F9F5F1] p-4"><p className="text-[10px] font-bold uppercase tracking-[0.1em] text-[#817873]">{label}</p><p className="mt-2 text-2xl font-semibold">{value}</p></div>)}</div></section><section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="font-semibold">Competitor benchmark</h3><p className="mt-1 text-xs text-[#827A74]">Anonymized comparison against up to 100 profiles.</p><div className="mt-5 space-y-4">{[["Your score", analysis.scores.overall], ["City average", analysis.benchmark.cityAverageScore], ["Top 10 average", analysis.benchmark.top10AverageScore]].map(([label, value]) => <div key={String(label)}><div className="mb-1 flex justify-between text-xs"><span>{label}</span><strong>{value}</strong></div><div className="h-2 overflow-hidden rounded-full bg-[#F0EAE5]"><div className={label === "Your score" ? "h-full rounded-full bg-[#8B1E2D]" : "h-full rounded-full bg-[#BFB3AA]"} style={{ width: `${Math.min(100, Number(value))}%` }} /></div></div>)}</div><p className="mt-5 rounded-2xl bg-[#F8F4F0] px-4 py-3 text-xs leading-5 text-[#6F6761]">You are around the <strong>{analysis.benchmark.percentile}th percentile</strong> and approximately <strong>{analysis.benchmark.pointsToTop10} points</strong> from the top-10 average.</p></section><section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm lg:col-span-2"><h3 className="font-semibold">Trending local keywords</h3>{analysis.market.topKeywords.length ? <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{analysis.market.topKeywords.map((keyword, index) => <div key={keyword.keyword} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><span className="flex h-7 w-7 items-center justify-center rounded-full bg-[#F9EDEE] text-xs font-bold text-[#8B1E2D]">{index + 1}</span><p className="mt-3 text-sm font-semibold">{keyword.keyword}</p><p className="mt-1 text-xs text-[#817873]">Score {keyword.score} · {keyword.trend}</p></div>)}</div> : <Empty icon={Search} title="No keyword trends yet" copy="Local trends will appear as search activity is collected." />}</section></div>;
 }
 
-function MarketMetric({ label, value, note }: { label: string; value: string | number; note: string }) {
-  return <div className="rounded-2xl bg-[#F9F5F1] p-4"><p className="text-[10px] font-bold uppercase tracking-[0.1em] text-[#817873]">{label}</p><p className="mt-2 text-2xl font-semibold">{value}</p><p className="mt-1 text-xs capitalize text-[#8A817B]">{note}</p></div>;
-}
-
-function ReportsPanel({ reports, busy, onGenerate }: { reports: Report[]; busy: string | null; onGenerate: (period: "weekly" | "monthly") => void }) {
-  return (
-    <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">Executive performance reports</h3><p className="mt-1 text-xs text-[#827A74]">Narrative summaries grounded in profile analytics and estimates.</p></div><div className="flex gap-2"><button type="button" onClick={() => onGenerate("weekly")} disabled={busy !== null} className="rounded-xl border border-[#DAD1CA] px-3 py-2 text-xs font-semibold disabled:opacity-50">{busy === "report-weekly" ? "Generating…" : "Weekly report"}</button><button type="button" onClick={() => onGenerate("monthly")} disabled={busy !== null} className="rounded-xl bg-[#8B1E2D] px-3 py-2 text-xs font-semibold text-white disabled:opacity-50">{busy === "report-monthly" ? "Generating…" : "Monthly report"}</button></div></div>{reports.length ? <div className="mt-5 space-y-3">{reports.map((report) => <article key={report.id} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex flex-wrap items-center justify-between gap-2"><p className="text-xs font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">{report.period_type} report</p><span className="text-[10px] text-[#8A817B]">{report.period_start} – {report.period_end}</span></div><p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#514B46]">{report.narrative || "Report generated without a narrative."}</p></article>)}</div> : <EmptyState icon={BarChart3} title="No reports generated" copy="Create a weekly or monthly executive summary." />}</section>
-  );
+function Reports({ reports, busy, onGenerate }: { reports: Report[]; busy: string | null; onGenerate: (period: "weekly" | "monthly") => void }) {
+  return <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center"><div><h3 className="font-semibold">Executive reports</h3><p className="mt-1 text-xs text-[#827A74]">Weekly and monthly summaries grounded in profile analytics.</p></div><div className="flex gap-2"><button type="button" onClick={() => onGenerate("weekly")} disabled={busy !== null} className="rounded-xl border border-[#DAD1CA] px-3 py-2 text-xs font-semibold disabled:opacity-50">{busy === "report-weekly" ? "Generating…" : "Weekly"}</button><button type="button" onClick={() => onGenerate("monthly")} disabled={busy !== null} className="rounded-xl bg-[#8B1E2D] px-3 py-2 text-xs font-semibold text-white disabled:opacity-50">{busy === "report-monthly" ? "Generating…" : "Monthly"}</button></div></div>{reports.length ? <div className="mt-5 space-y-3">{reports.map((report) => <article key={report.id} className="rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-4"><div className="flex flex-wrap justify-between gap-2"><p className="text-xs font-bold uppercase tracking-[0.12em] text-[#8B1E2D]">{report.period_type} report</p><span className="text-[10px] text-[#8A817B]">{report.period_start} – {report.period_end}</span></div><p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#514B46]">{report.narrative || "Report generated."}</p></article>)}</div> : <Empty icon={BarChart3} title="No reports generated" copy="Create a weekly or monthly executive summary." />}</section>;
 }
 
 function TrustSignals({ profile }: { profile: Profile }) {
-  const signals = [
-    { label: "ID Verified", complete: Boolean(profile.is_verified_identity) },
-    { label: "Phone Verified", complete: Boolean(profile.is_verified_phone) },
-    { label: "Email Verified", complete: Boolean(profile.is_verified_email) },
-    { label: "Photos Verified", complete: Boolean(profile.is_verified_photos) },
-  ];
-  return <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-[#8B1E2D]" /><div><h3 className="font-semibold">Trust Signals</h3><p className="text-xs text-[#827A74]">Build confidence with visible, verified profile details.</p></div></div><div className="mt-4 flex flex-wrap gap-2">{signals.map((signal) => <span key={signal.label} className={`inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-semibold ${signal.complete ? "bg-[#EDF7EF] text-[#347348]" : "bg-[#F7F2EE] text-[#756D67]"}`}>{signal.complete ? <Check className="h-3.5 w-3.5" /> : <X className="h-3.5 w-3.5" />}{signal.label}</span>)}</div></section>;
+  const signals = [["ID Verified", profile.is_verified_identity], ["Phone Verified", profile.is_verified_phone], ["Email Verified", profile.is_verified_email], ["Photos Verified", profile.is_verified_photos]];
+  return <section className="rounded-3xl border border-[#E9E2DC] bg-white p-5 shadow-sm"><h3 className="flex items-center gap-2 font-semibold"><ShieldCheck className="h-5 w-5 text-[#8B1E2D]" />Trust Signals</h3><p className="mt-1 text-xs text-[#827A74]">Visible verification helps clients feel confident.</p><div className="mt-4 flex flex-wrap gap-2">{signals.map(([label, complete]) => <span key={String(label)} className={`inline-flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-semibold ${complete ? "bg-[#EDF7EF] text-[#347348]" : "bg-[#F7F2EE] text-[#756D67]"}`}>{complete ? <Check className="h-3.5 w-3.5" /> : <X className="h-3.5 w-3.5" />}{label}</span>)}</div></section>;
 }
 
-function CoachPanel({ firstName, analysis, busy, chatMessage, chatAnswer, onClose, onMessageChange, onSend, onRecommendation }: { firstName: string; analysis: Analysis; busy: string | null; chatMessage: string; chatAnswer: string | null; onClose: () => void; onMessageChange: (value: string) => void; onSend: () => void; onRecommendation: (recommendation: Recommendation) => void }) {
-  return (
-    <aside className="sticky top-0 hidden h-dvh overflow-y-auto bg-[#FBFAF8] px-4 py-5 2xl:block">
-      <div className="rounded-3xl border border-[#E6DED7] bg-white p-4 shadow-[0_18px_50px_rgba(61,43,33,0.06)]">
-        <div className="flex items-start justify-between"><div><div className="flex items-center gap-2"><Sparkles className="h-5 w-5 text-[#8B1E2D]" /><h2 className="text-lg font-semibold">AI Profile Coach</h2><span className="rounded-full bg-[#F9EDEE] px-2 py-0.5 text-[9px] font-bold uppercase text-[#8B1E2D]">Beta</span></div><p className="mt-1 text-xs text-[#827A74]">Personalized profile optimization assistant.</p></div><button type="button" onClick={onClose} aria-label="Close AI coach" className="rounded-lg p-1.5 text-[#817873] hover:bg-[#F5F0EC]"><X className="h-4 w-4" /></button></div>
-        <div className="mt-4 rounded-2xl bg-gradient-to-br from-[#FFF8F2] to-[#FFF5F6] p-4"><p className="text-sm leading-6 text-[#504844]">Hi {firstName}! I reviewed your profile, market signals, and recent activity. Your score is <strong>{analysis.scores.overall}/100</strong>. Let&apos;s work through the highest-impact improvements.</p></div>
-        <div className="mt-5 flex items-center justify-between"><h3 className="text-sm font-semibold">Your Action Plan</h3><span className="text-[10px] text-[#8A817B]">{analysis.recommendations.length} suggestions</span></div>
-        <div className="mt-3 space-y-2.5">{analysis.recommendations.slice(0, 6).map((item) => <button key={item.key} type="button" onClick={() => onRecommendation(item)} className="group flex w-full items-start gap-3 rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-3 text-left transition hover:border-[#CFBFB4]"><div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F9EDEE] text-[#8B1E2D]"><Zap className="h-4 w-4" /></div><div className="min-w-0 flex-1"><div className="flex items-start justify-between gap-2"><p className="text-xs font-semibold">{item.title}</p><span className={`shrink-0 rounded-full px-2 py-0.5 text-[8px] font-bold uppercase ${impactStyle[item.impact]}`}>{item.impact}</span></div><p className="mt-1 text-[10px] leading-4 text-[#817873]">{item.action}</p></div><ChevronRight className="mt-1 h-4 w-4 text-[#B8AEA7] transition group-hover:translate-x-0.5" /></button>)}</div>
-        {chatAnswer && <div className="mt-4 rounded-2xl border border-[#E4D8D0] bg-[#FFF9F4] p-4 text-xs leading-5 text-[#5C524D]">{chatAnswer}</div>}
-        <div className="mt-4 flex items-center gap-2 rounded-2xl border border-[#E4DCD5] bg-white p-2 shadow-inner"><input value={chatMessage} onChange={(event) => onMessageChange(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); onSend(); } }} placeholder="Ask your AI coach anything…" className="min-w-0 flex-1 bg-transparent px-2 py-2 text-xs outline-none placeholder:text-[#A69D96]" /><button type="button" onClick={onSend} disabled={busy !== null || !chatMessage.trim()} aria-label="Send message" className="flex h-9 w-9 items-center justify-center rounded-full bg-[#8B1E2D] text-white disabled:opacity-40">{busy === "chat" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</button></div>
-        <p className="mt-2 text-center text-[9px] leading-4 text-[#9B928B]">AI recommendations and forecasts are estimates. Review changes before applying them.</p>
-      </div>
-    </aside>
-  );
+function CoachPanel({ firstName, analysis, busy, message, answer, onMessage, onSend, onClose, onAction }: { firstName: string; analysis: Analysis; busy: string | null; message: string; answer: string | null; onMessage: (value: string) => void; onSend: () => void; onClose: () => void; onAction: (recommendation: Recommendation) => void }) {
+  return <aside className="sticky top-0 hidden h-dvh overflow-y-auto bg-[#FBFAF8] px-4 py-5 2xl:block"><div className="rounded-3xl border border-[#E6DED7] bg-white p-4 shadow-[0_18px_50px_rgba(61,43,33,0.06)]"><div className="flex items-start justify-between"><div><div className="flex items-center gap-2"><Sparkles className="h-5 w-5 text-[#8B1E2D]" /><h2 className="text-lg font-semibold">AI Profile Coach</h2><span className="rounded-full bg-[#F9EDEE] px-2 py-0.5 text-[9px] font-bold uppercase text-[#8B1E2D]">Beta</span></div><p className="mt-1 text-xs text-[#827A74]">Your profile optimization assistant.</p></div><button type="button" onClick={onClose} aria-label="Close coach"><X className="h-4 w-4 text-[#817873]" /></button></div><div className="mt-4 rounded-2xl bg-gradient-to-br from-[#FFF8F2] to-[#FFF5F6] p-4"><p className="text-sm leading-6 text-[#504844]">Hi {firstName}! Your profile score is <strong>{analysis.scores.overall}/100</strong>. I reviewed your profile, market, and recent activity to prioritize the best next actions.</p></div><div className="mt-5 flex items-center justify-between"><h3 className="text-sm font-semibold">Your Action Plan</h3><span className="text-[10px] text-[#8A817B]">{analysis.recommendations.length} suggestions</span></div><div className="mt-3 space-y-2.5">{analysis.recommendations.slice(0, 6).map((item) => <button key={item.key} type="button" onClick={() => onAction(item)} className="flex w-full items-start gap-3 rounded-2xl border border-[#EEE7E1] bg-[#FFFCFA] p-3 text-left"><div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F9EDEE] text-[#8B1E2D]"><Zap className="h-4 w-4" /></div><div className="min-w-0 flex-1"><div className="flex items-start justify-between gap-2"><p className="text-xs font-semibold">{item.title}</p><span className={`rounded-full px-2 py-0.5 text-[8px] font-bold uppercase ${IMPACT_CLASS[item.impact]}`}>{item.impact}</span></div><p className="mt-1 text-[10px] leading-4 text-[#817873]">{item.action}</p></div><ChevronRight className="h-4 w-4 text-[#B8AEA7]" /></button>)}</div>{answer && <div className="mt-4 rounded-2xl border border-[#E4D8D0] bg-[#FFF9F4] p-4 text-xs leading-5 text-[#5C524D]">{answer}</div>}<div className="mt-4 flex items-center gap-2 rounded-2xl border border-[#E4DCD5] bg-white p-2"><input value={message} onChange={(event) => onMessage(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); onSend(); } }} placeholder="Ask your AI coach anything…" className="min-w-0 flex-1 bg-transparent px-2 py-2 text-xs outline-none" /><button type="button" onClick={onSend} disabled={busy !== null || !message.trim()} aria-label="Send message" className="flex h-9 w-9 items-center justify-center rounded-full bg-[#8B1E2D] text-white disabled:opacity-40">{busy === "chat" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}</button></div><p className="mt-2 text-center text-[9px] leading-4 text-[#9B928B]">AI suggestions and forecasts are estimates. Review changes before applying.</p></div></aside>;
 }
 
-function EmptyState({ icon: Icon, title, copy, href, action }: { icon: LucideIcon; title: string; copy: string; href?: string; action?: string }) {
-  return <div className="mt-5 flex min-h-44 flex-col items-center justify-center rounded-2xl border border-dashed border-[#DCD2CA] bg-[#FCF9F6] p-6 text-center"><Icon className="h-8 w-8 text-[#B1A69E]" /><p className="mt-3 text-sm font-semibold">{title}</p><p className="mt-1 max-w-sm text-xs leading-5 text-[#817873]">{copy}</p>{href && action && <Link href={href} className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-[#8B1E2D]">{action}<ArrowRight className="h-3.5 w-3.5" /></Link>}</div>;
+function Empty({ icon: Icon, title, copy, href }: { icon: LucideIcon; title: string; copy: string; href?: string }) {
+  return <div className="mt-5 flex min-h-44 flex-col items-center justify-center rounded-2xl border border-dashed border-[#DCD2CA] bg-[#FCF9F6] p-6 text-center"><Icon className="h-8 w-8 text-[#B1A69E]" /><p className="mt-3 text-sm font-semibold">{title}</p><p className="mt-1 max-w-sm text-xs leading-5 text-[#817873]">{copy}</p>{href && <Link href={href} className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-[#8B1E2D]">Continue <ArrowRight className="h-3.5 w-3.5" /></Link>}</div>;
 }

--- a/src/lib/ai/profile-coach.ts
+++ b/src/lib/ai/profile-coach.ts
@@ -1,0 +1,629 @@
+import { envAny } from "@/app/api/_lib/env";
+import { chatMessages, completeText, OPENAI_MODEL, type LlmResult } from "@/lib/ai/llm";
+
+export type CoachImpact = "high" | "medium" | "low";
+
+export type CoachProfile = {
+  id: string;
+  display_name: string | null;
+  full_name: string | null;
+  headline: string | null;
+  tagline: string | null;
+  bio: string | null;
+  city: string | null;
+  state: string | null;
+  neighborhood: string | null;
+  slug: string | null;
+  photo_url: string | null;
+  avatar_url: string | null;
+  massage_techniques: string[] | null;
+  modalities: string[] | null;
+  specialties: string[] | null;
+  service_categories: string[] | null;
+  languages: string[] | null;
+  languages_spoken: string[] | null;
+  years_experience: number | null;
+  offers_incall: boolean | null;
+  offers_outcall: boolean | null;
+  incall: boolean | null;
+  outcall: boolean | null;
+  starting_price: number | null;
+  starting_rate: number | null;
+  incall_price: number | null;
+  outcall_price: number | null;
+  pricing_sessions: unknown;
+  rates: unknown;
+  session_lengths: number[] | null;
+  incall_amenities: string[] | null;
+  studio_amenities: string[] | null;
+  payment_methods: string[] | null;
+  areas_served: string[] | null;
+  travel_schedule: unknown;
+  business_trips: unknown;
+  education_entries: unknown;
+  certifications: string | null;
+  training: string | null;
+  is_verified_phone: boolean | null;
+  is_verified_email: boolean | null;
+  is_verified_identity: boolean | null;
+  is_verified_profile: boolean | null;
+  is_verified_photos: boolean | null;
+  lgbtq_affirming: boolean | null;
+  accepts_all_genders: boolean | null;
+  available_now: boolean | null;
+  is_featured: boolean | null;
+  seo_title: string | null;
+  seo_description: string | null;
+  seo_keywords: string[] | null;
+  review_count: number | null;
+  average_rating: number | string | null;
+  subscription_tier: string | null;
+  visibility_status: string | null;
+  profile_status: string | null;
+};
+
+export type CoachPhoto = {
+  id: string;
+  url: string | null;
+  storage_path: string | null;
+  is_primary: boolean | null;
+  moderation_status: string | null;
+  sort_order: number | null;
+};
+
+export type PhotoScore = {
+  photo_id: string;
+  overall_score: number;
+  pose_score: number;
+  lighting_score: number;
+  smile_score: number;
+  composition_score: number;
+  background_score: number;
+  professionalism_score: number;
+  sharpness_score: number;
+  thumbnail_score: number;
+  predicted_ctr_lift_pct: number;
+  recommended_primary: boolean;
+  strengths: string[];
+  improvements: string[];
+  recommendation: string;
+  analysis_mode: "vision" | "metadata";
+  provider: string | null;
+  model: string | null;
+};
+
+export type CoachRecommendation = {
+  key: string;
+  title: string;
+  reason: string;
+  action: string;
+  impact: CoachImpact;
+  href: string;
+  estimatedLift: number;
+};
+
+export type CoachAnalysis = {
+  scores: {
+    overall: number;
+    completion: number;
+    content: number;
+    trust: number;
+    visibility: number;
+    conversion: number;
+    seo: number;
+    photos: number;
+  };
+  metrics: {
+    views1d: number;
+    views7d: number;
+    views30d: number;
+    contacts1d: number;
+    contacts7d: number;
+    contacts30d: number;
+    favorites7d: number;
+    inquiries7d: number;
+    contactRate: number;
+  };
+  ranking: {
+    current: number | null;
+    previous: number | null;
+    change: number | null;
+    explanation: string;
+  };
+  forecast: {
+    contactsLow: number;
+    contactsLikely: number;
+    contactsHigh: number;
+    viewsLikely: number;
+    confidence: number;
+  };
+  market: {
+    demandScore: number | null;
+    demandTrend: string;
+    competitionIndex: number | null;
+    searchVolumeIndex: number | null;
+    topKeywords: Array<{ keyword: string; score: number; trend: string }>;
+  };
+  benchmark: {
+    cityProfileCount: number;
+    cityAverageScore: number;
+    top10AverageScore: number;
+    percentile: number;
+    pointsToTop10: number;
+  };
+  recommendations: CoachRecommendation[];
+  missingFields: string[];
+  completedFields: string[];
+  strongestKeyword: string | null;
+  photoScores: PhotoScore[];
+  history: Array<{ date: string; overall: number; visibility: number; trust: number; content: number; conversion: number }>;
+};
+
+type Snapshot = {
+  snapshot_date: string;
+  profile_score: number;
+  visibility_score: number;
+  trust_score: number;
+  content_score: number;
+  conversion_score: number;
+};
+
+type RankingEvent = { position_in_results: number | null; created_at: string | null };
+type KeywordTrend = { keyword: string; score: number; trend_direction: string | null; week_over_week_change: number | null };
+type MarketRow = { score: number; trend: string; competition_index: number; search_volume_index: number } | null;
+type Metrics = {
+  views1d: number;
+  views7d: number;
+  views30d: number;
+  contacts1d: number;
+  contacts7d: number;
+  contacts30d: number;
+  favorites7d: number;
+  inquiries7d: number;
+};
+
+type AnalysisInput = {
+  profile: CoachProfile;
+  photos: CoachPhoto[];
+  photoScores: PhotoScore[];
+  snapshots: Snapshot[];
+  rankings: RankingEvent[];
+  keywords: KeywordTrend[];
+  market: MarketRow;
+  metrics: Metrics;
+  competitorScores: number[];
+};
+
+const clamp = (value: number, min = 0, max = 100) => Math.max(min, Math.min(max, Math.round(value)));
+const listLength = (value: unknown) => (Array.isArray(value) ? value.length : 0);
+const hasText = (value: unknown, min = 1) => typeof value === "string" && value.trim().length >= min;
+const hasValue = (value: unknown) => value !== null && value !== undefined;
+
+export function quickProfileScore(profile: Partial<CoachProfile>, approvedPhotoCount = 0): number {
+  let points = 0;
+  points += hasText(profile.headline, 25) ? 10 : 0;
+  points += hasText(profile.tagline, 15) ? 5 : 0;
+  points += hasText(profile.bio, 250) ? 15 : hasText(profile.bio, 100) ? 8 : 0;
+  points += listLength(profile.massage_techniques) + listLength(profile.modalities) >= 3 ? 10 : 4;
+  points += listLength(profile.languages) + listLength(profile.languages_spoken) >= 1 ? 5 : 0;
+  points += (profile.years_experience ?? 0) > 0 ? 5 : 0;
+  points += approvedPhotoCount >= 3 ? 10 : approvedPhotoCount > 0 ? 5 : 0;
+  points += profile.is_verified_identity ? 8 : 0;
+  points += profile.is_verified_phone ? 4 : 0;
+  points += profile.is_verified_email ? 3 : 0;
+  points += hasText(profile.city) && hasText(profile.state) ? 5 : 0;
+  points += hasValue(profile.starting_price) || hasValue(profile.starting_rate) || hasValue(profile.incall_price) ? 5 : 0;
+  points += listLength(profile.areas_served) > 0 ? 3 : 0;
+  points += profile.available_now ? 2 : 0;
+  return clamp(points);
+}
+
+function scoreProfile(profile: CoachProfile, approvedPhotoCount: number, avgPhotoScore: number) {
+  const completed: string[] = [];
+  const missing: string[] = [];
+  const mark = (ok: boolean, key: string) => (ok ? completed.push(key) : missing.push(key));
+
+  const techniqueCount = new Set([
+    ...(profile.massage_techniques ?? []),
+    ...(profile.modalities ?? []),
+    ...(profile.specialties ?? []),
+  ]).size;
+  const languageCount = new Set([...(profile.languages ?? []), ...(profile.languages_spoken ?? [])]).size;
+  const amenities = new Set([...(profile.incall_amenities ?? []), ...(profile.studio_amenities ?? [])]).size;
+  const hasPricing = [profile.starting_price, profile.starting_rate, profile.incall_price, profile.outcall_price].some(hasValue)
+    || hasValue(profile.pricing_sessions)
+    || hasValue(profile.rates);
+  const hasCredentials = listLength(profile.education_entries) > 0 || hasText(profile.certifications) || hasText(profile.training);
+
+  mark(hasText(profile.headline, 25), "headline");
+  mark(hasText(profile.tagline, 15), "tagline");
+  mark(hasText(profile.bio, 250), "bio");
+  mark(techniqueCount >= 3, "techniques");
+  mark(languageCount > 0, "languages");
+  mark((profile.years_experience ?? 0) > 0, "experience");
+  mark(hasCredentials, "credentials");
+  mark(approvedPhotoCount >= 3, "gallery");
+  mark(Boolean(profile.is_verified_identity), "identity_verification");
+  mark(Boolean(profile.is_verified_photos), "photo_verification");
+  mark(Boolean(profile.is_verified_phone), "phone_verification");
+  mark(hasPricing, "pricing");
+  mark(amenities > 0, "amenities");
+  mark((profile.areas_served?.length ?? 0) > 0, "areas_served");
+  mark(hasText(profile.neighborhood), "neighborhood");
+  mark((profile.payment_methods?.length ?? 0) > 0, "payment_methods");
+
+  const content = clamp(
+    (hasText(profile.headline, 25) ? 18 : 5)
+      + (hasText(profile.tagline, 15) ? 8 : 0)
+      + (hasText(profile.bio, 250) ? 28 : hasText(profile.bio, 100) ? 15 : 0)
+      + Math.min(18, techniqueCount * 4)
+      + Math.min(8, languageCount * 4)
+      + ((profile.years_experience ?? 0) > 0 ? 10 : 0)
+      + (hasCredentials ? 10 : 0),
+  );
+  const trust = clamp(
+    (profile.is_verified_identity ? 25 : 0)
+      + (profile.is_verified_photos ? 18 : 0)
+      + (profile.is_verified_phone ? 12 : 0)
+      + (profile.is_verified_email ? 10 : 0)
+      + Math.min(15, approvedPhotoCount * 5)
+      + ((profile.review_count ?? 0) > 0 ? 10 : 0)
+      + (profile.lgbtq_affirming || profile.accepts_all_genders ? 10 : 0),
+  );
+  const visibility = clamp(
+    (hasText(profile.city) && hasText(profile.state) ? 20 : 0)
+      + (hasText(profile.neighborhood) ? 10 : 0)
+      + Math.min(15, (profile.areas_served?.length ?? 0) * 4)
+      + (profile.offers_incall || profile.incall ? 10 : 0)
+      + (profile.offers_outcall || profile.outcall ? 10 : 0)
+      + (profile.available_now ? 15 : 0)
+      + (profile.is_featured ? 10 : 0)
+      + (hasText(profile.slug) ? 10 : 0),
+  );
+  const conversion = clamp(
+    (hasPricing ? 25 : 0)
+      + ((profile.session_lengths?.length ?? 0) > 0 ? 10 : 0)
+      + (amenities > 0 ? 15 : 0)
+      + ((profile.payment_methods?.length ?? 0) > 0 ? 10 : 0)
+      + (hasText(profile.bio, 250) ? 15 : 5)
+      + (approvedPhotoCount >= 3 ? 15 : 5)
+      + ((profile.review_count ?? 0) > 0 ? 10 : 0),
+  );
+  const seoKeywordCount = new Set([...(profile.seo_keywords ?? []), ...(profile.massage_techniques ?? []), ...(profile.modalities ?? [])]).size;
+  const seo = clamp(
+    (hasText(profile.seo_title, 30) ? 25 : 0)
+      + (hasText(profile.seo_description, 100) ? 25 : 0)
+      + Math.min(25, seoKeywordCount * 4)
+      + (hasText(profile.headline, 25) ? 15 : 0)
+      + (hasText(profile.city) && hasText(profile.state) ? 10 : 0),
+  );
+  const photos = approvedPhotoCount === 0 ? 0 : clamp(avgPhotoScore || Math.min(88, 48 + approvedPhotoCount * 8));
+  const completion = clamp((completed.length / (completed.length + missing.length)) * 100);
+  const overall = clamp(content * 0.22 + trust * 0.2 + visibility * 0.18 + conversion * 0.16 + seo * 0.14 + photos * 0.1);
+
+  return { content, trust, visibility, conversion, seo, photos, completion, overall, completed, missing };
+}
+
+function buildRecommendations(profile: CoachProfile, scores: ReturnType<typeof scoreProfile>, approvedPhotoCount: number): CoachRecommendation[] {
+  const items: CoachRecommendation[] = [];
+  const add = (item: CoachRecommendation) => items.push(item);
+
+  if (!hasText(profile.headline, 25)) add({ key: "headline", title: "Improve your headline", reason: "Your headline is missing or too generic to communicate value in search results.", action: "Use a specialty + benefit + city headline.", impact: "high", href: "/pro/listing", estimatedLift: 18 });
+  if (!hasText(profile.bio, 250)) add({ key: "bio", title: "Strengthen your bio", reason: "Clients need more detail before they feel ready to contact you.", action: "Add your approach, experience, techniques, and what a client can expect.", impact: "high", href: "/pro/listing", estimatedLift: 16 });
+  if (approvedPhotoCount < 3) add({ key: "photos", title: "Add verified photos", reason: `Your profile has ${approvedPhotoCount} approved photo${approvedPhotoCount === 1 ? "" : "s"}.`, action: "Upload at least three clear, current, varied photos.", impact: "high", href: "/pro/photos", estimatedLift: 15 });
+  if (!profile.is_verified_identity || !profile.is_verified_photos) add({ key: "trust", title: "Complete trust verification", reason: "Verified identity and photos help clients feel confident before contacting you.", action: "Complete the remaining verification steps.", impact: "high", href: "/pro/settings", estimatedLift: 13 });
+  if (![profile.starting_price, profile.starting_rate, profile.incall_price, profile.outcall_price].some(hasValue) && !hasValue(profile.pricing_sessions) && !hasValue(profile.rates)) add({ key: "pricing", title: "Publish clear rates", reason: "Missing rates can reduce qualified contacts and increase abandoned visits.", action: "Add session duration and incall/outcall starting rates.", impact: "high", href: "/pro/rates", estimatedLift: 12 });
+  if ((profile.incall_amenities?.length ?? 0) + (profile.studio_amenities?.length ?? 0) === 0) add({ key: "amenities", title: "Clarify your amenities", reason: "Clients want to know what is available before they reach out.", action: "Add parking, shower, table setup, and other relevant amenities.", impact: "medium", href: "/pro/listing", estimatedLift: 8 });
+  if ((profile.areas_served?.length ?? 0) === 0 || !hasText(profile.neighborhood)) add({ key: "local", title: "Improve local visibility", reason: "Neighborhood and service-area details improve relevance in nearby searches.", action: "Add your neighborhood and service areas without publishing an exact address.", impact: "medium", href: "/pro/listing", estimatedLift: 9 });
+  if (!profile.available_now) add({ key: "availability", title: "Refresh availability", reason: "Fresh availability signals can increase engagement from clients ready to contact now.", action: "Update your hours or activate Available Now when appropriate.", impact: "medium", href: "/pro/growth", estimatedLift: 7 });
+  if (scores.seo < 75) add({ key: "seo", title: "Improve profile SEO", reason: "Your profile is missing search-friendly title, description, or keyword coverage.", action: "Generate an SEO-focused version using the AI writer.", impact: "medium", href: "/pro/ai-coach?tab=writer", estimatedLift: 11 });
+
+  if (items.length === 0) add({ key: "maintain", title: "Keep your profile fresh", reason: "Your profile is in strong condition.", action: "Review availability and add one recent photo this month.", impact: "low", href: "/pro/photos", estimatedLift: 3 });
+  const order: Record<CoachImpact, number> = { high: 0, medium: 1, low: 2 };
+  return items.sort((a, b) => order[a.impact] - order[b.impact] || b.estimatedLift - a.estimatedLift).slice(0, 8);
+}
+
+function rankingInsight(rankings: RankingEvent[]) {
+  const valid = rankings.filter((row) => row.position_in_results && row.created_at);
+  if (!valid.length) return { current: null, previous: null, change: null, explanation: "Ranking history will appear after your profile is shown in search results." };
+  const grouped = new Map<string, number[]>();
+  valid.forEach((row) => {
+    const date = String(row.created_at).slice(0, 10);
+    grouped.set(date, [...(grouped.get(date) ?? []), Number(row.position_in_results)]);
+  });
+  const dates = [...grouped.keys()].sort().reverse();
+  const average = (values: number[]) => Math.round(values.reduce((sum, value) => sum + value, 0) / Math.max(1, values.length));
+  const current = average(grouped.get(dates[0]) ?? []);
+  const previous = dates[1] ? average(grouped.get(dates[1]) ?? []) : null;
+  const change = previous === null ? null : previous - current;
+  const explanation = change === null
+    ? `Your current average search position is #${current}. More history is needed to explain movement.`
+    : change > 0
+      ? `You gained ${change} position${change === 1 ? "" : "s"}, supported by stronger profile freshness and relevance signals.`
+      : change < 0
+        ? `You lost ${Math.abs(change)} position${Math.abs(change) === 1 ? "" : "s"}. Common causes are fresher nearby profiles, stronger verification, new photos, or a temporary demand shift.`
+        : `Your average position held steady at #${current}. Completing a high-impact task is the clearest next move.`;
+  return { current, previous, change, explanation };
+}
+
+function forecast(metrics: Metrics, history: Snapshot[]) {
+  const recentDailyContacts = metrics.contacts7d / 7;
+  const monthlyDailyContacts = metrics.contacts30d / 30;
+  const velocity = recentDailyContacts > 0 ? recentDailyContacts : monthlyDailyContacts;
+  const scoreTrend = history.length > 1 ? history[0].profile_score - history[Math.min(history.length - 1, 6)].profile_score : 0;
+  const trendFactor = Math.max(0.75, Math.min(1.35, 1 + scoreTrend / 100));
+  const likely = Math.max(0, Math.round(velocity * 7 * trendFactor));
+  const viewsLikely = Math.max(metrics.views7d, Math.round((metrics.views30d / 30) * 7 * trendFactor));
+  const sample = metrics.views30d + metrics.contacts30d;
+  const confidence = clamp(45 + Math.min(35, sample / 4) + Math.min(15, history.length * 2), 45, 92);
+  return {
+    contactsLow: Math.max(0, Math.floor(likely * 0.72)),
+    contactsLikely: likely,
+    contactsHigh: Math.max(likely, Math.ceil(likely * 1.32)),
+    viewsLikely,
+    confidence,
+  };
+}
+
+export function buildCoachAnalysis(input: AnalysisInput): CoachAnalysis {
+  const approvedPhotos = input.photos.filter((photo) => photo.moderation_status === "approved");
+  const avgPhotoScore = input.photoScores.length
+    ? input.photoScores.reduce((sum, item) => sum + item.overall_score, 0) / input.photoScores.length
+    : 0;
+  const scores = scoreProfile(input.profile, approvedPhotos.length, avgPhotoScore);
+  const contactRate = input.metrics.views7d > 0 ? Number(((input.metrics.contacts7d / input.metrics.views7d) * 100).toFixed(1)) : 0;
+  const sortedCompetitors = input.competitorScores.filter(Number.isFinite).sort((a, b) => b - a).slice(0, 100);
+  const cityAverageScore = sortedCompetitors.length ? Math.round(sortedCompetitors.reduce((a, b) => a + b, 0) / sortedCompetitors.length) : scores.overall;
+  const top10 = sortedCompetitors.slice(0, 10);
+  const top10AverageScore = top10.length ? Math.round(top10.reduce((a, b) => a + b, 0) / top10.length) : scores.overall;
+  const below = sortedCompetitors.filter((value) => value <= scores.overall).length;
+  const percentile = sortedCompetitors.length ? clamp((below / sortedCompetitors.length) * 100, 1, 99) : 50;
+  const topKeywords = input.keywords
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 6)
+    .map((row) => ({ keyword: row.keyword, score: row.score, trend: row.trend_direction ?? (row.week_over_week_change && row.week_over_week_change > 0 ? "up" : "stable") }));
+  const strongestKeyword = topKeywords[0]?.keyword ?? null;
+
+  return {
+    scores: {
+      overall: scores.overall,
+      completion: scores.completion,
+      content: scores.content,
+      trust: scores.trust,
+      visibility: scores.visibility,
+      conversion: scores.conversion,
+      seo: scores.seo,
+      photos: scores.photos,
+    },
+    metrics: { ...input.metrics, contactRate },
+    ranking: rankingInsight(input.rankings),
+    forecast: forecast(input.metrics, input.snapshots),
+    market: {
+      demandScore: input.market?.score ?? null,
+      demandTrend: input.market?.trend ?? "stable",
+      competitionIndex: input.market?.competition_index ?? null,
+      searchVolumeIndex: input.market?.search_volume_index ?? null,
+      topKeywords,
+    },
+    benchmark: {
+      cityProfileCount: sortedCompetitors.length,
+      cityAverageScore,
+      top10AverageScore,
+      percentile,
+      pointsToTop10: Math.max(0, top10AverageScore - scores.overall),
+    },
+    recommendations: buildRecommendations(input.profile, scores, approvedPhotos.length),
+    missingFields: scores.missing,
+    completedFields: scores.completed,
+    strongestKeyword,
+    photoScores: input.photoScores,
+    history: input.snapshots
+      .slice()
+      .reverse()
+      .map((row) => ({
+        date: row.snapshot_date,
+        overall: row.profile_score,
+        visibility: row.visibility_score,
+        trust: row.trust_score,
+        content: row.content_score,
+        conversion: row.conversion_score,
+      })),
+  };
+}
+
+function fallbackRewrite(profile: CoachProfile, field: string) {
+  const firstTechnique = profile.massage_techniques?.[0] ?? profile.modalities?.[0] ?? profile.specialties?.[0] ?? "Professional Massage";
+  const secondTechnique = profile.massage_techniques?.[1] ?? profile.modalities?.[1] ?? "Bodywork";
+  const location = [profile.city, profile.state].filter(Boolean).join(", ") || "your area";
+  const years = profile.years_experience ? `${profile.years_experience} years of experience` : "an experienced approach";
+  if (field === "headline") return `${firstTechnique} & ${secondTechnique} Massage in ${location}`;
+  if (field === "tagline") return `Personalized bodywork focused on comfort, recovery, and genuine care.`;
+  if (field === "seo_title") return `${firstTechnique} Massage Therapist in ${location} | MasseurMatch`;
+  if (field === "seo_description") return `Discover personalized ${firstTechnique.toLowerCase()} and ${secondTechnique.toLowerCase()} sessions in ${location}. View services, rates, availability, and contact details.`;
+  return `I offer personalized ${firstTechnique.toLowerCase()} and ${secondTechnique.toLowerCase()} sessions in ${location}, backed by ${years}. Each session is tailored to your goals, preferred pressure, and comfort. My approach is professional, welcoming, and focused on helping you relax, recover, and feel your best. Review my services, rates, and availability, then contact me directly to plan your session.`;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const cleaned = text.replace(/^```(?:json)?/i, "").replace(/```$/i, "").trim();
+    const parsed = JSON.parse(cleaned);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function rewriteProfileField(profile: CoachProfile, field: "headline" | "tagline" | "bio" | "seo_title" | "seo_description") {
+  const fallback = fallbackRewrite(profile, field);
+  const result = await completeText({
+    system: "You are the MasseurMatch AI Profile Coach. Write professional, inclusive, non-sexual massage directory copy. Do not invent licenses, credentials, reviews, medical claims, bookings, or guarantees. Return strict JSON with suggested_text and rationale.",
+    user: JSON.stringify({
+      task: `Rewrite the provider ${field}`,
+      constraints: field === "headline" ? "Maximum 70 characters" : field === "tagline" ? "Maximum 120 characters" : field === "bio" ? "220-420 words, warm and natural" : field === "seo_title" ? "Maximum 60 characters" : "Maximum 155 characters",
+      profile: {
+        name: profile.display_name ?? profile.full_name,
+        city: profile.city,
+        state: profile.state,
+        techniques: profile.massage_techniques ?? profile.modalities ?? profile.specialties,
+        experience: profile.years_experience,
+        languages: profile.languages ?? profile.languages_spoken,
+        incall: profile.offers_incall ?? profile.incall,
+        outcall: profile.offers_outcall ?? profile.outcall,
+        current: profile[field],
+      },
+    }),
+    json: true,
+    temperature: 0.55,
+    maxTokens: field === "bio" ? 700 : 240,
+    timeoutMs: 12000,
+  });
+  const parsed = result ? parseJsonObject(result.text) : null;
+  const suggestedText = typeof parsed?.suggested_text === "string" && parsed.suggested_text.trim() ? parsed.suggested_text.trim() : fallback;
+  const rationale = typeof parsed?.rationale === "string" ? parsed.rationale.trim() : "Improves clarity, local relevance, and client confidence.";
+  return { suggestedText, rationale, provider: result?.provider ?? "deterministic", model: result?.model ?? "profile-coach-fallback" };
+}
+
+export async function generateOptimization(profile: CoachProfile, keywords: string[]) {
+  const fallback = {
+    headline: fallbackRewrite(profile, "headline"),
+    tagline: fallbackRewrite(profile, "tagline"),
+    bio: fallbackRewrite(profile, "bio"),
+    seo_title: fallbackRewrite(profile, "seo_title"),
+    seo_description: fallbackRewrite(profile, "seo_description"),
+    seo_keywords: [...new Set([...(profile.massage_techniques ?? []), ...(profile.modalities ?? []), ...keywords])].slice(0, 12),
+  };
+  const result = await completeText({
+    system: "You are the MasseurMatch AI Profile Coach. Optimize massage-provider profiles for clarity, trust, conversion, and local SEO. Keep copy professional, inclusive, non-sexual, natural, and factual. Never invent credentials, licensure, testimonials, or medical outcomes. Return strict JSON only.",
+    user: JSON.stringify({
+      task: "Create a complete optimization preview",
+      required_keys: ["headline", "tagline", "bio", "seo_title", "seo_description", "seo_keywords", "rationale"],
+      profile,
+      local_keywords: keywords.slice(0, 12),
+      limits: { headline: 70, tagline: 120, bio_words: "220-420", seo_title: 60, seo_description: 155, seo_keywords: 12 },
+    }),
+    json: true,
+    temperature: 0.55,
+    maxTokens: 1200,
+    timeoutMs: 16000,
+  });
+  const parsed = result ? parseJsonObject(result.text) : null;
+  const after = {
+    headline: typeof parsed?.headline === "string" ? parsed.headline.trim().slice(0, 160) : fallback.headline,
+    tagline: typeof parsed?.tagline === "string" ? parsed.tagline.trim().slice(0, 200) : fallback.tagline,
+    bio: typeof parsed?.bio === "string" ? parsed.bio.trim().slice(0, 4000) : fallback.bio,
+    seo_title: typeof parsed?.seo_title === "string" ? parsed.seo_title.trim().slice(0, 120) : fallback.seo_title,
+    seo_description: typeof parsed?.seo_description === "string" ? parsed.seo_description.trim().slice(0, 240) : fallback.seo_description,
+    seo_keywords: Array.isArray(parsed?.seo_keywords) ? parsed.seo_keywords.filter((value): value is string => typeof value === "string").slice(0, 12) : fallback.seo_keywords,
+  };
+  return {
+    after,
+    rationale: typeof parsed?.rationale === "string" ? parsed.rationale : "A coordinated rewrite improves profile clarity, keyword coverage, and conversion readiness.",
+    provider: result?.provider ?? "deterministic",
+    model: result?.model ?? "profile-coach-fallback",
+  };
+}
+
+export async function askProfileCoach(profile: CoachProfile, analysis: CoachAnalysis, message: string): Promise<LlmResult> {
+  return chatMessages([
+    {
+      role: "system",
+      content: "You are the MasseurMatch AI Profile Coach. Give concise, practical, professional, non-sexual advice grounded only in the supplied profile data. Do not promise rankings, contacts, bookings, or revenue. Clarify that forecasts are estimates. Never recommend publishing exact home addresses.",
+    },
+    {
+      role: "user",
+      content: JSON.stringify({ profile, analysis, question: message }),
+    },
+  ], { temperature: 0.55, maxTokens: 520, timeoutMs: 14000 });
+}
+
+function metadataPhotoScore(photo: CoachPhoto, index: number): PhotoScore {
+  const approved = photo.moderation_status === "approved";
+  const primary = Boolean(photo.is_primary);
+  const base = approved ? 68 : 48;
+  const overall = clamp(base + (primary ? 8 : 0) + Math.max(0, 5 - index) * 2, 35, 88);
+  return {
+    photo_id: photo.id,
+    overall_score: overall,
+    pose_score: clamp(overall - 2),
+    lighting_score: clamp(overall - 5),
+    smile_score: clamp(overall - 4),
+    composition_score: clamp(overall),
+    background_score: clamp(overall - 6),
+    professionalism_score: clamp(overall + 3),
+    sharpness_score: clamp(overall - 3),
+    thumbnail_score: clamp(overall + (primary ? 4 : 0)),
+    predicted_ctr_lift_pct: Math.max(0, Number(((overall - 60) * 0.35).toFixed(1))),
+    recommended_primary: primary || index === 0,
+    strengths: approved ? ["Approved for profile use", primary ? "Currently selected as primary" : "Adds gallery variety"].filter(Boolean) as string[] : ["Available for review"],
+    improvements: ["Run AI Vision for pose, lighting, expression, and background scoring"],
+    recommendation: approved ? "Keep the image current, clear, and visually distinct from the rest of the gallery." : "Complete moderation before using this image as a primary profile photo.",
+    analysis_mode: "metadata",
+    provider: null,
+    model: null,
+  };
+}
+
+export async function analyzePhoto(photo: CoachPhoto, index: number): Promise<PhotoScore> {
+  const imageUrl = photo.url;
+  const apiKey = envAny(["OPENAI_API_KEY"], "");
+  if (!apiKey || !imageUrl) return metadataPhotoScore(photo, index);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 18000);
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        temperature: 0.2,
+        max_tokens: 650,
+        response_format: { type: "json_object" },
+        messages: [
+          {
+            role: "system",
+            content: "You evaluate profile-photo presentation quality for a professional massage-provider directory. Assess only visible photographic qualities. Do not infer identity, ethnicity, health, personality, sexual content, or protected traits. Return JSON with integer scores 0-100 for overall, pose, lighting, smile_or_approachability, composition, background, professionalism, sharpness, thumbnail; numeric predicted_ctr_lift_pct; arrays strengths and improvements; recommendation; recommended_primary boolean.",
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Analyze this profile photo for professional directory presentation." },
+              { type: "image_url", image_url: { url: imageUrl, detail: "low" } },
+            ],
+          },
+        ],
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) return metadataPhotoScore(photo, index);
+    const payload = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+    const parsed = parseJsonObject(payload.choices?.[0]?.message?.content ?? "");
+    if (!parsed) return metadataPhotoScore(photo, index);
+    const score = (key: string, fallback: number) => clamp(typeof parsed[key] === "number" ? Number(parsed[key]) : fallback);
+    const fallback = metadataPhotoScore(photo, index);
+    return {
+      photo_id: photo.id,
+      overall_score: score("overall", fallback.overall_score),
+      pose_score: score("pose", fallback.pose_score),
+      lighting_score: score("lighting", fallback.lighting_score),
+      smile_score: score("smile_or_approachability", fallback.smile_score),
+      composition_score: score("composition", fallback.composition_score),
+      background_score: score("background", fallback.background_score),
+      professionalism_score: score("professionalism", fallback.professionalism_score),
+      sharpness_score: score("sharpness", fallback.sharpness_score),
+      thumbnail_score: score("thumbnail", fallback.thumbnail_score),
+      predicted_ctr_lift_pct: typeof parsed.predicted_ctr_lift_pct === "number" ? Number(parsed.predicted_ctr_lift_pct.toFixed(1)) : fallback.predicted_ctr_lift_pct,
+      recommended_primary: Boolean(parsed.recommended_primary),
+      strengths: Array.isArray(parsed.strengths) ? parsed.strengths.filter((value): value is string => typeof value === "string").slice(0, 5) : fallback.strengths,
+      improvements: Array.isArray(parsed.improvements) ? parsed.improvements.filter((value): value is string => typeof value === "string").slice(0, 5) : fallback.improvements,
+      recommendation: typeof parsed.recommendation === "string" ? parsed.recommendation : fallback.recommendation,
+      analysis_mode: "vision",
+      provider: "openai",
+      model: OPENAI_MODEL,
+    };
+  } catch {
+    return metadataPhotoScore(photo, index);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/supabase/migrations/20260711164130_add_profile_promotion_columns.sql
+++ b/supabase/migrations/20260711164130_add_profile_promotion_columns.sql
@@ -1,0 +1,13 @@
+-- Ensure the legacy therapist-to-profile promotion migration can run on a
+-- clean Supabase preview branch. Production already has these additive fields;
+-- IF NOT EXISTS keeps this safe and idempotent.
+
+alter table public.profiles
+  add column if not exists keyword_slugs text[] not null default '{}'::text[],
+  add column if not exists segments text[] not null default '{}'::text[];
+
+create index if not exists idx_profiles_keyword_slugs
+  on public.profiles using gin (keyword_slugs);
+
+create index if not exists idx_profiles_segments
+  on public.profiles using gin (segments);

--- a/supabase/migrations/20260720192213_prepare_rls_launch_v3_columns.sql
+++ b/supabase/migrations/20260720192213_prepare_rls_launch_v3_columns.sql
@@ -1,0 +1,63 @@
+-- Prepare the additive columns referenced by the legacy launch-v3 RLS
+-- migration. Production already contains these columns. The IF EXISTS / IF
+-- NOT EXISTS guards make this safe on both clean preview branches and the
+-- live schema without changing existing data or constraints.
+
+alter table if exists public.appointments
+  add column if not exists user_id uuid,
+  add column if not exists therapist_id uuid,
+  add column if not exists profile_id uuid;
+
+alter table if exists public.favorites
+  add column if not exists user_id uuid,
+  add column if not exists therapist_id uuid,
+  add column if not exists profile_id uuid;
+
+alter table if exists public.conversations
+  add column if not exists user_id uuid,
+  add column if not exists therapist_id uuid,
+  add column if not exists profile_id uuid;
+
+alter table if exists public.payment_transactions
+  add column if not exists user_id uuid,
+  add column if not exists therapist_id uuid;
+
+alter table if exists public.therapist_availability
+  add column if not exists therapist_id uuid,
+  add column if not exists profile_id uuid;
+
+alter table if exists public.user_mfa
+  add column if not exists user_id uuid;
+
+alter table if exists public.mfa_pending
+  add column if not exists user_id uuid;
+
+alter table if exists public.user_suspensions
+  add column if not exists user_id uuid;
+
+alter table if exists public.photo_moderations
+  add column if not exists therapist_id uuid;
+
+alter table if exists public.profile_reports
+  add column if not exists profile_id uuid;
+
+alter table if exists public.profile_status_debug_log
+  add column if not exists profile_id uuid;
+
+alter table if exists public.profile_status_invalid_log
+  add column if not exists profile_id uuid;
+
+alter table if exists public.imported_profile_data
+  add column if not exists profile_id uuid;
+
+alter table if exists public.therapist_learning_scores
+  add column if not exists profile_id uuid,
+  add column if not exists therapist_id uuid;
+
+alter table if exists public.profile_documents
+  add column if not exists profile_id uuid;
+
+alter table if exists public.profiles
+  add column if not exists boost_score integer default 0,
+  add column if not exists is_demo boolean not null default false,
+  add column if not exists canonical_city_slug text;

--- a/supabase/migrations/20260720192214_fix_rls_policies_launch_v3.sql
+++ b/supabase/migrations/20260720192214_fix_rls_policies_launch_v3.sql
@@ -1,161 +1,215 @@
 -- ============================================================
 -- MIGRATION: fix_rls_policies_launch_v3
--- RLS policies with correct column names + performance indexes
+-- Branch-safe RLS policies and performance indexes.
+-- Optional legacy tables are not present on every clean preview branch, so
+-- every policy and index is guarded by relation and column checks.
 -- ============================================================
 
-DO $$ BEGIN
-
--- 1. APPOINTMENTS (has: user_id, profile_id, therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='appointments' AND policyname='Users can view own appointments') THEN
-  CREATE POLICY "Users can view own appointments" ON public.appointments FOR SELECT USING (auth.uid() = user_id);
-END IF;
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='appointments' AND policyname='Users can insert own appointments') THEN
-  CREATE POLICY "Users can insert own appointments" ON public.appointments FOR INSERT WITH CHECK (auth.uid() = user_id);
-END IF;
-
--- 2. FAVORITES (has: user_id, profile_id, therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='favorites' AND policyname='Users can manage own favorites') THEN
-  CREATE POLICY "Users can manage own favorites" ON public.favorites FOR ALL USING (auth.uid() = user_id);
-END IF;
-
--- 3. CONVERSATIONS (has: user_id, profile_id, therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='conversations' AND policyname='Users can view own conversations') THEN
-  CREATE POLICY "Users can view own conversations" ON public.conversations FOR SELECT USING (auth.uid() = user_id OR auth.uid() = therapist_id);
-END IF;
-
--- 4. MESSAGES (has: id only — no user/profile col, link via conversation)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='messages' AND policyname='Users can view own messages') THEN
-  CREATE POLICY "Users can view own messages" ON public.messages FOR SELECT
-    USING (EXISTS (
-      SELECT 1 FROM conversations c
-      WHERE c.id = messages.id
-        AND (c.user_id = auth.uid() OR c.therapist_id = auth.uid())
-    ));
-END IF;
-
--- 5. PAYMENT_TRANSACTIONS (has: user_id, therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='payment_transactions' AND policyname='Users can view own payment transactions') THEN
-  CREATE POLICY "Users can view own payment transactions" ON public.payment_transactions FOR SELECT
-    USING (auth.uid() = user_id OR auth.uid() = therapist_id);
-END IF;
-
--- 6. THERAPIST_AVAILABILITY (has: profile_id, therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='therapist_availability' AND policyname='Public can read availability') THEN
-  CREATE POLICY "Public can read availability" ON public.therapist_availability FOR SELECT USING (true);
-END IF;
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='therapist_availability' AND policyname='Provider can manage own availability') THEN
-  CREATE POLICY "Provider can manage own availability" ON public.therapist_availability FOR ALL
-    USING (auth.uid() = therapist_id);
-END IF;
-
--- 7. SITE_SETTINGS (no user col — admin only via profiles)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='site_settings' AND policyname='Admins can manage site settings') THEN
-  CREATE POLICY "Admins can manage site settings" ON public.site_settings FOR ALL
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
--- 8. USER_MFA (has: user_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='user_mfa' AND policyname='Users can manage own MFA') THEN
-  CREATE POLICY "Users can manage own MFA" ON public.user_mfa FOR ALL USING (auth.uid() = user_id);
-END IF;
-
--- 9. MFA_PENDING (has: user_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='mfa_pending' AND policyname='Users can manage own MFA pending') THEN
-  CREATE POLICY "Users can manage own MFA pending" ON public.mfa_pending FOR ALL USING (auth.uid() = user_id);
-END IF;
-
--- 10. USER_SUSPENSIONS (has: user_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='user_suspensions' AND policyname='Admins can manage suspensions') THEN
-  CREATE POLICY "Admins can manage suspensions" ON public.user_suspensions FOR ALL
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
--- 11. PHOTO_MODERATIONS (has: therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='photo_moderations' AND policyname='Admins can manage photo moderations') THEN
-  CREATE POLICY "Admins can manage photo moderations" ON public.photo_moderations FOR ALL
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
--- 12. PROFILE_REPORTS (has: profile_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='profile_reports' AND policyname='Admins can manage profile reports') THEN
-  CREATE POLICY "Admins can manage profile reports" ON public.profile_reports FOR ALL
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
--- 13. LOG TABLES (have: profile_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='profile_status_debug_log' AND policyname='Admins can view debug logs') THEN
-  CREATE POLICY "Admins can view debug logs" ON public.profile_status_debug_log FOR SELECT
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='profile_status_invalid_log' AND policyname='Admins can view invalid status logs') THEN
-  CREATE POLICY "Admins can view invalid status logs" ON public.profile_status_invalid_log FOR SELECT
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
--- 14. IMPORTED_PROFILE_DATA (has: profile_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='imported_profile_data' AND policyname='Admins can manage imported profile data') THEN
-  CREATE POLICY "Admins can manage imported profile data" ON public.imported_profile_data FOR ALL
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
--- 15. THERAPIST_LEARNING_SCORES (has: profile_id, therapist_id)
-IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='therapist_learning_scores' AND policyname='Admins can manage learning scores') THEN
-  CREATE POLICY "Admins can manage learning scores" ON public.therapist_learning_scores FOR ALL
-    USING ((SELECT role FROM profiles WHERE id = auth.uid()) = 'admin');
-END IF;
-
-END $$;
-
--- ============================================================
--- FIX OVERLY PERMISSIVE POLICIES
--- ============================================================
-
--- KEYWORD_TRENDS
-DROP POLICY IF EXISTS "Anyone can read and write keyword_trends" ON public.keyword_trends;
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='keyword_trends' AND policyname='Public read keyword_trends') THEN
-    CREATE POLICY "Public read keyword_trends" ON public.keyword_trends FOR SELECT USING (true);
+DO $$
+BEGIN
+  IF to_regclass('public.appointments') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='appointments' AND column_name='user_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='appointments' AND policyname='Users can view own appointments') THEN
+    CREATE POLICY "Users can view own appointments" ON public.appointments
+      FOR SELECT USING ((select auth.uid()) = user_id);
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='keyword_trends' AND policyname='Service role write keyword_trends') THEN
-    CREATE POLICY "Service role write keyword_trends" ON public.keyword_trends FOR INSERT WITH CHECK (auth.role() = 'service_role');
+
+  IF to_regclass('public.appointments') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='appointments' AND column_name='user_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='appointments' AND policyname='Users can insert own appointments') THEN
+    CREATE POLICY "Users can insert own appointments" ON public.appointments
+      FOR INSERT WITH CHECK ((select auth.uid()) = user_id);
   END IF;
-END $$;
 
--- PROFILE_DOCUMENTS (has: profile_id — use that)
-DROP POLICY IF EXISTS "Users can delete their own documents" ON public.profile_documents;
-DROP POLICY IF EXISTS "Users can insert their own documents" ON public.profile_documents;
-DROP POLICY IF EXISTS "Users can update their own documents" ON public.profile_documents;
-CREATE POLICY "Users can delete their own documents" ON public.profile_documents FOR DELETE
-  USING (auth.uid() = (SELECT user_id FROM profiles WHERE id = profile_id));
-CREATE POLICY "Users can insert their own documents" ON public.profile_documents FOR INSERT
-  WITH CHECK (auth.uid() = (SELECT user_id FROM profiles WHERE id = profile_id));
-CREATE POLICY "Users can update their own documents" ON public.profile_documents FOR UPDATE
-  USING (auth.uid() = (SELECT user_id FROM profiles WHERE id = profile_id));
-
--- REVIEWS
-DROP POLICY IF EXISTS "reviews_insert_authenticated" ON public.reviews;
-DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='reviews' AND policyname='Authenticated users insert own reviews') THEN
-    CREATE POLICY "Authenticated users insert own reviews" ON public.reviews FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+  IF to_regclass('public.favorites') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='favorites' AND column_name='user_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='favorites' AND policyname='Users can manage own favorites') THEN
+    CREATE POLICY "Users can manage own favorites" ON public.favorites
+      FOR ALL USING ((select auth.uid()) = user_id)
+      WITH CHECK ((select auth.uid()) = user_id);
   END IF;
-END $$;
 
--- ============================================================
--- PERFORMANCE INDEXES
--- ============================================================
+  IF to_regclass('public.conversations') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='conversations' AND column_name='user_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='conversations' AND column_name='therapist_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='conversations' AND policyname='Users can view own conversations') THEN
+    CREATE POLICY "Users can view own conversations" ON public.conversations
+      FOR SELECT USING ((select auth.uid()) = user_id OR (select auth.uid()) = therapist_id);
+  END IF;
 
-CREATE INDEX IF NOT EXISTS idx_profiles_directory
-  ON profiles(city, visibility_status, profile_status)
-  WHERE visibility_status = 'public' AND profile_status = 'approved';
+  IF to_regclass('public.messages') IS NOT NULL
+     AND to_regclass('public.conversations') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='messages' AND column_name='conversation_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='conversations' AND column_name='user_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='conversations' AND column_name='therapist_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='messages' AND policyname='Users can view own messages') THEN
+    CREATE POLICY "Users can view own messages" ON public.messages
+      FOR SELECT USING (
+        EXISTS (
+          SELECT 1 FROM public.conversations c
+          WHERE c.id = messages.conversation_id
+            AND (c.user_id = (select auth.uid()) OR c.therapist_id = (select auth.uid()))
+        )
+      );
+  END IF;
 
-CREATE INDEX IF NOT EXISTS idx_profiles_ranking
-  ON profiles(is_featured DESC, boost_score DESC)
-  WHERE visibility_status = 'public' AND is_demo = false;
+  IF to_regclass('public.payment_transactions') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='payment_transactions' AND column_name='user_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='payment_transactions' AND column_name='therapist_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='payment_transactions' AND policyname='Users can view own payment transactions') THEN
+    CREATE POLICY "Users can view own payment transactions" ON public.payment_transactions
+      FOR SELECT USING ((select auth.uid()) = user_id OR (select auth.uid()) = therapist_id);
+  END IF;
 
-CREATE INDEX IF NOT EXISTS idx_profiles_slug
-  ON profiles(slug)
-  WHERE slug IS NOT NULL;
+  IF to_regclass('public.therapist_availability') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='therapist_availability' AND policyname='Public can read availability') THEN
+    CREATE POLICY "Public can read availability" ON public.therapist_availability
+      FOR SELECT USING (true);
+  END IF;
 
-CREATE INDEX IF NOT EXISTS idx_profiles_canonical_city
-  ON profiles(canonical_city_slug)
-  WHERE canonical_city_slug IS NOT NULL AND visibility_status = 'public';
+  IF to_regclass('public.therapist_availability') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='therapist_availability' AND column_name='therapist_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='therapist_availability' AND policyname='Provider can manage own availability') THEN
+    CREATE POLICY "Provider can manage own availability" ON public.therapist_availability
+      FOR ALL USING ((select auth.uid()) = therapist_id)
+      WITH CHECK ((select auth.uid()) = therapist_id);
+  END IF;
+
+  IF to_regclass('public.site_settings') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='site_settings' AND policyname='Admins can manage site settings') THEN
+    CREATE POLICY "Admins can manage site settings" ON public.site_settings
+      FOR ALL USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin')
+      WITH CHECK ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.user_mfa') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='user_mfa' AND column_name='user_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='user_mfa' AND policyname='Users can manage own MFA') THEN
+    CREATE POLICY "Users can manage own MFA" ON public.user_mfa
+      FOR ALL USING ((select auth.uid()) = user_id)
+      WITH CHECK ((select auth.uid()) = user_id);
+  END IF;
+
+  IF to_regclass('public.mfa_pending') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='mfa_pending' AND column_name='user_id')
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='mfa_pending' AND policyname='Users can manage own MFA pending') THEN
+    CREATE POLICY "Users can manage own MFA pending" ON public.mfa_pending
+      FOR ALL USING ((select auth.uid()) = user_id)
+      WITH CHECK ((select auth.uid()) = user_id);
+  END IF;
+
+  IF to_regclass('public.user_suspensions') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='user_suspensions' AND policyname='Admins can manage suspensions') THEN
+    CREATE POLICY "Admins can manage suspensions" ON public.user_suspensions
+      FOR ALL USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin')
+      WITH CHECK ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.photo_moderations') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='photo_moderations' AND policyname='Admins can manage photo moderations') THEN
+    CREATE POLICY "Admins can manage photo moderations" ON public.photo_moderations
+      FOR ALL USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin')
+      WITH CHECK ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.profile_reports') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='profile_reports' AND policyname='Admins can manage profile reports') THEN
+    CREATE POLICY "Admins can manage profile reports" ON public.profile_reports
+      FOR ALL USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin')
+      WITH CHECK ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.profile_status_debug_log') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='profile_status_debug_log' AND policyname='Admins can view debug logs') THEN
+    CREATE POLICY "Admins can view debug logs" ON public.profile_status_debug_log
+      FOR SELECT USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.profile_status_invalid_log') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='profile_status_invalid_log' AND policyname='Admins can view invalid status logs') THEN
+    CREATE POLICY "Admins can view invalid status logs" ON public.profile_status_invalid_log
+      FOR SELECT USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.imported_profile_data') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='imported_profile_data' AND policyname='Admins can manage imported profile data') THEN
+    CREATE POLICY "Admins can manage imported profile data" ON public.imported_profile_data
+      FOR ALL USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin')
+      WITH CHECK ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+
+  IF to_regclass('public.therapist_learning_scores') IS NOT NULL
+     AND to_regclass('public.profiles') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='therapist_learning_scores' AND policyname='Admins can manage learning scores') THEN
+    CREATE POLICY "Admins can manage learning scores" ON public.therapist_learning_scores
+      FOR ALL USING ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin')
+      WITH CHECK ((SELECT role FROM public.profiles WHERE id = (select auth.uid())) = 'admin');
+  END IF;
+END
+$$;
+
+-- Replace overly permissive keyword-trend policies when the table exists.
+DO $$
+BEGIN
+  IF to_regclass('public.keyword_trends') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "Anyone can read and write keyword_trends" ON public.keyword_trends;
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='keyword_trends' AND policyname='Public read keyword_trends') THEN
+      CREATE POLICY "Public read keyword_trends" ON public.keyword_trends FOR SELECT USING (true);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='keyword_trends' AND policyname='Service role write keyword_trends') THEN
+      CREATE POLICY "Service role write keyword_trends" ON public.keyword_trends
+        FOR INSERT WITH CHECK ((select auth.role()) = 'service_role');
+    END IF;
+  END IF;
+END
+$$;
+
+-- Profile documents are optional on a clean branch.
+DO $$
+BEGIN
+  IF to_regclass('public.profile_documents') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='profile_documents' AND column_name='profile_id') THEN
+    DROP POLICY IF EXISTS "Users can delete their own documents" ON public.profile_documents;
+    DROP POLICY IF EXISTS "Users can insert their own documents" ON public.profile_documents;
+    DROP POLICY IF EXISTS "Users can update their own documents" ON public.profile_documents;
+    CREATE POLICY "Users can delete their own documents" ON public.profile_documents FOR DELETE
+      USING ((select auth.uid()) = (SELECT user_id FROM public.profiles WHERE id = profile_id));
+    CREATE POLICY "Users can insert their own documents" ON public.profile_documents FOR INSERT
+      WITH CHECK ((select auth.uid()) = (SELECT user_id FROM public.profiles WHERE id = profile_id));
+    CREATE POLICY "Users can update their own documents" ON public.profile_documents FOR UPDATE
+      USING ((select auth.uid()) = (SELECT user_id FROM public.profiles WHERE id = profile_id))
+      WITH CHECK ((select auth.uid()) = (SELECT user_id FROM public.profiles WHERE id = profile_id));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.reviews') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "reviews_insert_authenticated" ON public.reviews;
+    IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='reviews' AND policyname='Authenticated users insert own reviews') THEN
+      CREATE POLICY "Authenticated users insert own reviews" ON public.reviews
+        FOR INSERT WITH CHECK ((select auth.uid()) IS NOT NULL);
+    END IF;
+  END IF;
+END
+$$;
+
+-- Performance indexes are created only when their target relation exists.
+DO $$
+BEGIN
+  IF to_regclass('public.profiles') IS NOT NULL THEN
+    EXECUTE 'create index if not exists idx_profiles_directory on public.profiles(city, visibility_status, profile_status) where visibility_status=''public'' and profile_status=''approved''';
+    EXECUTE 'create index if not exists idx_profiles_ranking on public.profiles(is_featured desc, boost_score desc) where visibility_status=''public'' and is_demo=false';
+    EXECUTE 'create index if not exists idx_profiles_slug on public.profiles(slug) where slug is not null';
+    EXECUTE 'create index if not exists idx_profiles_canonical_city on public.profiles(canonical_city_slug) where canonical_city_slug is not null and visibility_status=''public''';
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260720220521_fix_rls_auth_initplan.sql
+++ b/supabase/migrations/20260720220521_fix_rls_auth_initplan.sql
@@ -1,65 +1,132 @@
 -- ========================================
 -- FIX: RLS Auth Init Plan
--- Replace auth.uid() with (select auth.uid())
+-- Branch-safe policy replacements.
 -- ========================================
 
--- client_favorites
-DROP POLICY IF EXISTS client_favorites_own ON public.client_favorites;
-CREATE POLICY client_favorites_own ON public.client_favorites
-  USING ((select auth.uid()) = user_id OR (select auth.uid()) = client_user_id);
+DO $$
+BEGIN
+  IF to_regclass('public.client_favorites') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='client_favorites' AND column_name='user_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='client_favorites' AND column_name='client_user_id') THEN
+    DROP POLICY IF EXISTS client_favorites_own ON public.client_favorites;
+    CREATE POLICY client_favorites_own ON public.client_favorites
+      USING ((select auth.uid()) = user_id OR (select auth.uid()) = client_user_id)
+      WITH CHECK ((select auth.uid()) = user_id OR (select auth.uid()) = client_user_id);
+  END IF;
 
--- notification_deliveries
-DROP POLICY IF EXISTS notification_deliveries_own_read ON public.notification_deliveries;
-CREATE POLICY notification_deliveries_own_read ON public.notification_deliveries
-  FOR SELECT USING ((select auth.uid()) = user_id);
+  IF to_regclass('public.notification_deliveries') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='notification_deliveries' AND column_name='user_id') THEN
+    DROP POLICY IF EXISTS notification_deliveries_own_read ON public.notification_deliveries;
+    CREATE POLICY notification_deliveries_own_read ON public.notification_deliveries
+      FOR SELECT USING ((select auth.uid()) = user_id);
+  END IF;
 
--- push_subscriptions
-DROP POLICY IF EXISTS push_subscriptions_own ON public.push_subscriptions;
-CREATE POLICY push_subscriptions_own ON public.push_subscriptions
-  USING ((select auth.uid()) = user_id);
+  IF to_regclass('public.push_subscriptions') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='push_subscriptions' AND column_name='user_id') THEN
+    DROP POLICY IF EXISTS push_subscriptions_own ON public.push_subscriptions;
+    CREATE POLICY push_subscriptions_own ON public.push_subscriptions
+      USING ((select auth.uid()) = user_id)
+      WITH CHECK ((select auth.uid()) = user_id);
+  END IF;
 
--- user_notification_preferences
-DROP POLICY IF EXISTS user_notification_prefs_own ON public.user_notification_preferences;
-CREATE POLICY user_notification_prefs_own ON public.user_notification_preferences
-  USING ((select auth.uid()) = user_id);
+  IF to_regclass('public.user_notification_preferences') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='user_notification_preferences' AND column_name='user_id') THEN
+    DROP POLICY IF EXISTS user_notification_prefs_own ON public.user_notification_preferences;
+    CREATE POLICY user_notification_prefs_own ON public.user_notification_preferences
+      USING ((select auth.uid()) = user_id)
+      WITH CHECK ((select auth.uid()) = user_id);
+  END IF;
 
--- provider_travel
-DROP POLICY IF EXISTS provider_travel_own ON public.provider_travel;
-CREATE POLICY provider_travel_own ON public.provider_travel
-  USING ((select auth.uid()) = ( SELECT profiles.user_id FROM profiles WHERE profiles.id = provider_travel.profile_id LIMIT 1));
+  IF to_regclass('public.provider_travel') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='provider_travel' AND column_name='profile_id') THEN
+    DROP POLICY IF EXISTS provider_travel_own ON public.provider_travel;
+    CREATE POLICY provider_travel_own ON public.provider_travel
+      USING ((select auth.uid()) = (
+        SELECT profiles.user_id FROM public.profiles
+        WHERE profiles.id = provider_travel.profile_id
+        LIMIT 1
+      ))
+      WITH CHECK ((select auth.uid()) = (
+        SELECT profiles.user_id FROM public.profiles
+        WHERE profiles.id = provider_travel.profile_id
+        LIMIT 1
+      ));
+  END IF;
 
--- contact_inquiries
-DROP POLICY IF EXISTS "providers can view own inquiries" ON public.contact_inquiries;
-CREATE POLICY "providers can view own inquiries" ON public.contact_inquiries
-  FOR SELECT USING (EXISTS ( SELECT 1 FROM profiles WHERE profiles.id = contact_inquiries.profile_id AND profiles.user_id = (select auth.uid())));
+  IF to_regclass('public.contact_inquiries') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='contact_inquiries' AND column_name='profile_id') THEN
+    DROP POLICY IF EXISTS "providers can view own inquiries" ON public.contact_inquiries;
+    CREATE POLICY "providers can view own inquiries" ON public.contact_inquiries
+      FOR SELECT USING (EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = contact_inquiries.profile_id
+          AND profiles.user_id = (select auth.uid())
+      ));
 
-DROP POLICY IF EXISTS "providers can update own inquiries" ON public.contact_inquiries;
-CREATE POLICY "providers can update own inquiries" ON public.contact_inquiries
-  FOR UPDATE USING (EXISTS ( SELECT 1 FROM profiles WHERE profiles.id = contact_inquiries.profile_id AND profiles.user_id = (select auth.uid())))
-  WITH CHECK (EXISTS ( SELECT 1 FROM profiles WHERE profiles.id = contact_inquiries.profile_id AND profiles.user_id = (select auth.uid())));
+    DROP POLICY IF EXISTS "providers can update own inquiries" ON public.contact_inquiries;
+    CREATE POLICY "providers can update own inquiries" ON public.contact_inquiries
+      FOR UPDATE USING (EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = contact_inquiries.profile_id
+          AND profiles.user_id = (select auth.uid())
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = contact_inquiries.profile_id
+          AND profiles.user_id = (select auth.uid())
+      ));
 
-DROP POLICY IF EXISTS contact_inquiries_select_own ON public.contact_inquiries;
-CREATE POLICY contact_inquiries_select_own ON public.contact_inquiries
-  FOR SELECT USING (EXISTS ( SELECT 1 FROM profiles WHERE profiles.id = contact_inquiries.profile_id AND profiles.user_id = (select auth.uid())));
+    DROP POLICY IF EXISTS contact_inquiries_select_own ON public.contact_inquiries;
+    CREATE POLICY contact_inquiries_select_own ON public.contact_inquiries
+      FOR SELECT USING (EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = contact_inquiries.profile_id
+          AND profiles.user_id = (select auth.uid())
+      ));
 
-DROP POLICY IF EXISTS contact_inquiries_update_own ON public.contact_inquiries;
-CREATE POLICY contact_inquiries_update_own ON public.contact_inquiries
-  FOR UPDATE USING (EXISTS ( SELECT 1 FROM profiles WHERE profiles.id = contact_inquiries.profile_id AND profiles.user_id = (select auth.uid())));
+    DROP POLICY IF EXISTS contact_inquiries_update_own ON public.contact_inquiries;
+    CREATE POLICY contact_inquiries_update_own ON public.contact_inquiries
+      FOR UPDATE USING (EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = contact_inquiries.profile_id
+          AND profiles.user_id = (select auth.uid())
+      ))
+      WITH CHECK (EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE profiles.id = contact_inquiries.profile_id
+          AND profiles.user_id = (select auth.uid())
+      ));
+  END IF;
 
--- ranking_events
-DROP POLICY IF EXISTS ranking_events_owner_select ON public.ranking_events;
-CREATE POLICY ranking_events_owner_select ON public.ranking_events
-  FOR SELECT USING (profile_id IN ( SELECT p.id FROM profiles p WHERE p.user_id = (select auth.uid())));
+  -- ranking_events uses therapist_id in the canonical schema.
+  IF to_regclass('public.ranking_events') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='ranking_events' AND column_name='therapist_id') THEN
+    DROP POLICY IF EXISTS ranking_events_owner_select ON public.ranking_events;
+    CREATE POLICY ranking_events_owner_select ON public.ranking_events
+      FOR SELECT USING (therapist_id IN (
+        SELECT p.id FROM public.profiles p WHERE p.user_id = (select auth.uid())
+      ));
 
-DROP POLICY IF EXISTS ranking_events_owner_insert ON public.ranking_events;
-CREATE POLICY ranking_events_owner_insert ON public.ranking_events
-  FOR INSERT WITH CHECK (profile_id IN ( SELECT p.id FROM profiles p WHERE p.user_id = (select auth.uid())));
+    DROP POLICY IF EXISTS ranking_events_owner_insert ON public.ranking_events;
+    CREATE POLICY ranking_events_owner_insert ON public.ranking_events
+      FOR INSERT WITH CHECK (therapist_id IN (
+        SELECT p.id FROM public.profiles p WHERE p.user_id = (select auth.uid())
+      ));
 
-DROP POLICY IF EXISTS ranking_events_owner_update ON public.ranking_events;
-CREATE POLICY ranking_events_owner_update ON public.ranking_events
-  FOR UPDATE USING (profile_id IN ( SELECT p.id FROM profiles p WHERE p.user_id = (select auth.uid())))
-  WITH CHECK (profile_id IN ( SELECT p.id FROM profiles p WHERE p.user_id = (select auth.uid())));
+    DROP POLICY IF EXISTS ranking_events_owner_update ON public.ranking_events;
+    CREATE POLICY ranking_events_owner_update ON public.ranking_events
+      FOR UPDATE USING (therapist_id IN (
+        SELECT p.id FROM public.profiles p WHERE p.user_id = (select auth.uid())
+      ))
+      WITH CHECK (therapist_id IN (
+        SELECT p.id FROM public.profiles p WHERE p.user_id = (select auth.uid())
+      ));
 
-DROP POLICY IF EXISTS ranking_events_owner_delete ON public.ranking_events;
-CREATE POLICY ranking_events_owner_delete ON public.ranking_events
-  FOR DELETE USING (profile_id IN ( SELECT p.id FROM profiles p WHERE p.user_id = (select auth.uid())));
+    DROP POLICY IF EXISTS ranking_events_owner_delete ON public.ranking_events;
+    CREATE POLICY ranking_events_owner_delete ON public.ranking_events
+      FOR DELETE USING (therapist_id IN (
+        SELECT p.id FROM public.profiles p WHERE p.user_id = (select auth.uid())
+      ));
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260720220933_fix_unindexed_foreign_keys.sql
+++ b/supabase/migrations/20260720220933_fix_unindexed_foreign_keys.sql
@@ -1,43 +1,69 @@
 -- ========================================
 -- FIX: Unindexed Foreign Keys
+-- Create indexes only when both the target table and column exist.
 -- ========================================
 
-CREATE INDEX IF NOT EXISTS idx_analytics_events_user_id ON public.analytics_events(user_id);
-CREATE INDEX IF NOT EXISTS idx_appointments_client_id ON public.appointments(client_id);
-CREATE INDEX IF NOT EXISTS idx_appointments_profile_id ON public.appointments(profile_id);
-CREATE INDEX IF NOT EXISTS idx_audit_log_admin_id ON public.audit_log(admin_id);
-CREATE INDEX IF NOT EXISTS idx_booking_inquiries_reviewed_by ON public.booking_inquiries(reviewed_by);
-CREATE INDEX IF NOT EXISTS idx_complaints_complainant_id ON public.complaints(complainant_id);
-CREATE INDEX IF NOT EXISTS idx_complaints_reviewed_by ON public.complaints(reviewed_by);
-CREATE INDEX IF NOT EXISTS idx_conversations_participant_a ON public.conversations(participant_a_id);
-CREATE INDEX IF NOT EXISTS idx_conversations_participant_b ON public.conversations(participant_b_id);
-CREATE INDEX IF NOT EXISTS idx_conversations_profile_id ON public.conversations(profile_id);
-CREATE INDEX IF NOT EXISTS idx_conversations_therapist_id ON public.conversations(therapist_id);
-CREATE INDEX IF NOT EXISTS idx_favorites_profile_id ON public.favorites(profile_id);
-CREATE INDEX IF NOT EXISTS idx_favorites_therapist_id ON public.favorites(therapist_id);
-CREATE INDEX IF NOT EXISTS idx_imported_reviews_reviewed_by ON public.imported_reviews(reviewed_by);
-CREATE INDEX IF NOT EXISTS idx_messages_sender_id ON public.messages(sender_id);
-CREATE INDEX IF NOT EXISTS idx_messages_sender_user_id ON public.messages(sender_user_id);
-CREATE INDEX IF NOT EXISTS idx_moderation_actions_actor_admin ON public.moderation_actions(actor_admin_id);
-CREATE INDEX IF NOT EXISTS idx_moderation_actions_target_profile ON public.moderation_actions(target_profile_id);
-CREATE INDEX IF NOT EXISTS idx_payment_transactions_appointment ON public.payment_transactions(appointment_id);
-CREATE INDEX IF NOT EXISTS idx_payment_transactions_therapist ON public.payment_transactions(therapist_id);
-CREATE INDEX IF NOT EXISTS idx_profile_migrations_verified_by ON public.profile_migrations(verified_by);
-CREATE INDEX IF NOT EXISTS idx_profile_reports_profile_id ON public.profile_reports(profile_id);
-CREATE INDEX IF NOT EXISTS idx_profiles_rejected_by ON public.profiles(rejected_by);
-CREATE INDEX IF NOT EXISTS idx_profiles_reviewed_by ON public.profiles(reviewed_by);
-CREATE INDEX IF NOT EXISTS idx_ranking_events_therapist_id ON public.ranking_events(therapist_id);
-CREATE INDEX IF NOT EXISTS idx_ranking_events_user_id ON public.ranking_events(user_id);
-CREATE INDEX IF NOT EXISTS idx_search_history_client_user_id ON public.search_history(client_user_id);
-CREATE INDEX IF NOT EXISTS idx_site_settings_updated_by ON public.site_settings(updated_by);
-CREATE INDEX IF NOT EXISTS idx_sms_follow_up_alerts_resolved_by ON public.sms_follow_up_alerts(resolved_by);
-CREATE INDEX IF NOT EXISTS idx_sms_logs_booking_inquiry_id ON public.sms_logs(booking_inquiry_id);
-CREATE INDEX IF NOT EXISTS idx_sms_profiles_profile_id ON public.sms_profiles(profile_id);
-CREATE INDEX IF NOT EXISTS idx_support_tickets_profile_id ON public.support_tickets(profile_id);
-CREATE INDEX IF NOT EXISTS idx_therapist_availability_profile ON public.therapist_availability(profile_id);
-CREATE INDEX IF NOT EXISTS idx_therapist_photos_main_profile ON public.therapist_photos(main_profile_id);
-CREATE INDEX IF NOT EXISTS idx_therapist_photos_reviewed_by ON public.therapist_photos(reviewed_by);
-CREATE INDEX IF NOT EXISTS idx_therapist_pricing_profile_id ON public.therapist_pricing(profile_id);
-CREATE INDEX IF NOT EXISTS idx_therapist_services_profile_id ON public.therapist_services(profile_id);
-CREATE INDEX IF NOT EXISTS idx_therapist_subscriptions_profile ON public.therapist_subscriptions(profile_id);
-CREATE INDEX IF NOT EXISTS idx_waitlist_voice_ai_profile_id ON public.waitlist_voice_ai(profile_id);
+DO $$
+DECLARE
+  item record;
+BEGIN
+  FOR item IN
+    SELECT * FROM (VALUES
+      ('analytics_events','user_id','idx_analytics_events_user_id'),
+      ('appointments','client_id','idx_appointments_client_id'),
+      ('appointments','profile_id','idx_appointments_profile_id'),
+      ('audit_log','admin_id','idx_audit_log_admin_id'),
+      ('booking_inquiries','reviewed_by','idx_booking_inquiries_reviewed_by'),
+      ('complaints','complainant_id','idx_complaints_complainant_id'),
+      ('complaints','reviewed_by','idx_complaints_reviewed_by'),
+      ('conversations','participant_a_id','idx_conversations_participant_a'),
+      ('conversations','participant_b_id','idx_conversations_participant_b'),
+      ('conversations','profile_id','idx_conversations_profile_id'),
+      ('conversations','therapist_id','idx_conversations_therapist_id'),
+      ('favorites','profile_id','idx_favorites_profile_id'),
+      ('favorites','therapist_id','idx_favorites_therapist_id'),
+      ('imported_reviews','reviewed_by','idx_imported_reviews_reviewed_by'),
+      ('messages','sender_id','idx_messages_sender_id'),
+      ('messages','sender_user_id','idx_messages_sender_user_id'),
+      ('moderation_actions','actor_admin_id','idx_moderation_actions_actor_admin'),
+      ('moderation_actions','target_profile_id','idx_moderation_actions_target_profile'),
+      ('payment_transactions','appointment_id','idx_payment_transactions_appointment'),
+      ('payment_transactions','therapist_id','idx_payment_transactions_therapist'),
+      ('profile_migrations','verified_by','idx_profile_migrations_verified_by'),
+      ('profile_reports','profile_id','idx_profile_reports_profile_id'),
+      ('profiles','rejected_by','idx_profiles_rejected_by'),
+      ('profiles','reviewed_by','idx_profiles_reviewed_by'),
+      ('ranking_events','therapist_id','idx_ranking_events_therapist_id'),
+      ('ranking_events','user_id','idx_ranking_events_user_id'),
+      ('search_history','client_user_id','idx_search_history_client_user_id'),
+      ('site_settings','updated_by','idx_site_settings_updated_by'),
+      ('sms_follow_up_alerts','resolved_by','idx_sms_follow_up_alerts_resolved_by'),
+      ('sms_logs','booking_inquiry_id','idx_sms_logs_booking_inquiry_id'),
+      ('sms_profiles','profile_id','idx_sms_profiles_profile_id'),
+      ('support_tickets','profile_id','idx_support_tickets_profile_id'),
+      ('therapist_availability','profile_id','idx_therapist_availability_profile'),
+      ('therapist_photos','main_profile_id','idx_therapist_photos_main_profile'),
+      ('therapist_photos','reviewed_by','idx_therapist_photos_reviewed_by'),
+      ('therapist_pricing','profile_id','idx_therapist_pricing_profile_id'),
+      ('therapist_services','profile_id','idx_therapist_services_profile_id'),
+      ('therapist_subscriptions','profile_id','idx_therapist_subscriptions_profile'),
+      ('waitlist_voice_ai','profile_id','idx_waitlist_voice_ai_profile_id')
+    ) AS values_list(table_name, column_name, index_name)
+  LOOP
+    IF to_regclass(format('public.%I', item.table_name)) IS NOT NULL
+       AND EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema='public'
+           AND table_name=item.table_name
+           AND column_name=item.column_name
+       ) THEN
+      EXECUTE format(
+        'create index if not exists %I on public.%I(%I)',
+        item.index_name,
+        item.table_name,
+        item.column_name
+      );
+    END IF;
+  END LOOP;
+END
+$$;

--- a/supabase/migrations/20260720234046_fix_rls_security_and_storage.sql
+++ b/supabase/migrations/20260720234046_fix_rls_security_and_storage.sql
@@ -1,34 +1,56 @@
--- 1. contact_inquiries: restrict INSERT
-DROP POLICY IF EXISTS "contact_inquiries_insert_public" ON public.contact_inquiries;
-CREATE POLICY "contact_inquiries_insert_public" ON public.contact_inquiries
-FOR INSERT WITH CHECK (
-  profile_id IS NOT NULL
-  AND char_length(COALESCE(message, '')) >= 10
-  AND char_length(COALESCE(message, '')) <= 2000
-);
+-- Security policy hardening. Optional relations are guarded so clean preview
+-- branches can replay the complete migration history.
 
--- 2. newsletter_subscribers: restrict INSERT with email validation
-DROP POLICY IF EXISTS "newsletter_insert_anon" ON public.newsletter_subscribers;
-CREATE POLICY "newsletter_insert_anon" ON public.newsletter_subscribers
-FOR INSERT WITH CHECK (
-  email IS NOT NULL
-  AND email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
-);
+DO $$
+BEGIN
+  IF to_regclass('public.contact_inquiries') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='contact_inquiries' AND column_name='profile_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='contact_inquiries' AND column_name='message') THEN
+    DROP POLICY IF EXISTS "contact_inquiries_insert_public" ON public.contact_inquiries;
+    CREATE POLICY "contact_inquiries_insert_public" ON public.contact_inquiries
+      FOR INSERT WITH CHECK (
+        profile_id IS NOT NULL
+        AND char_length(coalesce(message, '')) >= 10
+        AND char_length(coalesce(message, '')) <= 2000
+      );
+  END IF;
 
--- 3. support_tickets: restrict ALL to service_role only
-DROP POLICY IF EXISTS "service_role_tickets_all" ON public.support_tickets;
-CREATE POLICY "service_role_tickets_all" ON public.support_tickets
-FOR ALL USING (auth.role() = 'service_role');
+  IF to_regclass('public.newsletter_subscribers') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='newsletter_subscribers' AND column_name='email') THEN
+    DROP POLICY IF EXISTS "newsletter_insert_anon" ON public.newsletter_subscribers;
+    CREATE POLICY "newsletter_insert_anon" ON public.newsletter_subscribers
+      FOR INSERT WITH CHECK (
+        email IS NOT NULL
+        AND email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+      );
+  END IF;
 
--- 4. support_ticket_messages: restrict ALL to service_role only
-DROP POLICY IF EXISTS "service_role_messages_all" ON public.support_ticket_messages;
-CREATE POLICY "service_role_messages_all" ON public.support_ticket_messages
-FOR ALL USING (auth.role() = 'service_role');
+  IF to_regclass('public.support_tickets') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "service_role_tickets_all" ON public.support_tickets;
+    CREATE POLICY "service_role_tickets_all" ON public.support_tickets
+      FOR ALL USING ((select auth.role()) = 'service_role')
+      WITH CHECK ((select auth.role()) = 'service_role');
+  END IF;
 
--- 5. Storage: replace broad listing policy with path-restricted read
-DROP POLICY IF EXISTS "Public can read therapist photos" ON storage.objects;
-CREATE POLICY "Public read therapist photos by path" ON storage.objects
-FOR SELECT USING (
-  bucket_id = 'therapist-photos'
-  AND (storage.foldername(name))[1] IS NOT NULL
-);
+  IF to_regclass('public.support_ticket_messages') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "service_role_messages_all" ON public.support_ticket_messages;
+    CREATE POLICY "service_role_messages_all" ON public.support_ticket_messages
+      FOR ALL USING ((select auth.role()) = 'service_role')
+      WITH CHECK ((select auth.role()) = 'service_role');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF to_regclass('storage.objects') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "Public can read therapist photos" ON storage.objects;
+    DROP POLICY IF EXISTS "Public read therapist photos by path" ON storage.objects;
+    CREATE POLICY "Public read therapist photos by path" ON storage.objects
+      FOR SELECT USING (
+        bucket_id = 'therapist-photos'
+        AND (storage.foldername(name))[1] IS NOT NULL
+      );
+  END IF;
+END
+$$;

--- a/supabase/migrations/20260721190207_contain_public_pii_and_privilege_escalation.sql
+++ b/supabase/migrations/20260721190207_contain_public_pii_and_privilege_escalation.sql
@@ -1,26 +1,40 @@
 begin;
 
--- Stop exposing complete records through the Data API. Public directory access will
--- move to a deliberately scoped view/API in the application migration.
+-- Stop exposing complete records through the Data API.
 drop policy if exists "profiles_public_read_approved" on public.profiles;
-drop policy if exists "Public can read approved therapist profiles" on public.therapist_profiles;
 
--- Do not expose verification documents to other users or anonymous callers.
-drop policy if exists "Users can view own documents" on public.profile_documents;
-create policy "profile_documents_owner_read"
-on public.profile_documents
-for select
-to authenticated
-using (
-  exists (
-    select 1
-    from public.profiles p
-    where p.id = profile_documents.profile_id
-      and p.user_id = (select auth.uid())
-  )
-);
+DO $$
+BEGIN
+  IF to_regclass('public.therapist_profiles') IS NOT NULL THEN
+    DROP POLICY IF EXISTS "Public can read approved therapist profiles" ON public.therapist_profiles;
+  END IF;
+END
+$$;
 
--- A profile owner may edit normal profile content, but never their authorization,
+-- Verification documents are optional on clean branches.
+DO $$
+BEGIN
+  IF to_regclass('public.profile_documents') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='profile_documents' AND column_name='profile_id') THEN
+    DROP POLICY IF EXISTS "Users can view own documents" ON public.profile_documents;
+    DROP POLICY IF EXISTS "profile_documents_owner_read" ON public.profile_documents;
+    CREATE POLICY "profile_documents_owner_read"
+      ON public.profile_documents
+      FOR SELECT
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1
+          FROM public.profiles p
+          WHERE p.id = profile_documents.profile_id
+            AND p.user_id = (select auth.uid())
+        )
+      );
+  END IF;
+END
+$$;
+
+-- A profile owner may edit normal profile content, but never authorization,
 -- moderation, lifecycle, or billing state.
 create or replace function public.prevent_sensitive_profile_mutation()
 returns trigger
@@ -65,7 +79,7 @@ create trigger prevent_sensitive_profile_mutation
 before update on public.profiles
 for each row execute function public.prevent_sensitive_profile_mutation();
 
--- A provider cannot self-publish or self-approve the secondary profile record.
+-- The secondary therapist profile is optional on some clean branches.
 create or replace function public.prevent_sensitive_therapist_profile_mutation()
 returns trigger
 language plpgsql
@@ -93,10 +107,16 @@ begin
 end;
 $$;
 
-drop trigger if exists prevent_sensitive_therapist_profile_mutation on public.therapist_profiles;
-create trigger prevent_sensitive_therapist_profile_mutation
-before update on public.therapist_profiles
-for each row execute function public.prevent_sensitive_therapist_profile_mutation();
+DO $$
+BEGIN
+  IF to_regclass('public.therapist_profiles') IS NOT NULL THEN
+    DROP TRIGGER IF EXISTS prevent_sensitive_therapist_profile_mutation ON public.therapist_profiles;
+    CREATE TRIGGER prevent_sensitive_therapist_profile_mutation
+      BEFORE UPDATE ON public.therapist_profiles
+      FOR EACH ROW EXECUTE FUNCTION public.prevent_sensitive_therapist_profile_mutation();
+  END IF;
+END
+$$;
 
 revoke all on function public.prevent_sensitive_profile_mutation() from public;
 revoke all on function public.prevent_sensitive_therapist_profile_mutation() from public;

--- a/supabase/migrations/20260722001000_cleanup_profiles_columns.sql
+++ b/supabase/migrations/20260722001000_cleanup_profiles_columns.sql
@@ -1,160 +1,25 @@
 -- ============================================================
--- MIGRATION: Cleanup Profiles Columns
--- Remove redundant/unused columns from profiles (87 cols)
+-- MIGRATION: Cleanup Profiles Columns — superseded
 -- ============================================================
--- WARNING: This removes columns with low usage
--- Backup before running on production!
 --
--- Removed categories:
--- 1. Duplicate contact fields (phone_number, whatsapp, booking_link, etc)
--- 2. Duplicate location fields (primary_area, zip_code, street_reference)
--- 3. Unused/deprecated fields (traveling, visiting, tagline, etc)
--- 4. Redundant status/tier fields (will consolidate)
--- 5. Future-only fields (accessibility_features, studio_amenities, etc)
--- ============================================================
+-- This historical migration attempted to remove a large set of profile fields.
+-- Those fields remain part of the canonical production schema and are actively
+-- used by provider editing, verification, subscriptions, analytics, SEO, and the
+-- AI Profile Coach. Production never recorded the destructive cleanup migration.
+--
+-- Keep this version as an explicit, non-destructive compatibility marker so a
+-- clean Supabase preview branch can replay the repository history without
+-- diverging from production or deleting live application contracts.
+--
+-- Any future schema cleanup must be introduced as a new migration after a
+-- verified application/data migration, deprecation window, and rollback plan.
 
-BEGIN;
+begin;
 
--- ============================================================
--- BACKUP: Create shadow table to preserve deleted data
--- (Can be dropped after verification in 30 days)
--- ============================================================
-CREATE TABLE public.profiles_backup_20260722 AS
-SELECT * FROM public.profiles;
+do $$
+begin
+  raise notice 'Skipping superseded destructive profiles cleanup; canonical production columns are retained.';
+end
+$$;
 
-ALTER TABLE public.profiles_backup_20260722 ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY "admins_only_read_backup" ON public.profiles_backup_20260722 FOR SELECT
-  USING ((SELECT role FROM public.profiles WHERE id = auth.uid()) = 'admin');
-
--- ============================================================
--- DROP UNUSED/REDUNDANT COLUMNS (87 total)
--- ============================================================
-
--- Duplicate Contact Fields (keep: phone, email_address, website, whatsapp_number, show_email)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS phone_number;     -- duplicate of phone
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS whatsapp;         -- duplicate of whatsapp_number
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS booking_link;     -- use website instead
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS booking_url;      -- duplicate
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS contact_email;    -- duplicate of email_address
-
--- Duplicate Location Fields (keep: city, state, neighborhood, latitude, longitude, canonical_city_slug)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS primary_area;     -- rename of neighborhood
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS neighborhood_name; -- description of neighborhood
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS zip_code;         -- not used
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS street_reference; -- not used
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS country;          -- always Brazil, not needed
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS location_type;    -- redundant
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS map_enabled;      -- UI config, not data
-
--- Duplicate/Redundant Price Fields (keep: starting_price, pricing_sessions, add_ons)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS incall_price;     -- use pricing_sessions JSONB
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS outcall_price;    -- use pricing_sessions JSONB
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS starting_rate;    -- duplicate of starting_price
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS price_min;        -- use pricing_sessions
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS price_max;        -- use pricing_sessions
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS session_duration; -- use pricing_sessions
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS session_lengths;  -- use pricing_sessions
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS rates;            -- duplicate of pricing_sessions
-
--- Duplicate Hours/Schedule (keep: business_hours, travel_schedule)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS studio_hours;     -- use business_hours JSONB
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS mobile_hours;     -- use business_hours JSONB
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS incall_details;   -- use custom_faq instead
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS outcall_details;  -- use custom_faq instead
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS availability_note; -- use custom_faq instead
-
--- Duplicate Education/Training (keep: education, training, certifications)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS education_entries; -- JSONB, not needed
-
--- Redundant Verification Fields (consolidate to verification_status)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS is_verified_email;     -- check verification_status
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS is_verified_phone;     -- check verification_status
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS is_verified_photos;    -- check verification_status
-
--- Unused Preference Fields (low adoption)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS accepts_all_genders;   -- not used by app
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS accessibility_features; -- future feature
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS affiliations;          -- not populated
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS studio_amenities;      -- not populated
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS massage_setup;         -- not populated
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS incall_amenities;      -- not populated
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS mobile_extras;         -- not populated
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS products_used;         -- not populated
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS products_sold;         -- not populated
-
--- Duplicate Discount Fields (not used)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS regular_discounts;     -- JSONB, not implemented
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS day_of_week_discount;  -- JSONB, not implemented
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS weekly_special;        -- JSONB, not implemented
-
--- Unused Status/Tier Fields (consolidate to status, subscription_tier)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS role;               -- use from auth.users or user_roles
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS current_status;     -- use status
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS profile_status;     -- use status
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS account_status;     -- use status
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS _tier;              -- use subscription_tier
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS tier;               -- use subscription_tier
-
--- Duplicate View/Analytics Fields (consolidate)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS profile_views;      -- use view_count
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS view_count;         -- duplicate
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS rating_average;     -- use average_rating
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS inquiry_count;      -- not reliably tracked
-
--- Redundant Completion Fields (consolidate to profile_completeness %)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS profile_completion_score; -- use profile_completeness
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS completion_score;   -- duplicate
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS completion_percentage; -- duplicate
-
--- Removed/Deprecated Fields
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS email;              -- use email_address or auth.users.email
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS tagline;            -- rename of headline, not used
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS traveling;          -- vague, use travel_schedule JSONB
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS visiting;           -- vague, use travel_schedule JSONB
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS business_trips;     -- JSONB, not used
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS presentation_video_url; -- not implemented
-
--- Service Radius Duplicates (keep: outcall_radius_miles)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS service_radius_miles;   -- duplicate
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS service_radius_km;      -- duplicate
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS travel_destination;     -- not used
-
--- Social/Marketing (not used for core profile)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS social_media;       -- JSONB, not used
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS booking_platform;   -- string, not used
-
--- Old Subscription Fields (keep: subscription_tier, subscription_status, stripe_customer_id)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS current_period_end;       -- use subscription_current_period_end
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS photo_limit;             -- use subscription tier
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS visibility_level;        -- use visibility_status
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS subscription_plan;       -- use subscription_tier name
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS subscription_current_period_start;  -- not needed
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS subscription_current_period_end;    -- not needed
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS subscription_cancel_at_period_end;  -- not needed
-
--- Unused Identifiers (keep: seo_title, seo_description if SEO still active)
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS location_marker_type;    -- map UI config, not data
-
--- Unused Old Fields
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS featured_until;     -- use is_featured + feature expiry
-ALTER TABLE public.profiles DROP COLUMN IF EXISTS boost_score;        -- ranking algorithm detail
-
--- ============================================================
--- VERIFY & SUMMARY
--- ============================================================
-DO $$
-DECLARE
-  col_count INT;
-BEGIN
-  SELECT COUNT(*) INTO col_count
-  FROM information_schema.columns
-  WHERE table_schema = 'public' AND table_name = 'profiles';
-
-  RAISE NOTICE 'Profiles table cleanup complete:';
-  RAISE NOTICE '  - Remaining columns: %', col_count;
-  RAISE NOTICE '  - Backup created: profiles_backup_20260722';
-  RAISE NOTICE '  - Can delete backup after 30 days of verification';
-END $$;
-
-COMMIT;
+commit;

--- a/supabase/migrations/20260723150000_ai_profile_coach_base.sql
+++ b/supabase/migrations/20260723150000_ai_profile_coach_base.sql
@@ -77,24 +77,48 @@ alter table public.ai_profile_coach_email_preferences enable row level security;
 drop policy if exists providers_read_own_ai_coach_snapshots on public.ai_profile_coach_daily_snapshots;
 create policy providers_read_own_ai_coach_snapshots
   on public.ai_profile_coach_daily_snapshots for select to authenticated
-  using (profile_id = (select auth.uid()));
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = ai_profile_coach_daily_snapshots.profile_id
+        and p.user_id = (select auth.uid())
+    )
+  );
 
 drop policy if exists providers_manage_own_ai_coach_preferences on public.ai_profile_coach_email_preferences;
 create policy providers_manage_own_ai_coach_preferences
   on public.ai_profile_coach_email_preferences for all to authenticated
-  using (profile_id = (select auth.uid()))
-  with check (profile_id = (select auth.uid()));
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = ai_profile_coach_email_preferences.profile_id
+        and p.user_id = (select auth.uid())
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = ai_profile_coach_email_preferences.profile_id
+        and p.user_id = (select auth.uid())
+    )
+  );
 
 grant select on public.ai_profile_coach_daily_snapshots to authenticated;
 grant select, insert, update, delete on public.ai_profile_coach_email_preferences to authenticated;
 grant all on public.ai_profile_coach_daily_snapshots to service_role;
 grant all on public.ai_profile_coach_email_preferences to service_role;
 
+-- Server-only normalized source. Legacy column names are exposed as aliases so
+-- reporting jobs remain compatible with the consolidated profiles schema.
 create or replace view public.ai_profile_coach_source
 with (security_invoker = true)
 as
 select
   p.id as profile_id,
+  p.user_id,
   coalesce(p.display_name, p.full_name, 'Provider') as display_name,
   coalesce(p.email_address, p.email) as recipient_email,
   p.slug,
@@ -107,7 +131,7 @@ select
   p.country,
   p.photo_url,
   p.avatar_url,
-  p.profile_completion_score,
+  coalesce(p.profile_completeness, p.completion_score, p.completion_percentage, 0) as profile_completion_score,
   p.profile_completeness,
   p.completion_score,
   p.completion_percentage,
@@ -141,19 +165,19 @@ select
   p.languages,
   p.languages_spoken,
   p.years_experience,
-  p.education_entries,
+  '[]'::jsonb as education_entries,
   p.certifications,
   p.training,
-  p.affiliations,
-  p.massage_setup,
-  p.incall_amenities,
-  p.studio_amenities,
-  p.mobile_extras,
-  p.products_used,
-  p.payment_methods,
+  '{}'::text[] as affiliations,
+  null::text as massage_setup,
+  '{}'::text[] as incall_amenities,
+  '{}'::text[] as studio_amenities,
+  '{}'::text[] as mobile_extras,
+  '{}'::text[] as products_used,
+  '{}'::text[] as payment_methods,
   p.areas_served,
   p.travel_schedule,
-  p.business_trips,
+  '[]'::jsonb as business_trips,
   p.is_verified_phone,
   p.is_verified_email,
   p.is_verified_identity,
@@ -167,7 +191,7 @@ select
   p.inquiry_count,
   p.review_count,
   p.average_rating,
-  p.last_seen_at,
+  p.last_active_at as last_seen_at,
   p.updated_at,
   (select count(*) from public.profile_photos pp where pp.profile_id = p.id and pp.moderation_status = 'approved') as approved_photo_count,
   (select count(*) from public.profile_view_analytics pva where pva.profile_id = p.id and pva.created_at >= now() - interval '1 day') as profile_views_1d,
@@ -178,7 +202,7 @@ select
   (select count(*) from public.contact_events ce where ce.profile_id = p.id and ce.created_at >= now() - interval '30 days') as contact_clicks_30d,
   (select count(*) from public.favorites f where f.profile_id = p.id and f.created_at >= now() - interval '7 days') as favorites_7d,
   (select count(*) from public.contact_inquiries ci where ci.profile_id = p.id and ci.created_at >= now() - interval '7 days') as inquiries_7d,
-  (select avg(re.position_in_results)::numeric(8,2) from public.ranking_events re where re.profile_id = p.id and re.created_at >= now() - interval '7 days' and re.position_in_results is not null) as average_search_position,
+  (select avg(re.position_in_results)::numeric(8,2) from public.ranking_events re where re.therapist_id = p.id and re.created_at >= now() - interval '7 days' and re.position_in_results is not null) as average_search_position,
   (select ds.score from public.demand_scores ds where lower(ds.city) = lower(p.city) and lower(ds.state) = lower(p.state) order by ds.week_start desc limit 1) as local_demand_score,
   (select ds.trend from public.demand_scores ds where lower(ds.city) = lower(p.city) and lower(ds.state) = lower(p.state) order by ds.week_start desc limit 1) as local_demand_trend
 from public.profiles p

--- a/supabase/migrations/20260723150000_ai_profile_coach_base.sql
+++ b/supabase/migrations/20260723150000_ai_profile_coach_base.sql
@@ -1,0 +1,190 @@
+-- AI Profile Coach base schema.
+-- The application computes deterministic snapshots server-side; production may
+-- additionally use scheduled database functions for lifecycle email delivery.
+
+create table if not exists public.ai_profile_coach_daily_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  snapshot_date date not null default current_date,
+  profile_score integer not null default 0 check (profile_score between 0 and 100),
+  previous_profile_score integer check (previous_profile_score between 0 and 100),
+  score_change integer not null default 0,
+  visibility_score integer not null default 0 check (visibility_score between 0 and 100),
+  trust_score integer not null default 0 check (trust_score between 0 and 100),
+  content_score integer not null default 0 check (content_score between 0 and 100),
+  conversion_score integer not null default 0 check (conversion_score between 0 and 100),
+  profile_views_1d integer not null default 0,
+  profile_views_7d integer not null default 0,
+  profile_views_30d integer not null default 0,
+  profile_views_change_pct numeric(8,2),
+  contact_clicks_1d integer not null default 0,
+  contact_clicks_7d integer not null default 0,
+  contact_clicks_30d integer not null default 0,
+  contact_rate_pct numeric(8,2),
+  favorites_7d integer not null default 0,
+  inquiries_7d integer not null default 0,
+  average_search_position numeric(8,2),
+  local_demand_score integer,
+  local_demand_trend text,
+  strongest_keyword text,
+  weakest_section text,
+  top_recommendation_key text,
+  top_recommendation_title text,
+  top_recommendation_reason text,
+  top_recommendation_action text,
+  top_recommendation_impact text check (top_recommendation_impact in ('high','medium','low')),
+  recommended_headline text,
+  missing_fields jsonb not null default '[]'::jsonb,
+  completed_fields jsonb not null default '[]'::jsonb,
+  trust_signals jsonb not null default '{}'::jsonb,
+  photo_analysis jsonb not null default '{}'::jsonb,
+  content_analysis jsonb not null default '{}'::jsonb,
+  market_analysis jsonb not null default '{}'::jsonb,
+  recommendation_list jsonb not null default '[]'::jsonb,
+  trial_status text,
+  trial_day integer,
+  trial_days_remaining integer,
+  subscription_tier text,
+  email_subject text,
+  email_preheader text,
+  email_payload jsonb not null default '{}'::jsonb,
+  generated_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique(profile_id, snapshot_date)
+);
+
+create index if not exists ai_profile_coach_daily_snapshots_profile_date_idx
+  on public.ai_profile_coach_daily_snapshots(profile_id, snapshot_date desc);
+
+create table if not exists public.ai_profile_coach_email_preferences (
+  profile_id uuid primary key references public.profiles(id) on delete cascade,
+  daily_email_enabled boolean not null default true,
+  send_time_local time not null default '08:00',
+  timezone text not null default 'America/Chicago',
+  include_performance boolean not null default true,
+  include_market_insights boolean not null default true,
+  include_trial_status boolean not null default true,
+  include_ai_rewrite boolean not null default true,
+  last_sent_at timestamptz,
+  last_queued_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.ai_profile_coach_daily_snapshots enable row level security;
+alter table public.ai_profile_coach_email_preferences enable row level security;
+
+drop policy if exists providers_read_own_ai_coach_snapshots on public.ai_profile_coach_daily_snapshots;
+create policy providers_read_own_ai_coach_snapshots
+  on public.ai_profile_coach_daily_snapshots for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+drop policy if exists providers_manage_own_ai_coach_preferences on public.ai_profile_coach_email_preferences;
+create policy providers_manage_own_ai_coach_preferences
+  on public.ai_profile_coach_email_preferences for all to authenticated
+  using (profile_id = (select auth.uid()))
+  with check (profile_id = (select auth.uid()));
+
+grant select on public.ai_profile_coach_daily_snapshots to authenticated;
+grant select, insert, update, delete on public.ai_profile_coach_email_preferences to authenticated;
+grant all on public.ai_profile_coach_daily_snapshots to service_role;
+grant all on public.ai_profile_coach_email_preferences to service_role;
+
+create or replace view public.ai_profile_coach_source
+with (security_invoker = true)
+as
+select
+  p.id as profile_id,
+  coalesce(p.display_name, p.full_name, 'Provider') as display_name,
+  coalesce(p.email_address, p.email) as recipient_email,
+  p.slug,
+  p.headline,
+  p.tagline,
+  p.bio,
+  p.city,
+  p.state,
+  p.neighborhood,
+  p.country,
+  p.photo_url,
+  p.avatar_url,
+  p.profile_completion_score,
+  p.profile_completeness,
+  p.completion_score,
+  p.completion_percentage,
+  p.visibility_status,
+  p.profile_status,
+  p.verification_status,
+  p.subscription_tier,
+  p.subscription_status,
+  p.current_period_end,
+  p.subscription_current_period_start,
+  p.subscription_current_period_end,
+  p.is_featured,
+  p.featured_until,
+  p.available_now,
+  p.available_now_expires,
+  p.offers_incall,
+  p.offers_outcall,
+  p.incall,
+  p.outcall,
+  p.starting_price,
+  p.starting_rate,
+  p.incall_price,
+  p.outcall_price,
+  p.pricing_sessions,
+  p.rates,
+  p.session_lengths,
+  p.service_categories,
+  p.massage_techniques,
+  p.modalities,
+  p.specialties,
+  p.languages,
+  p.languages_spoken,
+  p.years_experience,
+  p.education_entries,
+  p.certifications,
+  p.training,
+  p.affiliations,
+  p.massage_setup,
+  p.incall_amenities,
+  p.studio_amenities,
+  p.mobile_extras,
+  p.products_used,
+  p.payment_methods,
+  p.areas_served,
+  p.travel_schedule,
+  p.business_trips,
+  p.is_verified_phone,
+  p.is_verified_email,
+  p.is_verified_identity,
+  p.is_verified_profile,
+  p.is_verified_photos,
+  p.lgbtq_affirming,
+  p.accepts_all_genders,
+  p.view_count,
+  p.profile_views,
+  p.contact_clicks,
+  p.inquiry_count,
+  p.review_count,
+  p.average_rating,
+  p.last_seen_at,
+  p.updated_at,
+  (select count(*) from public.profile_photos pp where pp.profile_id = p.id and pp.moderation_status = 'approved') as approved_photo_count,
+  (select count(*) from public.profile_view_analytics pva where pva.profile_id = p.id and pva.created_at >= now() - interval '1 day') as profile_views_1d,
+  (select count(*) from public.profile_view_analytics pva where pva.profile_id = p.id and pva.created_at >= now() - interval '7 days') as profile_views_7d,
+  (select count(*) from public.profile_view_analytics pva where pva.profile_id = p.id and pva.created_at >= now() - interval '30 days') as profile_views_30d,
+  (select count(*) from public.contact_events ce where ce.profile_id = p.id and ce.created_at >= now() - interval '1 day') as contact_clicks_1d,
+  (select count(*) from public.contact_events ce where ce.profile_id = p.id and ce.created_at >= now() - interval '7 days') as contact_clicks_7d,
+  (select count(*) from public.contact_events ce where ce.profile_id = p.id and ce.created_at >= now() - interval '30 days') as contact_clicks_30d,
+  (select count(*) from public.favorites f where f.profile_id = p.id and f.created_at >= now() - interval '7 days') as favorites_7d,
+  (select count(*) from public.contact_inquiries ci where ci.profile_id = p.id and ci.created_at >= now() - interval '7 days') as inquiries_7d,
+  (select avg(re.position_in_results)::numeric(8,2) from public.ranking_events re where re.profile_id = p.id and re.created_at >= now() - interval '7 days' and re.position_in_results is not null) as average_search_position,
+  (select ds.score from public.demand_scores ds where lower(ds.city) = lower(p.city) and lower(ds.state) = lower(p.state) order by ds.week_start desc limit 1) as local_demand_score,
+  (select ds.trend from public.demand_scores ds where lower(ds.city) = lower(p.city) and lower(ds.state) = lower(p.state) order by ds.week_start desc limit 1) as local_demand_trend
+from public.profiles p
+where coalesce(p.is_demo, false) = false
+  and coalesce(p.is_banned, false) = false
+  and coalesce(p.is_suspended, false) = false;
+
+revoke all on public.ai_profile_coach_source from public, anon, authenticated;
+grant select on public.ai_profile_coach_source to service_role;

--- a/supabase/migrations/20260723160000_ai_profile_coach_growth_engine.sql
+++ b/supabase/migrations/20260723160000_ai_profile_coach_growth_engine.sql
@@ -170,12 +170,3 @@ create policy providers_manage_own_ai_coach_preferences
 alter view public.ai_profile_coach_source set (security_invoker = true);
 revoke all on public.ai_profile_coach_source from public, anon, authenticated;
 grant select on public.ai_profile_coach_source to service_role;
-
--- SECURITY DEFINER functions must never be callable through the public REST API.
-revoke all on function public.ai_profile_coach_build_snapshot(uuid, date) from public, anon, authenticated;
-revoke all on function public.ai_profile_coach_render_email(uuid) from public, anon, authenticated;
-revoke all on function public.ai_profile_coach_queue_due_emails() from public, anon, authenticated;
-
-grant execute on function public.ai_profile_coach_build_snapshot(uuid, date) to service_role;
-grant execute on function public.ai_profile_coach_render_email(uuid) to service_role;
-grant execute on function public.ai_profile_coach_queue_due_emails() to service_role;

--- a/supabase/migrations/20260723160000_ai_profile_coach_growth_engine.sql
+++ b/supabase/migrations/20260723160000_ai_profile_coach_growth_engine.sql
@@ -1,0 +1,181 @@
+-- AI Profile Coach growth engine
+-- Backward-compatible additions used by the provider dashboard and reporting jobs.
+
+create table if not exists public.ai_profile_analysis_runs (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  analysis_type text not null check (analysis_type in ('profile','seo','competitor','market','forecast','ranking','photo','report')),
+  status text not null default 'completed' check (status in ('queued','running','completed','failed')),
+  provider text,
+  model text,
+  input_summary jsonb not null default '{}'::jsonb,
+  result jsonb not null default '{}'::jsonb,
+  error_message text,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+create index if not exists ai_profile_analysis_runs_profile_created_idx
+  on public.ai_profile_analysis_runs(profile_id, created_at desc);
+
+create table if not exists public.ai_profile_photo_scores (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  photo_id uuid not null references public.profile_photos(id) on delete cascade,
+  overall_score integer not null default 0 check (overall_score between 0 and 100),
+  pose_score integer not null default 0 check (pose_score between 0 and 100),
+  lighting_score integer not null default 0 check (lighting_score between 0 and 100),
+  smile_score integer not null default 0 check (smile_score between 0 and 100),
+  composition_score integer not null default 0 check (composition_score between 0 and 100),
+  background_score integer not null default 0 check (background_score between 0 and 100),
+  professionalism_score integer not null default 0 check (professionalism_score between 0 and 100),
+  sharpness_score integer not null default 0 check (sharpness_score between 0 and 100),
+  thumbnail_score integer not null default 0 check (thumbnail_score between 0 and 100),
+  predicted_ctr_lift_pct numeric(8,2),
+  recommended_primary boolean not null default false,
+  strengths jsonb not null default '[]'::jsonb,
+  improvements jsonb not null default '[]'::jsonb,
+  recommendation text,
+  analysis_mode text not null default 'metadata' check (analysis_mode in ('vision','metadata')),
+  provider text,
+  model text,
+  analyzed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(profile_id, photo_id)
+);
+
+create index if not exists ai_profile_photo_scores_profile_score_idx
+  on public.ai_profile_photo_scores(profile_id, overall_score desc);
+
+create table if not exists public.ai_profile_content_drafts (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  field text not null check (field in ('headline','tagline','bio','seo_title','seo_description','seo_keywords')),
+  source_text text,
+  suggested_text text not null,
+  suggested_keywords text[] not null default '{}'::text[],
+  rationale text,
+  provider text,
+  model text,
+  status text not null default 'draft' check (status in ('draft','accepted','dismissed')),
+  created_at timestamptz not null default now(),
+  accepted_at timestamptz
+);
+
+create index if not exists ai_profile_content_drafts_profile_created_idx
+  on public.ai_profile_content_drafts(profile_id, created_at desc);
+
+create table if not exists public.ai_profile_optimization_runs (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  status text not null default 'preview' check (status in ('preview','applied','cancelled','failed')),
+  before_state jsonb not null default '{}'::jsonb,
+  after_state jsonb not null default '{}'::jsonb,
+  applied_fields text[] not null default '{}'::text[],
+  estimated_impact jsonb not null default '{}'::jsonb,
+  provider text,
+  model text,
+  created_at timestamptz not null default now(),
+  applied_at timestamptz,
+  error_message text
+);
+
+create index if not exists ai_profile_optimization_runs_profile_created_idx
+  on public.ai_profile_optimization_runs(profile_id, created_at desc);
+
+create table if not exists public.ai_profile_reports (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  period_type text not null check (period_type in ('weekly','monthly')),
+  period_start date not null,
+  period_end date not null,
+  summary jsonb not null default '{}'::jsonb,
+  narrative text,
+  provider text,
+  model text,
+  generated_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique(profile_id, period_type, period_start, period_end),
+  check (period_end >= period_start)
+);
+
+create index if not exists ai_profile_reports_profile_period_idx
+  on public.ai_profile_reports(profile_id, period_end desc);
+
+alter table public.ai_profile_analysis_runs enable row level security;
+alter table public.ai_profile_photo_scores enable row level security;
+alter table public.ai_profile_content_drafts enable row level security;
+alter table public.ai_profile_optimization_runs enable row level security;
+alter table public.ai_profile_reports enable row level security;
+
+-- Direct reads are limited to the signed-in provider. Mutations are performed
+-- by authenticated server routes through the service role after session checks.
+drop policy if exists ai_profile_analysis_runs_select_own on public.ai_profile_analysis_runs;
+create policy ai_profile_analysis_runs_select_own
+  on public.ai_profile_analysis_runs for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+drop policy if exists ai_profile_photo_scores_select_own on public.ai_profile_photo_scores;
+create policy ai_profile_photo_scores_select_own
+  on public.ai_profile_photo_scores for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+drop policy if exists ai_profile_content_drafts_select_own on public.ai_profile_content_drafts;
+create policy ai_profile_content_drafts_select_own
+  on public.ai_profile_content_drafts for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+drop policy if exists ai_profile_optimization_runs_select_own on public.ai_profile_optimization_runs;
+create policy ai_profile_optimization_runs_select_own
+  on public.ai_profile_optimization_runs for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+drop policy if exists ai_profile_reports_select_own on public.ai_profile_reports;
+create policy ai_profile_reports_select_own
+  on public.ai_profile_reports for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+revoke all on table public.ai_profile_analysis_runs from anon, authenticated;
+revoke all on table public.ai_profile_photo_scores from anon, authenticated;
+revoke all on table public.ai_profile_content_drafts from anon, authenticated;
+revoke all on table public.ai_profile_optimization_runs from anon, authenticated;
+revoke all on table public.ai_profile_reports from anon, authenticated;
+
+grant select on table public.ai_profile_analysis_runs to authenticated;
+grant select on table public.ai_profile_photo_scores to authenticated;
+grant select on table public.ai_profile_content_drafts to authenticated;
+grant select on table public.ai_profile_optimization_runs to authenticated;
+grant select on table public.ai_profile_reports to authenticated;
+
+grant all on table public.ai_profile_analysis_runs to service_role;
+grant all on table public.ai_profile_photo_scores to service_role;
+grant all on table public.ai_profile_content_drafts to service_role;
+grant all on table public.ai_profile_optimization_runs to service_role;
+grant all on table public.ai_profile_reports to service_role;
+
+-- Tighten the two existing provider policies and avoid per-row auth.uid() calls.
+drop policy if exists providers_read_own_ai_coach_snapshots on public.ai_profile_coach_daily_snapshots;
+create policy providers_read_own_ai_coach_snapshots
+  on public.ai_profile_coach_daily_snapshots for select to authenticated
+  using (profile_id = (select auth.uid()));
+
+drop policy if exists providers_manage_own_ai_coach_preferences on public.ai_profile_coach_email_preferences;
+create policy providers_manage_own_ai_coach_preferences
+  on public.ai_profile_coach_email_preferences for all to authenticated
+  using (profile_id = (select auth.uid()))
+  with check (profile_id = (select auth.uid()));
+
+-- The source view is server-only and must respect the invoking role.
+alter view public.ai_profile_coach_source set (security_invoker = true);
+revoke all on public.ai_profile_coach_source from public, anon, authenticated;
+grant select on public.ai_profile_coach_source to service_role;
+
+-- SECURITY DEFINER functions must never be callable through the public REST API.
+revoke all on function public.ai_profile_coach_build_snapshot(uuid, date) from public, anon, authenticated;
+revoke all on function public.ai_profile_coach_render_email(uuid) from public, anon, authenticated;
+revoke all on function public.ai_profile_coach_queue_due_emails() from public, anon, authenticated;
+
+grant execute on function public.ai_profile_coach_build_snapshot(uuid, date) to service_role;
+grant execute on function public.ai_profile_coach_render_email(uuid) to service_role;
+grant execute on function public.ai_profile_coach_queue_due_emails() to service_role;

--- a/tests/unit/profile-coach.test.ts
+++ b/tests/unit/profile-coach.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCoachAnalysis,
+  quickProfileScore,
+  type CoachProfile,
+} from "@/lib/ai/profile-coach";
+
+function profile(overrides: Partial<CoachProfile> = {}): CoachProfile {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    display_name: "Jordan Kai",
+    full_name: "Jordan Kai",
+    headline: "Deep Tissue & Sports Massage in Dallas",
+    tagline: "Personalized bodywork for recovery and relaxation",
+    bio: "I offer professional, personalized massage sessions focused on comfort, recovery, and relaxation. Every session is adapted to the client's preferred pressure, focus areas, and goals. My approach combines clear communication, a welcoming environment, and careful attention to the details that make a session feel comfortable and effective. Clients can review services, rates, availability, and contact options directly through the profile. I value trust, professionalism, inclusion, and a calm experience from the first message through the end of the session. My work may include deep tissue, sports-focused techniques, and relaxation methods depending on the client's needs and preferences.",
+    city: "Dallas",
+    state: "TX",
+    neighborhood: "Oak Lawn",
+    slug: "jordan-kai",
+    photo_url: null,
+    avatar_url: null,
+    massage_techniques: ["Deep Tissue", "Sports", "Swedish"],
+    modalities: [],
+    specialties: ["Recovery"],
+    service_categories: [],
+    languages: ["English"],
+    languages_spoken: [],
+    years_experience: 6,
+    offers_incall: true,
+    offers_outcall: true,
+    incall: true,
+    outcall: true,
+    starting_price: 140,
+    starting_rate: 140,
+    incall_price: 140,
+    outcall_price: 170,
+    pricing_sessions: [{ minutes: 60, incall_rate: 140 }],
+    rates: null,
+    session_lengths: [60, 90],
+    incall_amenities: ["Free parking", "Shower"],
+    studio_amenities: [],
+    payment_methods: ["Cash", "Zelle"],
+    areas_served: ["Dallas", "Uptown"],
+    travel_schedule: [],
+    business_trips: [],
+    education_entries: [{ institution: "Example School" }],
+    certifications: "Continuing education",
+    training: null,
+    is_verified_phone: true,
+    is_verified_email: true,
+    is_verified_identity: true,
+    is_verified_profile: true,
+    is_verified_photos: true,
+    lgbtq_affirming: true,
+    accepts_all_genders: true,
+    available_now: true,
+    is_featured: false,
+    seo_title: "Deep Tissue Massage in Dallas | Jordan Kai",
+    seo_description: "Professional deep tissue and sports massage sessions in Dallas with direct contact, rates, and availability.",
+    seo_keywords: ["deep tissue massage Dallas", "sports massage Dallas"],
+    review_count: 8,
+    average_rating: 4.9,
+    subscription_tier: "pro",
+    visibility_status: "public",
+    profile_status: "approved",
+    ...overrides,
+  };
+}
+
+describe("AI Profile Coach scoring", () => {
+  it("scores complete profiles higher than incomplete profiles", () => {
+    const complete = quickProfileScore(profile(), 5);
+    const incomplete = quickProfileScore(profile({
+      headline: null,
+      tagline: null,
+      bio: null,
+      massage_techniques: [],
+      modalities: [],
+      languages: [],
+      city: null,
+      state: null,
+      starting_price: null,
+      starting_rate: null,
+      incall_price: null,
+      is_verified_identity: false,
+      is_verified_phone: false,
+      is_verified_email: false,
+      available_now: false,
+    }), 0);
+
+    expect(complete).toBeGreaterThan(incomplete);
+    expect(complete).toBeGreaterThanOrEqual(80);
+    expect(incomplete).toBeLessThan(40);
+  });
+
+  it("builds recommendations, forecasts, and anonymized competitor benchmarks", () => {
+    const analysis = buildCoachAnalysis({
+      profile: profile({ headline: null, seo_title: null, seo_description: null }),
+      photos: [
+        { id: "photo-1", url: "https://example.com/1.jpg", storage_path: null, is_primary: true, moderation_status: "approved", sort_order: 0 },
+      ],
+      photoScores: [],
+      snapshots: [
+        { snapshot_date: "2026-07-21", profile_score: 70, visibility_score: 68, trust_score: 80, content_score: 65, conversion_score: 72 },
+        { snapshot_date: "2026-07-22", profile_score: 74, visibility_score: 72, trust_score: 82, content_score: 70, conversion_score: 74 },
+      ],
+      rankings: [
+        { position_in_results: 12, created_at: "2026-07-22T10:00:00Z" },
+        { position_in_results: 9, created_at: "2026-07-23T10:00:00Z" },
+      ],
+      keywords: [
+        { keyword: "deep tissue massage Dallas", score: 92, trend_direction: "up", week_over_week_change: 18 },
+      ],
+      market: { score: 88, trend: "up", competition_index: 63, search_volume_index: 81 },
+      metrics: {
+        views1d: 12,
+        views7d: 70,
+        views30d: 240,
+        contacts1d: 2,
+        contacts7d: 9,
+        contacts30d: 28,
+        favorites7d: 5,
+        inquiries7d: 3,
+      },
+      competitorScores: [94, 91, 88, 84, 79, 72],
+    });
+
+    expect(analysis.recommendations[0]?.key).toBe("headline");
+    expect(analysis.forecast.contactsHigh).toBeGreaterThanOrEqual(analysis.forecast.contactsLikely);
+    expect(analysis.metrics.contactRate).toBeCloseTo(12.9, 1);
+    expect(analysis.ranking.change).toBe(3);
+    expect(analysis.market.topKeywords[0]?.keyword).toBe("deep tissue massage Dallas");
+    expect(analysis.benchmark.cityProfileCount).toBe(6);
+    expect(analysis.history).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## AI Profile Coach

Implements a light, brand-aligned provider experience based on the approved MasseurMatch concept:

- light provider navigation with a dedicated **AI Profile Coach** entry
- left AI-powered promotional banner with MasseurMatch branding
- profile photo and provider summary at the top of the coach dashboard
- profile health, completion, trust, SEO, photo, visibility, and conversion scores
- AI action plan and grounded coach chat
- DeepSeek-first copy rewriting through the existing shared AI provider chain
- one-click optimization preview with explicit approval before profile changes
- optional OpenAI Vision photo presentation scoring with a deterministic fallback
- city market intelligence, anonymized top-100 benchmark, ranking explanations, and seven-day contact estimates
- weekly and monthly executive reports
- Supabase snapshot, photo-score, draft, optimization, report, RLS, and security migrations
- unit coverage for scoring, forecasting, ranking movement, and benchmarks

## Safety and data handling

- AI routes require an authenticated provider session.
- Service-role access remains server-only.
- Profile changes are never applied without an explicit provider action.
- Forecasts and estimated lifts are labeled as directional estimates, not guarantees.
- Photo analysis evaluates photographic presentation only and does not infer identity or protected traits.

## Merge gate

Do not merge until all of the following are green:

- lint
- typecheck
- unit tests
- API tests
- schema/database contract validation
- release audit
- production build
- GitHub Actions
- Vercel Preview deployment and page verification
- Supabase security review for feature-related objects
