### PR TITLE
fix: realign profiles public-read RLS policy and drop /explore from sitemap

### DIFF
--- a/docs/PRODUCTION_DEPLOYMENT_CHECKLIST_2026-07-25.md
+++ b/docs/PRODUCTION_DEPLOYMENT_CHECKLIST_2026-07-25.md
@@ -176,3 +176,61 @@ Vercel preview. Not verifiable from static analysis in this run.
   `pnpm validate:db-contract` passes; apply the lock before deployment and
   keep `validate:db-contract` as a release blocker (already wired into
   `release:check`).
+
+---
+
+## Appendix: live-service verification (later on 2026-07-25)
+
+After the initial run, live credentials were provided and the external
+services were verified directly.
+
+### Stripe (live account MASSEURMATCH) — ✅ verified
+
+- ✅ Live, enabled webhook endpoint at `https://masseurmatch.com/api/webhooks/stripe`
+  with all events the app handles (§4.1). ⏭ Still confirm in the dashboard
+  that the `whsec_…` in Vercel came from this endpoint (§4.2) — signing
+  secrets are not readable via API.
+- ✅ Live price IDs exist matching the app's $39/$79/$99 catalog:
+  Standard `price_1TkvMcLUTr1XrJODF8TSpohr`, Pro `price_1T7lDBLUTr1XrJODA1xj0i2d`,
+  Elite `price_1TwTCmLUTr1XrJODrKz1F8Zo`. These must be set both in Vercel
+  (release audit) and as Supabase Edge Function secrets (`create-checkout`
+  consumes them).
+- 🚩 A stray v2 event destination ("engaging-excellence-thin") points at a
+  `stripe-identity-webhook` function on Supabase project `cnycelkfbtzfnphbeurd`
+  — not the production project, and no such function exists in the repo.
+  Recommend deleting it.
+- ⚠️ Catalog clutter: a duplicate active Elite price ($149) and old BRL/test
+  products with active prices. Not purchasable via checkout (fixed IDs), but
+  worth archiving.
+
+### Vercel (project masseurmatch-3l) — ✅ verified
+
+- ✅ 15 of 16 required production vars set. `SUPABASE_ANON_KEY` is absent but
+  every server reader falls back to `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  (`getAnonKey` in `supabase-server.ts`), so this is cosmetic — add it for
+  completeness.
+- ✅ Production deploys from `main`; commit `9cc1524` is live and READY.
+
+### Supabase (project ijsdpozjfjjufjsoexod) — verified, one fix shipped
+
+- ✅ `pnpm validate:supabase-env` passes against the production project.
+- ✅ `pnpm verify:live-schema` passes — 69 contract tables satisfied.
+- ✅ RLS is enabled and fails closed: anon inserts are rejected (401) and
+  anon reads leak nothing.
+- 🚩 **Policy drift (fixed in this branch):** the public-read policy gated on
+  legacy `status IN ('active','approved')`, but live rows all carry
+  `status='pending'` — approval sets `profile_status`/`visibility_status`
+  instead. Anon could read **zero** profiles; production only works because
+  the directory reads through the service-role client. Migration
+  `20260725190000_fix_profiles_public_read_policy.sql` realigns the policy
+  with the app's filters (`profile_status='approved' AND
+  visibility_status='public' AND NOT suspended/banned`, plus self/admin).
+- ⏭ `app.settings.*` for cron Edge Functions still needs a dashboard check.
+
+### Production site smoke test — ✅ pass
+
+All public routes on `https://masseurmatch.com` return 200 with real
+therapist profiles rendering. One finding: the live sitemap listed
+`/explore`, which middleware deliberately serves with
+`X-Robots-Tag: noindex` — fixed in this branch by excluding `/explore`
+from the sitemap (`INTENTIONALLY_NOINDEX_PATHS`).

--- a/src/app/_lib/sitemap-release.ts
+++ b/src/app/_lib/sitemap-release.ts
@@ -32,8 +32,11 @@ type ChangeFrequency = NonNullable<SitemapEntry["changeFrequency"]>;
 export const SEO_CITY_MIN_PUBLIC_PROFILES = 1;
 
 const PROFILE_LOOKUP_CHUNK_SIZE = 100;
-const INVENTORY_DEPENDENT_HUB_PATHS = new Set(["/cities", "/explore", "/near-me"]);
-const INTENTIONALLY_NOINDEX_PATHS = new Set(["/therapist-agreement"]);
+const INVENTORY_DEPENDENT_HUB_PATHS = new Set(["/cities", "/near-me"]);
+// /explore is served with X-Robots-Tag: noindex by middleware (all /explore/*
+// filter pages are), so it must never appear in the sitemap even when city
+// inventory exists — a sitemapped noindex URL fails live sitemap validation.
+const INTENTIONALLY_NOINDEX_PATHS = new Set(["/therapist-agreement", "/explore"]);
 const BLOCKED_PROFILE_SLUGS = new Set([
   "carlos-luis-pena-fd794a8e",
   "david-213c8e32",

--- a/supabase/migrations/20260725190000_fix_profiles_public_read_policy.sql
+++ b/supabase/migrations/20260725190000_fix_profiles_public_read_policy.sql
@@ -1,0 +1,33 @@
+-- Realign the public-read RLS policy on profiles with the app's approval model.
+--
+-- The previous policy (20260322000000_rls_audit_fix.sql) gated anonymous reads
+-- on the legacy columns `status IN ('active','approved')` — but the approval
+-- flow sets `profile_status` / `visibility_status`, and every live profile
+-- carries status='pending'. Result: the anon key could read zero profiles and
+-- public reads only worked through the service-role client. The directory's
+-- documented anon fallback (env-less builds, sitemap prerender) silently
+-- returned no rows.
+--
+-- The app's own public filters (src/app/_lib/directory.ts) are:
+--   visibility_status = 'public' AND profile_status = 'approved'
+--   AND is_suspended = false
+-- This policy mirrors them, plus bans, plus self/admin access.
+
+DROP POLICY IF EXISTS "profiles_public_read_active" ON public.profiles;
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'profiles'
+  ) THEN
+    EXECUTE 'CREATE POLICY "profiles_public_read_active" ON public.profiles FOR SELECT USING (
+      (
+        profile_status = ''approved''
+        AND visibility_status = ''public''
+        AND COALESCE(is_suspended, false) = false
+        AND COALESCE(is_banned, false) = false
+      )
+      OR user_id = auth.uid()
+      OR public.is_admin()
+    )';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Two launch-checklist fixes surfaced by live-service verification against the production Supabase project, Stripe account, and Vercel project (results recorded in the report appendix).

### 1. RLS policy drift on `profiles` (checklist §3.5)

The public-read policy from `20260322000000_rls_audit_fix.sql` gates anonymous reads on legacy columns (`status IN ('active','approved') AND is_active`), but the approval flow sets `profile_status` / `visibility_status` instead — every live profile carries `status='pending'`, so **the anon key can read zero profiles** (verified against production: anon sees 0 rows, service role sees 9 public+approved). The site works only because the directory reads through the service-role client; the code's documented anon fallback would silently return nothing.

New migration `20260725190000_fix_profiles_public_read_policy.sql` recreates the policy to mirror the app's real filters: `profile_status='approved' AND visibility_status='public' AND NOT suspended AND NOT banned`, plus own-profile and admin access. Writes remain self-or-admin only (unchanged).

**Note:** merging this will apply the migration to the linked Supabase project via the Supabase GitHub integration (this PR touches `supabase/`); alternatively the SQL can be run in the dashboard SQL editor first.

### 2. `/explore` sitemapped while noindexed (checklist §8)

Middleware deliberately serves all `/explore*` routes with `X-Robots-Tag: noindex, follow`, but the sitemap included `/explore` once real city inventory exists — the exact mismatch the live sitemap validator flags. `/explore` is now in `INTENTIONALLY_NOINDEX_PATHS` so it is never sitemapped.

### Also

Appends the live verification appendix (Stripe webhook + price IDs, Vercel env diff, Supabase schema/RLS probes, production smoke test) to `docs/PRODUCTION_DEPLOYMENT_CHECKLIST_2026-07-25.md`.

## Validation

- `pnpm lint` (changed file), `pnpm typecheck`, `pnpm test:unit` (142 passing), `pnpm validate:sitemap`, `pnpm build` — all pass.
- Live probes: anon insert rejected (401), anon read returns no private columns, `pnpm verify:live-schema` OK (69 tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MED7dRvj51P1K1Qk17rwnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MED7dRvj51P1K1Qk17rwnq)_