### PR TITLE
FINAL GO LIVE: production schema, auth, CI, Stripe, and legacy cleanup

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -38,5 +38,17 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Verify dependency manifests are unchanged
         run: git diff --exit-code package.json pnpm-lock.yaml
-      - name: Run complete release validation
-        run: pnpm release:check
+      - name: Lint
+        run: pnpm lint
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Unit and API tests
+        run: pnpm test
+      - name: Validate sitemap
+        run: pnpm validate:sitemap
+      - name: Validate database contract
+        run: pnpm validate:db-contract
+      - name: Release audit
+        run: pnpm release:audit
+      - name: Production build
+        run: pnpm build

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -2,7 +2,32 @@
 
 This checklist defines the minimum release gates required before sending MasseurMatch to production.
 
-> **Launch-day closure pass (2026-07-09):** full repository gate (section 1) passes end to end.
+> **Final go-live closure pass (2026-07-25):** full repository gate (section 1) passes end to end.
+>
+> Changes in this pass (2026-07-25):
+> - `.github/workflows/release-checks.yml`: the single `pnpm release:check` step was split
+>   into discrete steps (lint → typecheck → test → validate:sitemap → validate:db-contract →
+>   release:audit → build) so CI failures point at the exact failing gate.
+> - `src/lib/profile-fields-config.ts`: the admin-only `profile_status` field choices now
+>   match the `profiles_profile_status_check` constraint in `PRODUCTION_SCHEMA_LOCK.sql`
+>   (removed stale `submitted`/`active`/`archived`; added `pending`, `pending_approval`,
+>   `under_review`, `changes_requested`, `rejected`).
+> - Re-verified: no legacy artifacts (`vite.config.ts`, `index.html`, `package-lock.json`,
+>   `public/robots.txt` absent); `packageManager` is `pnpm@10.32.1`; `.gitattributes` and
+>   `.vscode/extensions.json` match spec; Tailwind content paths contain no legacy
+>   `src/mm` / `src/pages` globs; no public phone OTP UI; Stripe checkout sends
+>   `metadata.user_id` on session and subscription; webhook syncs all tier fields and
+>   downgrades to free on deletion; release audit enforces `STRIPE_PRICE_*` IDs; no
+>   Portuguese comments in source.
+> - Known live-only observation: the deployed sitemap still lists `/explore` (served
+>   `noindex` by middleware). Source is already consistent (#593 removed it); the next
+>   production deploy resolves the mismatch.
+> - Validation results (2026-07-25): `pnpm install --frozen-lockfile`, lockfile diff clean,
+>   `pnpm lint` (0 errors), `pnpm typecheck`, `pnpm test` (142 unit + 8 API smoke),
+>   `pnpm validate:sitemap`, `pnpm validate:db-contract`, `pnpm release:audit`, and
+>   `pnpm build` all pass.
+>
+> Previous closure (2026-07-09): full repository gate (section 1) passes end to end.
 >
 > Changes in this pass (2026-07-09):
 > - `supabase/PRODUCTION_SCHEMA_LOCK.sql`: removed duplicate column definitions that

--- a/src/lib/profile-fields-config.ts
+++ b/src/lib/profile-fields-config.ts
@@ -1007,11 +1007,13 @@ export const PROFILE_FIELDS_CONFIG: ProfileFieldDefinition[] = [
     order: 6,
     choices: [
       { value: 'draft', label: 'Draft' },
-      { value: 'submitted', label: 'Submitted for Review' },
+      { value: 'pending', label: 'Pending' },
+      { value: 'pending_approval', label: 'Pending Approval' },
+      { value: 'under_review', label: 'Under Review' },
       { value: 'approved', label: 'Approved' },
-      { value: 'active', label: 'Active' },
+      { value: 'changes_requested', label: 'Changes Requested' },
+      { value: 'rejected', label: 'Rejected' },
       { value: 'suspended', label: 'Suspended' },
-      { value: 'archived', label: 'Archived' },
     ],
   },
 


### PR DESCRIPTION
Final production go-live closure pass over the full repository. Every checklist item from the go-live audit was verified; most were already satisfied by previous closure passes, and the three remaining gaps are patched here. The full validation chain passes end to end.

## Files changed

- `.github/workflows/release-checks.yml` — the single `pnpm release:check` step is split into discrete CI steps: lint → typecheck → test → validate:sitemap → validate:db-contract → release:audit → build. A CI failure now points at the exact failing gate instead of one opaque composite step. (A duplicate `release:check` step was intentionally not added on top — it is a composite of exactly these commands and would double every gate and run the build twice.)
- `src/lib/profile-fields-config.ts` — the admin-only `profile_status` field choices now match the `profiles_profile_status_check` constraint in `supabase/PRODUCTION_SCHEMA_LOCK.sql`: removed stale `submitted` / `active` / `archived` values; added `pending`, `pending_approval`, `under_review`, `changes_requested`, `rejected`.
- `docs/GO_LIVE_CHECKLIST.md` — recorded the 2026-07-25 closure pass with full validation results.

## What was removed

- The stale `submitted`, `active`, and `archived` options from the admin `profile_status` choices (values not permitted by the production schema constraint).
- Nothing else — no legacy artifacts remained: `vite.config.ts`, `index.html`, `package-lock.json`, and `public/robots.txt` are all already absent (robots is served by `src/app/robots.ts`).

## What was fixed / verified

- **Repo hygiene**: `packageManager` is `pnpm@10.32.1`; `.gitattributes` is exactly `* text=auto eol=lf`; `.vscode/extensions.json` recommends only eslint, prettier, and tailwindcss; Tailwind `content` globs contain no legacy `src/mm` / `src/pages` paths.
- **Schema**: `supabase/PRODUCTION_SCHEMA_LOCK.sql` present; `profiles_profile_status_check` contains no `submitted` value; `scripts/validate-db-contract.mjs` scans src/scripts/tests/supabase and passes.
- **profile_status**: no `profile_status: "submitted"` reference remains anywhere in src, scripts, tests, or supabase; `submitted` survives only in review-workflow contexts.
- **Auth**: OAuth/PKCE callback (`src/app/auth/callback/route.ts`) exchanges the code, writes Supabase SSR session cookies, ensures the profile/role rows, then routes new accounts into the signup wizard (`/signup/plan`) and returning users to `/pro/dashboard`. `mm_session` remains only as a legacy cookie cleared on logout — the live session system is Supabase SSR, so no change was needed. No public phone OTP UI exists; phone is a profile field only.
- **Stripe**: checkout (`supabase/functions/create-checkout`) sends `metadata.user_id` on both the session and the subscription; the webhook (`src/app/api/webhooks/stripe/route.ts`) syncs `subscription_tier`/`_tier`, `photo_limit`, `visibility_level`, `stripe_customer_id`, `stripe_subscription_id`, and `current_period_end` via `sync_stripe_subscription`, with signature verification and event-level idempotency; `customer.subscription.deleted` downgrades to `free`; `scripts/release-audit.mjs` fails when `STRIPE_SECRET_KEY` is set without valid `STRIPE_PRICE_STANDARD/PRO/ELITE` IDs.
- **Language**: no Portuguese comments or copy in src, scripts, tests, or supabase functions.

## Schema file to run

`supabase/PRODUCTION_SCHEMA_LOCK.sql` — idempotent; re-apply in the Supabase SQL editor before deploy. Release is blocked if `pnpm validate:db-contract` fails.

## Validation results (all pass, 2026-07-25)

| Command | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | OK, lockfile up to date |
| `git diff --exit-code package.json pnpm-lock.yaml` | clean |
| `pnpm lint` | 0 errors |
| `pnpm typecheck` | 0 errors |
| `pnpm test` | 142 unit + 8 API smoke tests pass |
| `pnpm validate:sitemap` | OK (source validation) |
| `pnpm validate:db-contract` | DB contract OK |
| `pnpm release:audit` | OK |
| `pnpm build` | production build succeeds, all routes compile |

`release:check` is the composite of the lint→build commands above; each constituent passed individually in that order.

## Manual smoke test checklist

1. `/`, `/therapists`, `/search`, `/pricing`, `/about`, `/compare`, `/blog`, `/dallas`, `/sitemap.xml`, `/robots.txt` render without crash or accidental login gate.
2. Email/password + Google OAuth login land on `/pro/dashboard`; a brand-new OAuth account lands in the signup wizard; no OTP UI is visible.
3. Upgrade to Standard/Pro/Elite via checkout → dashboard badge, photo limit, and search placement reflect the tier; cancel in the Stripe portal → profile downgrades to free.
4. Admin profile review: approve / request changes / reject transitions update `profile_status` and the public listing accordingly.
5. Mobile 360/390/430 px: no horizontal overflow, header menu and cookie banner usable.

## Risk notes

- The deployed production sitemap still lists `/explore` (served `noindex` by middleware). Source is already consistent (#593 removed it from the sitemap); the first deploy from `main` resolves the mismatch — no action needed beyond deploying.
- The `profile_status` choices change affects an admin-only, read-only display field; no write paths used the removed values, so behavior risk is nil.
- The CI workflow change is structural only — the same commands run, in the same order, with the same environment; total CI time is unchanged.
- Pre-existing flagged follow-ups (not in scope, tracked from #594): editor/public-profile row desync needs a data reconciliation; the four completeness formulas need a product decision; server-side enforcement of signup consent fields is a separate backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK7fe3omfMUCxdJHpAXMgW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK7fe3omfMUCxdJHpAXMgW)_