### PR TITLE
fix: keep OAuth PKCE verifier on canonical host

### DIFF
--- a/src/app/auth/oauth/route.ts
+++ b/src/app/auth/oauth/route.ts
@@ -1,0 +1,81 @@
+import { createServerClient } from "@supabase/ssr";
+import type { Provider } from "@supabase/supabase-js";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  SUPABASE_PUBLIC_ANON_KEY,
+  SUPABASE_PUBLIC_URL,
+} from "@/integrations/supabase/client";
+
+const CANONICAL_ORIGIN = "https://www.masseurmatch.com";
+const ALLOWED_PROVIDERS = new Set<Provider>(["google", "apple"]);
+
+function sanitizeNext(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/pro/dashboard";
+  }
+  return value;
+}
+
+function isLocalHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const provider = requestUrl.searchParams.get("provider") as Provider | null;
+  const next = sanitizeNext(requestUrl.searchParams.get("next"));
+
+  if (!provider || !ALLOWED_PROVIDERS.has(provider)) {
+    return NextResponse.redirect(new URL("/login?error=unsupported_oauth_provider", requestUrl.origin));
+  }
+
+  // PKCE's verifier cookie must be created and consumed on the same host.
+  // Supabase falls back to the configured Site URL when a preview/deployment
+  // hostname is not allow-listed, which previously moved the callback to www
+  // and caused `bad_code_verifier`. Start production OAuth only on the
+  // canonical host so the verifier and callback always share one cookie jar.
+  if (process.env.NODE_ENV === "production" && !isLocalHost(requestUrl.hostname) && requestUrl.origin !== CANONICAL_ORIGIN) {
+    const canonicalStart = new URL("/auth/oauth", CANONICAL_ORIGIN);
+    canonicalStart.searchParams.set("provider", provider);
+    canonicalStart.searchParams.set("next", next);
+    return NextResponse.redirect(canonicalStart);
+  }
+
+  const cookiesToSet: Array<{
+    name: string;
+    value: string;
+    options?: Parameters<NextResponse["cookies"]["set"]>[2];
+  }> = [];
+
+  const supabase = createServerClient(SUPABASE_PUBLIC_URL, SUPABASE_PUBLIC_ANON_KEY, {
+    cookies: {
+      getAll: () => request.cookies.getAll(),
+      setAll: (values) => {
+        values.forEach(({ name, value, options }) => {
+          cookiesToSet.push({ name, value, options });
+        });
+      },
+    },
+  });
+
+  const callbackUrl = new URL("/auth/callback", requestUrl.origin);
+  callbackUrl.searchParams.set("next", next);
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: {
+      redirectTo: callbackUrl.toString(),
+      skipBrowserRedirect: true,
+    },
+  });
+
+  if (error || !data.url) {
+    console.error("[auth/oauth] failed to start OAuth:", error?.message);
+    return NextResponse.redirect(new URL("/login?error=oauth_start_failed", requestUrl.origin));
+  }
+
+  const response = NextResponse.redirect(data.url);
+  cookiesToSet.forEach(({ name, value, options }) => response.cookies.set(name, value, options));
+  return response;
+}

--- a/src/app/login/LoginPageClient.tsx
+++ b/src/app/login/LoginPageClient.tsx
@@ -1,6 +1,6 @@
 ﻿"use client";
 
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, type MouseEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { AuthForms } from "@/app/_components/auth-forms";
 import { useAuth } from "@/contexts/AuthContext";
@@ -39,8 +39,30 @@ function LoginPageContent() {
     router.replace(redirectTo);
   }, [loading, redirectTo, router, user]);
 
+  const startOAuth = (event: MouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    const button = target.closest("button");
+    const label = button?.textContent ?? "";
+    const provider = label.includes("Google") ? "google" : label.includes("Apple") ? "apple" : null;
+
+    if (!provider) {
+      return;
+    }
+
+    // Capture the social-button click before the legacy browser OAuth handler.
+    // The server route owns PKCE cookie creation, redirects preview/apex hosts to
+    // the canonical www host, and guarantees the callback consumes the verifier
+    // from the same cookie jar.
+    event.preventDefault();
+    event.stopPropagation();
+    const startUrl = new URL("/auth/oauth", window.location.origin);
+    startUrl.searchParams.set("provider", provider);
+    startUrl.searchParams.set("next", redirectTo);
+    window.location.assign(startUrl.toString());
+  };
+
   return (
-    <div className="relative isolate overflow-hidden px-4 py-10 sm:py-14">
+    <div className="relative isolate overflow-hidden px-4 py-10 sm:py-14" onClickCapture={startOAuth}>
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_20%,rgba(139,30,45,0.14),transparent_40%),radial-gradient(circle_at_82%_18%,rgba(139,30,45,0.10),transparent_34%)]" />
       <div className="pointer-events-none absolute -top-16 left-1/2 -z-10 h-56 w-56 -translate-x-1/2 rounded-full bg-red-300/20 blur-3xl" />
 


### PR DESCRIPTION
## Fix

- starts Google/Apple OAuth through a server route
- creates the PKCE verifier cookie server-side
- redirects preview and apex hosts to `www.masseurmatch.com` before OAuth starts
- keeps callback and verifier on the same cookie jar
- prevents `bad_code_verifier` / `auth_callback_failed`

## Evidence

Supabase Auth logs showed `bad_code_verifier` with `code challenge does not match previously saved code verifier` during Google login.

## Merge gate

Do not merge until lint, typecheck, unit tests, build, E2E, accessibility, release checks, Vercel preview, and auth diagnostics are green.