### PR TITLE
fix(types): make profile CMS updates fully type-safe

### DIFF
--- a/src/app/api/admin/profile-cms/rollback/route.ts
+++ b/src/app/api/admin/profile-cms/rollback/route.ts
@@ -4,8 +4,12 @@ import {
   requireAdminSession,
   recordAuditLog,
 } from "@/app/api/_lib/supabase-server";
-import { getFieldByKey } from "@/lib/profile-fields-config";
-import type { Database, Json } from "@/integrations/supabase/types";
+import {
+  createProfileCmsUpdate,
+  isProfileCmsUpdateField,
+  toProfileCmsJson,
+} from "@/lib/profile-cms-update";
+import type { Json } from "@/integrations/supabase/types";
 
 export const dynamic = "force-dynamic";
 
@@ -19,24 +23,6 @@ type AuditDetails = {
   old_value?: unknown;
   new_value?: unknown;
 };
-
-type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
-
-function toJson(value: unknown): Json {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => toJson(item));
-  }
-  if (typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, item]) => [key, toJson(item)]),
-    );
-  }
-  return String(value);
-}
 
 export async function POST(request: Request) {
   try {
@@ -63,20 +49,21 @@ export async function POST(request: Request) {
         : {};
     const fieldName = typeof details.field_name === "string" ? details.field_name : null;
 
-    if (!fieldName || !getFieldByKey(fieldName)) {
+    if (!fieldName || !isProfileCmsUpdateField(fieldName)) {
       return Response.json({ error: "Audit log entry has an invalid field name" }, { status: 400 });
     }
 
-    const oldValue = toJson(details.old_value);
-    const newValue = toJson(details.new_value);
-    const updatePayload = {
-      [fieldName]: oldValue,
-      updated_at: new Date().toISOString(),
-    } as unknown as ProfileUpdate;
+    let update: ReturnType<typeof createProfileCmsUpdate>;
+    try {
+      update = createProfileCmsUpdate(fieldName, details.old_value);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Invalid rollback value";
+      return Response.json({ error: message }, { status: 400 });
+    }
 
     const { error: updateError } = await supabase
       .from("profiles")
-      .update(updatePayload)
+      .update(update.payload)
       .eq("id", profile_id);
 
     if (updateError) {
@@ -85,8 +72,8 @@ export async function POST(request: Request) {
 
     const auditDetails: Json = {
       field_name: fieldName,
-      old_value: newValue,
-      new_value: oldValue,
+      old_value: toProfileCmsJson(details.new_value),
+      new_value: toProfileCmsJson(update.normalizedValue),
       source_audit_log_id: audit_log_id,
       rolled_back_at: new Date().toISOString(),
     };
@@ -103,7 +90,7 @@ export async function POST(request: Request) {
       ok: true,
       profile_id,
       field_name: fieldName,
-      rolled_back_value: oldValue,
+      rolled_back_value: update.normalizedValue,
     });
   } catch (error) {
     console.error("Rollback error:", error);

--- a/src/app/api/pro/profile/cms-update/route.ts
+++ b/src/app/api/pro/profile/cms-update/route.ts
@@ -3,94 +3,59 @@ import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
 import { assertRateLimit } from "@/app/_lib/security";
 import { requireRequestSession } from "@/app/_lib/session";
-import { getProfileByUserId } from "@/app/_lib/store";
 import { getFieldByKey } from "@/lib/profile-fields-config";
-import type { Database } from "@/integrations/supabase/types";
+import {
+  createProfileCmsUpdate,
+  isProfileCmsUpdateField,
+  toProfileCmsJson,
+  type ProfileCmsUpdateField,
+  type ProfileRow,
+} from "@/lib/profile-cms-update";
+import type { Json } from "@/integrations/supabase/types";
 
-// Request body schema for single field update
 const fieldUpdateSchema = z.object({
   field_name: z.string().min(1).max(100),
   value: z.unknown(),
   reason: z.string().min(1).max(500).optional(),
 });
 
-type FieldUpdateRequest = z.infer<typeof fieldUpdateSchema>;
-type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
-
-/**
- * Extract client IP address from request headers
- */
 function getClientIpAddress(request: Request): string {
   const forwardedFor = request.headers.get("x-forwarded-for");
   if (forwardedFor) {
     return forwardedFor.split(",")[0]?.trim() ?? "unknown";
   }
-  const realIp = request.headers.get("x-real-ip");
-  if (realIp) {
-    return realIp;
-  }
-  return "unknown";
+  return request.headers.get("x-real-ip") ?? "unknown";
 }
 
-/**
- * Get old value from profile, safely handling undefined
- */
-function getOldValue(profile: Record<string, unknown>, fieldName: string): unknown {
+function getOldValue(profile: ProfileRow, fieldName: ProfileCmsUpdateField): unknown {
   return profile[fieldName] ?? null;
 }
 
-/**
- * Convert unknown values to JSON-serializable format
- */
-function toJsonValue(value: unknown): any {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return value;
-  }
-  if (Array.isArray(value) || (typeof value === "object" && value !== null)) {
-    return value;
-  }
-  return null;
-}
-
-/**
- * Validate and prepare the update value using the field's validation schema
- */
-async function validateAndPrepareValue(
-  fieldName: string,
-  value: unknown,
-): Promise<unknown> {
+function validateAndPrepareValue(fieldName: ProfileCmsUpdateField, value: unknown): unknown {
   const fieldDef = getFieldByKey(fieldName);
 
   if (!fieldDef) {
     throw new RouteError(400, `Field "${fieldName}" does not exist in profile schema.`);
   }
-
   if (!fieldDef.editable) {
     throw new RouteError(403, `Field "${fieldName}" is not editable by users.`);
   }
-
   if (fieldDef.adminOnly) {
     throw new RouteError(403, `Field "${fieldName}" can only be edited by administrators.`);
   }
 
-  // Validate using the field's validation schema
   try {
-    const validated = fieldDef.validationSchema.parse(value);
-    return validated;
+    return fieldDef.validationSchema.parse(value);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Validation failed";
     throw new RouteError(400, `Invalid value for field "${fieldName}": ${message}`);
   }
 }
 
-/**
- * Record audit log entry for the field update
- */
 async function recordFieldAuditLog(
   userId: string,
   profileId: string,
-  fieldName: string,
+  fieldName: ProfileCmsUpdateField,
   oldValue: unknown,
   newValue: unknown,
   reason: string | undefined,
@@ -99,10 +64,10 @@ async function recordFieldAuditLog(
   const adminClient = createSupabaseAdminClient();
 
   try {
-    const details = {
+    const details: Json = {
       field_name: fieldName,
-      old_value: toJsonValue(oldValue),
-      new_value: toJsonValue(newValue),
+      old_value: toProfileCmsJson(oldValue),
+      new_value: toProfileCmsJson(newValue),
       reason: reason || null,
       ip_address: ipAddress,
       updated_at: new Date().toISOString(),
@@ -117,70 +82,57 @@ async function recordFieldAuditLog(
     });
   } catch (error) {
     console.error("[api/pro/profile/cms-update] Audit log recording failed:", error);
-    // Continue even if audit log fails - don't break the update
   }
 }
 
 export async function POST(request: Request) {
   try {
-    // Rate limit: max 20 requests per minute
     assertRateLimit(request, "pro-profile-cms-field", { limit: 20, windowMs: 60_000 });
-
-    // Require authenticated session
     const session = await requireRequestSession(request);
+    const adminClient = createSupabaseAdminClient();
 
-    // Get user's profile
-    const profile = await getProfileByUserId(session.userId);
+    const { data: profile, error: profileError } = await adminClient
+      .from("profiles")
+      .select("*")
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    if (profileError) {
+      throw new RouteError(500, `Profile lookup failed: ${profileError.message}`);
+    }
     if (!profile) {
       throw new RouteError(404, "Profile not found.");
     }
 
-    // Parse and validate request body
-    const body: FieldUpdateRequest = await parseJsonBody(request, fieldUpdateSchema);
+    const body = await parseJsonBody(request, fieldUpdateSchema);
 
-    // Validate field exists and is editable
-    const fieldDef = getFieldByKey(body.field_name);
-    if (!fieldDef) {
-      throw new RouteError(400, `Field "${body.field_name}" does not exist in profile schema.`);
+    if (!isProfileCmsUpdateField(body.field_name)) {
+      throw new RouteError(400, `Field "${body.field_name}" is not an allowed profile column.`);
+    }
+    const fieldName = body.field_name;
+
+    const validatedValue = validateAndPrepareValue(fieldName, body.value);
+    let update: ReturnType<typeof createProfileCmsUpdate>;
+    try {
+      update = createProfileCmsUpdate(fieldName, validatedValue);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Invalid profile value";
+      throw new RouteError(400, message);
     }
 
-    if (!fieldDef.editable) {
-      throw new RouteError(403, `Field "${body.field_name}" is not editable.`);
-    }
-
-    if (fieldDef.adminOnly) {
-      throw new RouteError(403, `Field "${body.field_name}" can only be edited by administrators.`);
-    }
-
-    // Validate and prepare the new value
-    const newValue = await validateAndPrepareValue(body.field_name, body.value);
-
-    // Get the old value from the profile
-    const profileData = profile as Record<string, unknown>;
-    const oldValue = getOldValue(profileData, body.field_name);
-
-    // If no change, return without updating
+    const oldValue = getOldValue(profile, fieldName);
+    const newValue = update.normalizedValue;
     const hasChanged = JSON.stringify(oldValue) !== JSON.stringify(newValue);
-
-    const adminClient = createSupabaseAdminClient();
-    let updatedProfile = profile;
+    let updatedProfile: ProfileRow = profile;
 
     if (hasChanged) {
-      // The key is dynamic but has already been validated against the profile
-      // field registry. Cast only at this boundary to satisfy strict generated
-      // Supabase update types while retaining runtime field validation.
-      const updates = {
-        [body.field_name]: newValue,
-        updated_at: new Date().toISOString(),
-      } as unknown as ProfileUpdate;
+      const updates = update.payload;
 
-      // If profile was approved, mark as under_review for changes
       if (profile.profile_status === "approved") {
         updates.profile_status = "under_review";
-        updates.visibility_status = "public"; // Keep visible while under review
+        updates.visibility_status = "public";
       }
 
-      // Update the profile
       const { data: nextProfile, error } = await adminClient
         .from("profiles")
         .update(updates)
@@ -191,7 +143,6 @@ export async function POST(request: Request) {
       if (error) {
         throw new RouteError(500, `Database update failed: ${error.message}`);
       }
-
       if (!nextProfile) {
         throw new RouteError(500, "Profile update returned no data.");
       }
@@ -199,21 +150,16 @@ export async function POST(request: Request) {
       updatedProfile = nextProfile;
     }
 
-    // Get client IP address
-    const ipAddress = getClientIpAddress(request);
-
-    // Record audit log
     await recordFieldAuditLog(
       session.userId,
       profile.id,
-      body.field_name,
+      fieldName,
       oldValue,
       newValue,
       body.reason,
-      ipAddress,
+      getClientIpAddress(request),
     );
 
-    // Trigger revalidation if slug exists
     if (updatedProfile.slug || profile.slug) {
       await import("@/app/_lib/revalidate")
         .then(({ buildTherapistRevalidatePaths, triggerRevalidate }) =>
@@ -230,7 +176,7 @@ export async function POST(request: Request) {
 
     return json({
       success: true,
-      field_name: body.field_name,
+      field_name: fieldName,
       old_value: oldValue,
       new_value: newValue,
       changed: hasChanged,

--- a/src/components/profile-cms/FieldPreview.tsx
+++ b/src/components/profile-cms/FieldPreview.tsx
@@ -35,14 +35,18 @@ export const FieldPreview = React.forwardRef<
         }
         return (
           <div className="flex flex-wrap gap-2">
-            {value.map((item, idx) => (
-              <div
-                key={`${item}-${idx}`}
-                className="inline-flex items-center px-3 py-1 bg-accent/10 text-accent rounded-lg border border-accent/20 text-sm font-medium"
-              >
-                {item}
-              </div>
-            ))}
+            {value.map((item, idx) => {
+              const displayValue =
+                typeof item === "string" ? item : JSON.stringify(item) ?? String(item);
+              return (
+                <div
+                  key={`${displayValue}-${idx}`}
+                  className="inline-flex items-center px-3 py-1 bg-accent/10 text-accent rounded-lg border border-accent/20 text-sm font-medium"
+                >
+                  {displayValue}
+                </div>
+              );
+            })}
           </div>
         );
 
@@ -63,12 +67,15 @@ export const FieldPreview = React.forwardRef<
           );
         }
 
-      case FieldType.INTEGER:
+      case FieldType.INTEGER: {
+        const displayValue =
+          typeof value === "number" || typeof value === "string" ? value : 0;
         return (
           <span className="font-mono text-sm font-bold text-accent">
-            {value ?? 0}
+            {displayValue}
           </span>
         );
+      }
 
       case FieldType.SELECT: {
         const option = config.options?.find((opt) => opt.value === value);

--- a/src/lib/profile-cms-update.ts
+++ b/src/lib/profile-cms-update.ts
@@ -1,0 +1,215 @@
+import type { Database, Json } from "@/integrations/supabase/types";
+
+export type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+export type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
+
+export const PROFILE_CMS_UPDATE_FIELDS = [
+  "display_name",
+  "full_name",
+  "avatar_url",
+  "email",
+  "slug",
+  "bio",
+  "education",
+  "training",
+  "certifications",
+  "massage_setup",
+  "incall_amenities",
+  "mobile_extras",
+  "products_used",
+  "products_sold",
+  "studio_amenities",
+  "affiliations",
+  "pricing_sessions",
+  "regular_discounts",
+  "day_of_week_discount",
+  "weekly_special",
+  "business_hours",
+  "incall",
+  "outcall",
+  "traveling",
+  "starting_price",
+  "outcall_radius_miles",
+  "seo_title",
+  "seo_description",
+  "presentation_video_url",
+  "social_media",
+  "tagline",
+  "booking_platform",
+  "booking_url",
+  "keyword_slugs",
+  "custom_faq",
+  "years_experience",
+  "seo_keywords",
+] as const satisfies readonly (keyof ProfileUpdate & keyof ProfileRow)[];
+
+export type ProfileCmsUpdateField = (typeof PROFILE_CMS_UPDATE_FIELDS)[number];
+export type ProfileCmsUpdateValue = Exclude<
+  ProfileUpdate[ProfileCmsUpdateField],
+  undefined
+>;
+
+export function isProfileCmsUpdateField(value: string): value is ProfileCmsUpdateField {
+  return PROFILE_CMS_UPDATE_FIELDS.some((field) => field === value);
+}
+
+function invalidValue(fieldName: ProfileCmsUpdateField, expected: string): never {
+  throw new TypeError(`Field "${fieldName}" must be ${expected}.`);
+}
+
+function toNullableString(
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  return invalidValue(fieldName, "a string or null");
+}
+
+function toSerializedString(
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+
+  const serialized = JSON.stringify(toProfileCmsJson(value));
+  if (serialized === undefined) {
+    return invalidValue(fieldName, "JSON-serializable");
+  }
+  return serialized;
+}
+
+function toStringArray(
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+): string[] | null {
+  if (value === null || value === undefined) return null;
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+  return invalidValue(fieldName, "an array of strings or null");
+}
+
+function toNullableNumber(
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return invalidValue(fieldName, "a finite number or null");
+}
+
+function toNullableBoolean(
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+): boolean | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "boolean") return value;
+  return invalidValue(fieldName, "a boolean or null");
+}
+
+export function toProfileCmsJson(value: unknown): Json {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return value;
+    throw new TypeError("JSON numbers must be finite.");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => toProfileCmsJson(item));
+  }
+  if (typeof value === "object") {
+    const result: { [key: string]: Json | undefined } = {};
+    for (const [key, item] of Object.entries(value)) {
+      result[key] = toProfileCmsJson(item);
+    }
+    return result;
+  }
+  throw new TypeError("Value is not JSON-serializable.");
+}
+
+function assignProfileCmsUpdateValue(
+  update: ProfileUpdate,
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+): ProfileCmsUpdateValue {
+  switch (fieldName) {
+    case "display_name":
+    case "full_name":
+    case "avatar_url":
+    case "email":
+    case "slug":
+    case "bio":
+    case "seo_title":
+    case "seo_description":
+    case "presentation_video_url":
+    case "tagline":
+    case "booking_platform":
+    case "booking_url": {
+      const normalized = toNullableString(fieldName, value);
+      update[fieldName] = normalized;
+      return normalized;
+    }
+
+    case "education":
+    case "training":
+    case "certifications": {
+      const normalized = toSerializedString(fieldName, value);
+      update[fieldName] = normalized;
+      return normalized;
+    }
+
+    case "massage_setup":
+    case "incall_amenities":
+    case "mobile_extras":
+    case "products_used":
+    case "products_sold":
+    case "studio_amenities":
+    case "affiliations":
+    case "keyword_slugs":
+    case "seo_keywords": {
+      const normalized = toStringArray(fieldName, value);
+      update[fieldName] = normalized;
+      return normalized;
+    }
+
+    case "pricing_sessions":
+    case "regular_discounts":
+    case "day_of_week_discount":
+    case "weekly_special":
+    case "business_hours":
+    case "social_media":
+    case "custom_faq": {
+      const normalized = toProfileCmsJson(value);
+      update[fieldName] = normalized;
+      return normalized;
+    }
+
+    case "incall":
+    case "outcall":
+    case "traveling": {
+      const normalized = toNullableBoolean(fieldName, value);
+      update[fieldName] = normalized;
+      return normalized;
+    }
+
+    case "starting_price":
+    case "outcall_radius_miles":
+    case "years_experience": {
+      const normalized = toNullableNumber(fieldName, value);
+      update[fieldName] = normalized;
+      return normalized;
+    }
+  }
+}
+
+export function createProfileCmsUpdate(
+  fieldName: ProfileCmsUpdateField,
+  value: unknown,
+  updatedAt = new Date().toISOString(),
+): { payload: ProfileUpdate; normalizedValue: ProfileCmsUpdateValue } {
+  const payload: ProfileUpdate = { updated_at: updatedAt };
+  const normalizedValue = assignProfileCmsUpdateValue(payload, fieldName, value);
+  return { payload, normalizedValue };
+}


### PR DESCRIPTION
## Correções
- deriva `ProfileUpdate` e `ProfileRow` dos tipos gerados do Supabase
- adiciona allowlist explícita de colunas CMS realmente presentes em `profiles`
- rejeita nomes de coluna arbitrários antes de montar qualquer update
- normaliza valores por tipo de coluna sem `any`, `as any`, `@ts-ignore` ou desativação de checks
- usa payload `profiles.Update` tanto no update normal quanto no rollback
- mantém autenticação, rate limiting, auditoria, revalidação e respostas HTTP

## Compatibilidade
Esta versão foi reaplicada sobre o `main` mais recente, incluindo a correção de desempenho do login já integrada.

## Validação
O preview Vercel executa o comando real `pnpm run build`.