### PR TITLE
fix(auth): force fresh dashboard load after login

### DIFF
--- a/src/app/_components/auth-forms.tsx
+++ b/src/app/_components/auth-forms.tsx
@@ -173,7 +173,11 @@ export function AuthForms({
       : role === "client"
         ? "/dashboard"
         : sanitizedRedirectTo;
-    router.push(destination);
+
+    // Authentication writes SSR cookies on the server. A document-level
+    // navigation reloads the auth provider from those cookies and guarantees
+    // the dashboard uses assets from the current production deployment.
+    window.location.replace(destination);
   };
 
   const resendConfirmation = async () => {


### PR DESCRIPTION
## Problem
A successful email/password login used client-side navigation into the dashboard. When a browser tab was opened before a production promotion, it could retain JavaScript from the previous Vercel deployment and hydrate the new dashboard HTML with stale assets, producing React error #418.

## Fix
- Replace the post-authentication `router.push()` with `window.location.replace()`.
- Force a document-level navigation after server auth cookies are written.
- Remount the auth provider from current cookies and load assets from the active production deployment.

## Notes
The repeated `runtime.lastError` messages shown in Edge are browser-extension/Vercel-toolbar messaging noise and are separate from the React hydration failure.