### PR TITLE
fix: restore typed profile rollback payload

### DIFF
--- a/src/app/api/admin/profile-cms/rollback/route.ts
+++ b/src/app/api/admin/profile-cms/rollback/route.ts
@@ -4,6 +4,8 @@ import {
   requireAdminSession,
   recordAuditLog,
 } from "@/app/api/_lib/supabase-server";
+import { getFieldByKey } from "@/lib/profile-fields-config";
+import type { Database, Json } from "@/integrations/supabase/types";
 
 export const dynamic = "force-dynamic";
 
@@ -18,18 +20,22 @@ type AuditDetails = {
   new_value?: unknown;
 };
 
-/**
- * Convert unknown values to JSON-serializable format
- */
-function toJsonValue(value: unknown): any {
+type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
+
+function toJson(value: unknown): Json {
   if (value === null || value === undefined) return null;
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     return value;
   }
-  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
-    return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => toJson(item));
   }
-  return null;
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, toJson(item)]),
+    );
+  }
+  return String(value);
 }
 
 export async function POST(request: Request) {
@@ -57,35 +63,47 @@ export async function POST(request: Request) {
         : {};
     const fieldName = typeof details.field_name === "string" ? details.field_name : null;
 
-    if (!fieldName) {
-      return Response.json({ error: "Audit log entry has no field name" }, { status: 400 });
+    if (!fieldName || !getFieldByKey(fieldName)) {
+      return Response.json({ error: "Audit log entry has an invalid field name" }, { status: 400 });
     }
+
+    const oldValue = toJson(details.old_value);
+    const newValue = toJson(details.new_value);
+    const updatePayload = {
+      [fieldName]: oldValue,
+      updated_at: new Date().toISOString(),
+    } as unknown as ProfileUpdate;
 
     const { error: updateError } = await supabase
       .from("profiles")
-      .update({
-        [fieldName]: toJsonValue(details.old_value) ?? null,
-        updated_at: new Date().toISOString(),
-      })
+      .update(updatePayload)
       .eq("id", profile_id);
 
     if (updateError) {
       return Response.json({ error: "Failed to rollback" }, { status: 500 });
     }
 
-    await recordAuditLog(admin.userId, "provider.profile.field_rollback", "profile", profile_id, {
+    const auditDetails: Json = {
       field_name: fieldName,
-      old_value: toJsonValue(details.new_value) ?? null,
-      new_value: toJsonValue(details.old_value) ?? null,
+      old_value: newValue,
+      new_value: oldValue,
       source_audit_log_id: audit_log_id,
       rolled_back_at: new Date().toISOString(),
-    });
+    };
+
+    await recordAuditLog(
+      admin.userId,
+      "provider.profile.field_rollback",
+      "profile",
+      profile_id,
+      auditDetails,
+    );
 
     return Response.json({
       ok: true,
       profile_id,
       field_name: fieldName,
-      rolled_back_value: toJsonValue(details.old_value) ?? null,
+      rolled_back_value: oldValue,
     });
   } catch (error) {
     console.error("Rollback error:", error);


### PR DESCRIPTION
## Summary
- restore the generated `profiles.Update` type for dynamic rollback payloads
- validate rollback field names against the profile field registry
- preserve JSON-safe audit values

## Root cause
A later refactor replaced the typed payload with an object carrying a string index signature. Supabase's generated client rejects that shape because dynamic keys are not proven to be valid profile columns.

## Fix
Build the payload, validate the field name, and cast through `unknown` to the generated `Database["public"]["Tables"]["profiles"]["Update"]` type before calling `.update()`.