### PR TITLE
fix(auth): reduce delay before provider dashboard

### DIFF
--- a/src/app/api/pro/profile/cms-update/route.ts
+++ b/src/app/api/pro/profile/cms-update/route.ts
@@ -15,6 +15,7 @@ const fieldUpdateSchema = z.object({
 });
 
 type FieldUpdateRequest = z.infer<typeof fieldUpdateSchema>;
+type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
 
 /**
  * Extract client IP address from request headers
@@ -135,7 +136,7 @@ export async function POST(request: Request) {
     }
 
     // Parse and validate request body
-    const body = await parseJsonBody(request, fieldUpdateSchema);
+    const body: FieldUpdateRequest = await parseJsonBody(request, fieldUpdateSchema);
 
     // Validate field exists and is editable
     const fieldDef = getFieldByKey(body.field_name);
@@ -165,11 +166,13 @@ export async function POST(request: Request) {
     let updatedProfile = profile;
 
     if (hasChanged) {
-      // Prepare the update object with dynamic field name
-      const updates: Record<string, any> = {
+      // The key is dynamic but has already been validated against the profile
+      // field registry. Cast only at this boundary to satisfy strict generated
+      // Supabase update types while retaining runtime field validation.
+      const updates = {
         [body.field_name]: newValue,
         updated_at: new Date().toISOString(),
-      };
+      } as unknown as ProfileUpdate;
 
       // If profile was approved, mark as under_review for changes
       if (profile.profile_status === "approved") {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -58,20 +58,14 @@ type SubscriptionResponse = {
 };
 
 /**
- * After the server auth routes write the Supabase cookies, make sure the
- * browser client's in-memory session reflects them. getSession() reads the
- * freshly-set cookies; if the adapter hasn't picked them up yet we sign in
- * directly once as a fallback (no retry storms).
+ * The server auth routes already perform the password exchange and write the
+ * Supabase SSR cookies. Reading those cookies is enough to mirror the session
+ * into the browser client; signing in with the password a second time adds an
+ * unnecessary network round-trip and can rotate the session again.
  */
-async function hydrateBrowserSession(
-  email: string,
-  password: string,
-): Promise<Session | null> {
+async function readBrowserSession(): Promise<Session | null> {
   const { data } = await supabase.auth.getSession();
-  if (data.session) return data.session;
-
-  const { data: signInData } = await supabase.auth.signInWithPassword({ email, password });
-  return signInData.session ?? null;
+  return data.session ?? null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -141,10 +135,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const signUp = async (email: string, password: string, fullName: string) => {
     try {
       const result = await registerMutation({ email, password, fullName });
-      // Only hydrate a live session when email confirmation is NOT required.
+      // Only read a live session when email confirmation is NOT required.
       // When it is, there is no session yet — the user must confirm by email.
       if (!result.requiresEmailConfirmation) {
-        const hydrated = await hydrateBrowserSession(email, password);
+        const hydrated = await readBrowserSession();
         setSession(hydrated);
         setUser(hydrated?.user ?? null);
       }
@@ -160,10 +154,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const signIn = async (email: string, password: string) => {
     try {
-      // Server route enforces CSRF, rate limiting and brute-force lockout, then
-      // writes the auth cookies. We only mirror them into the browser client.
+      // The server route enforces CSRF, rate limiting and brute-force lockout,
+      // performs the only password exchange, and writes the auth cookies.
       const result = await loginMutation({ email, password });
-      const hydrated = await hydrateBrowserSession(email, password);
+      const hydrated = await readBrowserSession();
       setSession(hydrated);
       setUser(hydrated?.user ?? null);
       if (hydrated?.user) {


### PR DESCRIPTION
## Problem
Email/password sign-in performs the password exchange twice: once in `/api/auth/login` and again in the browser when hydrating the session. This adds an unnecessary Supabase round-trip and can rotate the freshly-created session before dashboard navigation.

## Change
- Keep the protected server login as the only password exchange.
- Hydrate the browser client by reading the SSR auth cookies with `getSession()`.
- Remove the fallback `signInWithPassword()` call from the client.

## Expected result
Faster transition from successful email/password authentication to `/pro/dashboard`, with fewer Supabase Auth requests and less chance of auth/navigation races.

## Validation notes
Supabase auth logs show the core password exchange completing successfully; the extra latency is in application orchestration. Production is currently promoted from `fix/ai-profile-coach-green-20260723`, so this PR targets `main` and must be included in the next production promotion or cherry-picked into the currently promoted branch.