### PR TITLE
fix(ci): prevent transient Supabase timeouts from blocking Vercel

### DIFF
--- a/scripts/validate-supabase-env.mjs
+++ b/scripts/validate-supabase-env.mjs
@@ -63,7 +63,7 @@ function parseSupabaseUrl(name, value) {
 
 function readJwtProjectRef(name, token) {
   // New Supabase publishable keys are opaque. Their project is validated by
-  // the URL reachability check. Legacy anon and service-role keys are JWTs.
+  // the URL configuration checks. Legacy anon and service-role keys are JWTs.
   if (token.startsWith("sb_publishable_") || token.startsWith("sb_secret_")) {
     return null;
   }
@@ -86,10 +86,11 @@ function delay(milliseconds) {
 }
 
 async function verifyReachable(origin) {
-  if (process.env.VERCEL !== "1") {
+  if (process.env.VERCEL !== "1" && process.env.SUPABASE_HEALTHCHECK_STRICT !== "1") {
     return;
   }
 
+  const strict = process.env.SUPABASE_HEALTHCHECK_STRICT === "1";
   const attempts = 3;
   const timeoutMs = 12_000;
   let lastDetail = "unknown network error";
@@ -127,9 +128,17 @@ async function verifyReachable(origin) {
     }
   }
 
-  fail(
-    `Supabase project ${origin} is unreachable after ${attempts} attempts (${lastDetail}). ` +
-      "The deployment may reference a deleted or stale preview branch.",
+  const message =
+    `Supabase project ${origin} was unreachable after ${attempts} attempts (${lastDetail}). ` +
+    "Static URL and key validation passed.";
+
+  if (strict) {
+    fail(message);
+  }
+
+  console.warn(
+    `\nSupabase reachability warning: ${message} ` +
+      "Continuing the build because external network availability is not a reliable build gate.\n",
   );
 }
 


### PR DESCRIPTION
## What changed
- keeps all deterministic Supabase URL, production project-ref, and JWT project checks as hard failures
- retries the live Supabase health endpoint three times
- treats network-only reachability failures as warnings during normal Vercel builds
- supports `SUPABASE_HEALTHCHECK_STRICT=1` for scheduled/explicit outage checks that must fail

## Why
The production Supabase project is healthy, but Vercel aborted the build after a transient `fetch` timeout. External service reachability is not a reliable build gate and caused a false deployment failure.

## Prevention
Use the normal build for configuration validation. Run the same validator separately with `SUPABASE_HEALTHCHECK_STRICT=1` in scheduled monitoring or operational checks.