### PR TITLE
fix(auth): guarantee complete logout

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,10 +1,45 @@
+import { cookies } from "next/headers";
+
 import { json } from "@/app/api/_lib/http";
 import { createServerSupabase } from "@/lib/supabase/server";
 
+function isAuthCookie(name: string) {
+  return (
+    name === "mm_session" ||
+    name.startsWith("sb-") ||
+    name.includes("-auth-token") ||
+    name.includes("code-verifier")
+  );
+}
+
 export async function POST() {
-  // Signs out with the default global scope: revokes the refresh token at
-  // Supabase and clears the auth cookies on the response.
-  const supabase = await createServerSupabase();
-  await supabase.auth.signOut();
-  return json({ ok: true });
+  const cookieStore = await cookies();
+
+  try {
+    const supabase = await createServerSupabase();
+    await supabase.auth.signOut({ scope: "global" });
+  } catch {
+    // An expired or already-revoked token must not block local logout.
+  }
+
+  for (const cookie of cookieStore.getAll()) {
+    if (!isAuthCookie(cookie.name)) continue;
+
+    cookieStore.set(cookie.name, "", {
+      path: "/",
+      expires: new Date(0),
+      maxAge: 0,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    });
+  }
+
+  return json(
+    { ok: true },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    },
+  );
 }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -170,15 +170,25 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const signOut = async () => {
+    setLoading(true);
+
     try {
+      // Revoke the refresh token while the server can still read the auth
+      // cookies. The route also explicitly expires every auth cookie.
       await logoutMutation().catch(() => null);
-      await supabase.auth.signOut();
-    } catch (error) {
-      console.error("Error during sign out:", error);
     } finally {
+      // The server has already attempted the global revocation. Use local scope
+      // here so an already-revoked token cannot prevent browser cookie cleanup.
+      await supabase.auth.signOut({ scope: "local" }).catch(() => null);
+
       setSession(null);
       setUser(null);
       setSubscription({ ...defaultSubscription, loading: false });
+      setLoading(false);
+
+      // A document navigation prevents cached protected layouts or stale React
+      // state from making the user appear signed in after logout.
+      window.location.replace("/login");
     }
   };
 


### PR DESCRIPTION
Fix users remaining authenticated after logout.

Changes:
- revoke the Supabase refresh token on the server
- explicitly expire current Supabase auth cookies and legacy `mm_session`
- use browser-local sign-out so an already-revoked token cannot block cookie cleanup
- clear React auth state and force a fresh document navigation to `/login`
- disable caching on the logout response