### PR TITLE
Fix lifecycle email cron failures and lock down Stripe RPCs + zero-policy RLS tables

### DIFF
--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -33,6 +33,13 @@ function createDirectoryClient(): AdminClient {
   }
 }
 
+// Fallback/demo profiles carry synthetic ids like "fallback-bruno-santos".
+// Those must never reach queries against uuid columns (profile_photos,
+// imported_reviews, …) — Postgres rejects them with 22P02 ("invalid input
+// syntax for type uuid") and the whole request errors.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isUuid = (value: string) => UUID_RE.test(value);
+
 const supabase: AdminClient = new Proxy({} as AdminClient, {
   get(_target, prop) {
     cachedDirectoryClient ??= createDirectoryClient();
@@ -219,8 +226,6 @@ const buildPublicTherapistsQuery = () => {
     .or("phone.is.null,phone.not.ilike.%555%");
   return q;
 };
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // A profile is linkable from the directory when it has a slug OR a real UUID id
 // (the profile route resolves both — `/therapists/<slug>` and `/therapists/<uuid>`).
@@ -454,10 +459,7 @@ export const getPublicTherapistBySlug = async (slug: string): Promise<PublicTher
   // valid UUID — otherwise Postgres raises `invalid input syntax for type uuid`
   // (22P02), which fails the whole request and makes every slug-based profile
   // page return 404. For plain slugs, match by `slug` only.
-  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-    sanitizedSlug,
-  );
-  const orFilter = isUuid
+  const orFilter = isUuid(sanitizedSlug)
     ? `slug.eq.${sanitizedSlug},id.eq.${sanitizedSlug}`
     : `slug.eq.${sanitizedSlug}`;
 
@@ -494,6 +496,8 @@ export const getPublicTherapistBySlug = async (slug: string): Promise<PublicTher
 };
 
 const getImportedReviews = async (profileId: string, limit = 5) => {
+  if (!isUuid(profileId)) return [] as ImportedReview[];
+
   const { data } = await supabase
     .from("imported_reviews")
     .select("id, review_text, rating, reviewer_name, review_date")
@@ -513,6 +517,14 @@ const resolvePhotoUrl = (
 
 export const getProfilePhotos = async (profileId: string, limit = 6) => {
   const fallback = (FALLBACK_PUBLIC_THERAPISTS as PublicTherapist[]).find((profile) => profile.id === profileId);
+
+  // Fallback ids ("fallback-…") are not UUIDs — querying profile_photos with
+  // one fails with 22P02, so serve the bundled avatar without touching the DB.
+  if (!isUuid(profileId)) {
+    if (!fallback?.avatar_url) return [];
+    return [{ id: `${fallback.id}-avatar`, storage_path: fallback.avatar_url, is_primary: true }];
+  }
+
   const { data, error } = await supabase
     .from("profile_photos")
     .select("id, storage_path, url, is_primary, sort_order")
@@ -540,6 +552,9 @@ export const getProfilePhotosBatch = async (
   limitPerProfile = 1,
 ): Promise<Map<string, ProfilePhoto[]>> => {
   const result = new Map<string, ProfilePhoto[]>();
+  // Drop fallback/demo ids defensively — most callers pre-filter, but a single
+  // non-UUID id would 22P02 the whole chunked query.
+  profileIds = profileIds.filter(isUuid);
   if (!profileIds.length) return result;
 
   // Chunk the id list before querying: Supabase encodes `.in()` arrays into

--- a/supabase/functions/process-lifecycle-email-queue/index.ts
+++ b/supabase/functions/process-lifecycle-email-queue/index.ts
@@ -87,16 +87,30 @@ serve(async (req) => {
   const rl = checkRateLimit(getClientKey(req), { limit: 10, windowMs: 60_000 });
   if (!rl.allowed) return rateLimitResponse(rl, corsHeaders);
 
+  // Config problems are reported as 503 (not 500) with the missing variable
+  // named, so a failing cron run is immediately diagnosable from the logs:
+  // fix with `supabase secrets set RESEND_API_KEY=... UNSUBSCRIBE_HMAC_SECRET=...`.
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  const resendKey = Deno.env.get("RESEND_API_KEY") ?? "";
+  const unsubscribeSecret = Deno.env.get("UNSUBSCRIBE_HMAC_SECRET") ?? "";
+
+  const missingConfig = [
+    !supabaseUrl && "SUPABASE_URL",
+    !serviceKey && "SUPABASE_SERVICE_ROLE_KEY",
+    !resendKey && "RESEND_API_KEY",
+    !unsubscribeSecret && "UNSUBSCRIBE_HMAC_SECRET",
+  ].filter(Boolean);
+
+  if (missingConfig.length > 0) {
+    logStep("Configuration missing", { missing: missingConfig });
+    return new Response(
+      JSON.stringify({ error: "configuration_error", missing: missingConfig }),
+      { status: 503, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
   try {
-    const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
-    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
-    const resendKey = Deno.env.get("RESEND_API_KEY") ?? "";
-    const unsubscribeSecret = Deno.env.get("UNSUBSCRIBE_HMAC_SECRET") ?? "";
-
-    if (!supabaseUrl || !serviceKey) throw new Error("Supabase service credentials are not configured");
-    if (!resendKey) throw new Error("RESEND_API_KEY not configured");
-    if (!unsubscribeSecret) throw new Error("UNSUBSCRIBE_HMAC_SECRET not configured");
-
     const supabase = createClient(supabaseUrl, serviceKey, { auth: { persistSession: false } });
     const unsubscribeBaseUrl = Deno.env.get("UNSUBSCRIBE_BASE_URL") || `${supabaseUrl}/functions/v1/lifecycle-unsubscribe`;
 
@@ -212,9 +226,11 @@ serve(async (req) => {
           }),
         });
 
-        const resendBody = await resendResponse.json();
+        // Resend can return non-JSON bodies on gateway errors; a parse crash
+        // here must not take down the whole batch.
+        const resendBody = await resendResponse.json().catch(() => null);
         if (!resendResponse.ok) {
-          throw new Error(resendBody?.message || "resend_send_failed");
+          throw new Error(resendBody?.message || `resend_send_failed_http_${resendResponse.status}`);
         }
 
         const providerId = resendBody?.id ?? null;

--- a/supabase/migrations/20260725100000_fix_lifecycle_trial_reminder_caller.sql
+++ b/supabase/migrations/20260725100000_fix_lifecycle_trial_reminder_caller.sql
@@ -1,0 +1,17 @@
+-- The lifecycle campaign scheduler was invoking a `trial-reminder-emails`
+-- edge function that does not exist (404 on every daily/weekly cron run).
+-- Trial-ending reminders are already produced by the `run-lifecycle-campaigns`
+-- function (segment "Therapist - Trial Ending", flow `trial_ending`), so the
+-- extra invocation is removed rather than wrapped.
+
+CREATE OR REPLACE FUNCTION public.run_lifecycle_campaign_jobs()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Core segment automation flow (includes the trial-ending cadence).
+  PERFORM public.invoke_edge_function('run-lifecycle-campaigns', '{}'::jsonb);
+END;
+$$;

--- a/supabase/migrations/20260725100100_lock_down_stripe_webhook_rpcs.sql
+++ b/supabase/migrations/20260725100100_lock_down_stripe_webhook_rpcs.sql
@@ -1,0 +1,174 @@
+-- Lock down the SECURITY DEFINER Stripe webhook RPCs so they can only be
+-- executed by the service role (the Stripe webhook route / edge functions).
+--
+-- Two gaps allowed anon execution despite the revokes in
+-- 20260721193547_restore_stripe_webhook_rpc_contract.sql:
+--
+-- 1. 20260626220000_stripe_webhook_rpcs.sql created these functions with
+--    different parameter types (text user ids). The July migration's
+--    CREATE OR REPLACE used new signatures, which *overloads* rather than
+--    replaces — the legacy anon-callable versions were still present.
+-- 2. Postgres grants EXECUTE on functions to PUBLIC by default, and the
+--    `anon` role inherits from PUBLIC. Revoking only from anon/authenticated
+--    leaves the PUBLIC grant in place, so anon could still execute them.
+--
+-- Fix: drop the legacy overloads, add an in-function service-role guard
+-- (defense in depth), and revoke from PUBLIC while granting service_role.
+
+-- ── 1. Drop legacy overloads from 20260626220000 ─────────────────────────────
+DROP FUNCTION IF EXISTS public.process_stripe_payment_intent_succeeded(text, text);
+DROP FUNCTION IF EXISTS public.process_stripe_identity_verified(text, text);
+DROP FUNCTION IF EXISTS public.sync_stripe_subscription(text, text, text, text, integer, integer, timestamptz, text);
+
+-- ── 2. Caller guard ──────────────────────────────────────────────────────────
+-- Allows: service_role JWTs (PostgREST calls from the webhook route / edge
+-- functions) and direct database connections (migrations, pg_cron, psql),
+-- which carry no request.jwt.claims. Blocks anon/authenticated PostgREST calls
+-- even if an EXECUTE grant ever reappears.
+CREATE OR REPLACE FUNCTION public.assert_service_role_caller()
+RETURNS void
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+DECLARE
+  v_claims text := current_setting('request.jwt.claims', true);
+BEGIN
+  IF v_claims IS NULL OR v_claims = '' THEN
+    RETURN; -- direct DB connection (no PostgREST JWT context)
+  END IF;
+
+  IF COALESCE(v_claims::jsonb ->> 'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'unauthorized' USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.assert_service_role_caller() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.assert_service_role_caller() TO service_role;
+
+-- ── 3. Recreate current RPCs with the guard ─────────────────────────────────
+create or replace function public.sync_stripe_subscription(
+  p_user_id uuid,
+  p_stripe_customer_id text,
+  p_stripe_subscription_id text,
+  p_tier text,
+  p_photo_limit integer,
+  p_visibility_level integer,
+  p_current_period_end timestamptz,
+  p_subscription_status text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_status text := coalesce(nullif(p_subscription_status, ''), 'active');
+  v_tier text := case when p_tier in ('free','standard','pro','elite') then p_tier else 'free' end;
+begin
+  perform public.assert_service_role_caller();
+
+  if p_user_id is null or p_stripe_subscription_id is null then
+    raise exception 'user and Stripe subscription are required' using errcode='22023';
+  end if;
+
+  if not exists (select 1 from public.profiles where id=p_user_id or user_id=p_user_id) then
+    raise exception 'profile not found for subscription user' using errcode='23503';
+  end if;
+
+  update public.profiles
+     set stripe_customer_id = p_stripe_customer_id,
+         stripe_subscription_id = p_stripe_subscription_id,
+         subscription_tier = v_tier,
+         subscription_status = v_status,
+         current_period_end = p_current_period_end,
+         photo_limit = coalesce(p_photo_limit, photo_limit),
+         visibility_level = coalesce(p_visibility_level, visibility_level),
+         updated_at = now()
+   where id=p_user_id or user_id=p_user_id;
+
+  update public.subscriptions
+     set tier=v_tier, status=v_status, stripe_customer_id=p_stripe_customer_id,
+         stripe_subscription_id=p_stripe_subscription_id,
+         current_period_end=p_current_period_end, updated_at=now()
+   where user_id=p_user_id;
+
+  if not found then
+    insert into public.subscriptions
+      (user_id, tier, status, stripe_customer_id, stripe_subscription_id, current_period_end)
+    values
+      (p_user_id, v_tier, v_status, p_stripe_customer_id, p_stripe_subscription_id, p_current_period_end);
+  end if;
+end;
+$$;
+
+create or replace function public.process_stripe_payment_intent_succeeded(
+  p_provider_transaction_id text,
+  p_appointment_id uuid default null
+)
+returns void language plpgsql security definer set search_path='' as $$
+begin
+  perform public.assert_service_role_caller();
+
+  update public.payment_transactions
+     set status='succeeded', updated_at=now()
+   where provider_transaction_id=p_provider_transaction_id
+      or stripe_payment_intent_id=p_provider_transaction_id;
+end; $$;
+
+create or replace function public.process_stripe_payment_intent_failed(
+  p_provider_transaction_id text
+)
+returns void language plpgsql security definer set search_path='' as $$
+begin
+  perform public.assert_service_role_caller();
+
+  update public.payment_transactions
+     set status='failed', updated_at=now()
+   where provider_transaction_id=p_provider_transaction_id
+      or stripe_payment_intent_id=p_provider_transaction_id;
+end; $$;
+
+create or replace function public.process_stripe_identity_verified(
+  p_stripe_session_id text,
+  p_user_id uuid
+)
+returns void language plpgsql security definer set search_path='' as $$
+begin
+  perform public.assert_service_role_caller();
+
+  update public.identity_verifications
+     set status='verified', updated_at=now()
+   where user_id=p_user_id
+     and (stripe_session_id=p_stripe_session_id or stripe_verification_session_id=p_stripe_session_id);
+
+  update public.profiles set is_verified_identity=true, identity_verified_at=now(), updated_at=now()
+   where id=p_user_id or user_id=p_user_id;
+end; $$;
+
+create or replace function public.process_stripe_identity_requires_input(
+  p_stripe_session_id text,
+  p_last_error_reason text default null
+)
+returns void language plpgsql security definer set search_path='' as $$
+begin
+  perform public.assert_service_role_caller();
+
+  update public.identity_verifications
+     set status='requires_input', last_error=p_last_error_reason, updated_at=now()
+   where stripe_session_id=p_stripe_session_id or stripe_verification_session_id=p_stripe_session_id;
+end; $$;
+
+-- ── 4. Revoke PUBLIC (the piece the previous migration missed) ──────────────
+REVOKE EXECUTE ON FUNCTION public.sync_stripe_subscription(uuid,text,text,text,integer,integer,timestamptz,text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.process_stripe_payment_intent_succeeded(text,uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.process_stripe_payment_intent_failed(text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.process_stripe_identity_verified(text,uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.process_stripe_identity_requires_input(text,text) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.sync_stripe_subscription(uuid,text,text,text,integer,integer,timestamptz,text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.process_stripe_payment_intent_succeeded(text,uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.process_stripe_payment_intent_failed(text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.process_stripe_identity_verified(text,uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.process_stripe_identity_requires_input(text,text) TO service_role;

--- a/supabase/migrations/20260725100200_rls_policies_for_zero_policy_tables.sql
+++ b/supabase/migrations/20260725100200_rls_policies_for_zero_policy_tables.sql
@@ -1,0 +1,164 @@
+-- Several live tables have RLS enabled but zero policies, which blocks every
+-- client query (anon and authenticated alike) — photos not loading, checkout
+-- and subscription reads failing, admin moderation panel empty.
+--
+-- This migration adds explicit minimal policies for the launch-critical tables
+-- and a safety-net service_role policy for any remaining RLS-on/zero-policy
+-- table (service_role bypasses RLS in Supabase, but the explicit policy keeps
+-- server flows working under linters/tools that flag policy-less tables and
+-- under non-bypass configurations).
+--
+-- All blocks are guarded with to_regclass so the migration is safe on
+-- databases where a given table does not exist.
+
+-- ── therapist_photos ─────────────────────────────────────────────────────────
+-- Owner + admin manage their rows; approved photos are publicly readable
+-- (they are displayed on public profile pages).
+DO $$
+BEGIN
+  IF to_regclass('public.therapist_photos') IS NULL THEN RETURN; END IF;
+
+  EXECUTE 'DROP POLICY IF EXISTS "therapist_photos_select_own_or_admin" ON public.therapist_photos';
+  EXECUTE $pol$CREATE POLICY "therapist_photos_select_own_or_admin"
+    ON public.therapist_photos FOR SELECT
+    USING (user_id = (SELECT auth.uid()) OR public.is_admin())$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "therapist_photos_select_approved_public" ON public.therapist_photos';
+  EXECUTE $pol$CREATE POLICY "therapist_photos_select_approved_public"
+    ON public.therapist_photos FOR SELECT
+    TO anon, authenticated
+    USING (status = 'approved')$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "therapist_photos_insert_own" ON public.therapist_photos';
+  EXECUTE $pol$CREATE POLICY "therapist_photos_insert_own"
+    ON public.therapist_photos FOR INSERT
+    WITH CHECK (user_id = (SELECT auth.uid()) OR public.is_admin())$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "therapist_photos_update_own_or_admin" ON public.therapist_photos';
+  EXECUTE $pol$CREATE POLICY "therapist_photos_update_own_or_admin"
+    ON public.therapist_photos FOR UPDATE
+    USING (user_id = (SELECT auth.uid()) OR public.is_admin())
+    WITH CHECK (user_id = (SELECT auth.uid()) OR public.is_admin())$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "therapist_photos_delete_own_or_admin" ON public.therapist_photos';
+  EXECUTE $pol$CREATE POLICY "therapist_photos_delete_own_or_admin"
+    ON public.therapist_photos FOR DELETE
+    USING (user_id = (SELECT auth.uid()) OR public.is_admin())$pol$;
+END $$;
+
+-- ── therapist_subscriptions ──────────────────────────────────────────────────
+-- Read-only for the owning therapist (via profiles / therapist_profiles) and
+-- admins. Writes happen exclusively through service-role server flows.
+DO $$
+BEGIN
+  IF to_regclass('public.therapist_subscriptions') IS NULL THEN RETURN; END IF;
+
+  EXECUTE 'DROP POLICY IF EXISTS "therapist_subscriptions_select_own_or_admin" ON public.therapist_subscriptions';
+  EXECUTE $pol$CREATE POLICY "therapist_subscriptions_select_own_or_admin"
+    ON public.therapist_subscriptions FOR SELECT
+    TO authenticated
+    USING (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = therapist_subscriptions.profile_id
+          AND (p.user_id = (SELECT auth.uid()) OR p.id = (SELECT auth.uid()))
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.therapist_profiles tp
+        WHERE tp.id = therapist_subscriptions.therapist_profile_id
+          AND tp.user_id = (SELECT auth.uid())
+      )
+    )$pol$;
+END $$;
+
+-- ── checkout_sessions ────────────────────────────────────────────────────────
+-- Read-only for the profile owner and admins; created/updated only by
+-- service-role server flows (Stripe checkout + webhooks).
+DO $$
+BEGIN
+  IF to_regclass('public.checkout_sessions') IS NULL THEN RETURN; END IF;
+
+  EXECUTE 'DROP POLICY IF EXISTS "checkout_sessions_select_own_or_admin" ON public.checkout_sessions';
+  EXECUTE $pol$CREATE POLICY "checkout_sessions_select_own_or_admin"
+    ON public.checkout_sessions FOR SELECT
+    TO authenticated
+    USING (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.profiles p
+        WHERE p.id = checkout_sessions.profile_id
+          AND (p.user_id = (SELECT auth.uid()) OR p.id = (SELECT auth.uid()))
+      )
+    )$pol$;
+END $$;
+
+-- ── moderation_queue ─────────────────────────────────────────────────────────
+-- Re-assert the policies from 20260322113000_moderation_queue.sql (the live
+-- database has the table with RLS on but no policies, so the admin panel and
+-- provider self-views return nothing).
+DO $$
+BEGIN
+  IF to_regclass('public.moderation_queue') IS NULL THEN RETURN; END IF;
+
+  EXECUTE 'DROP POLICY IF EXISTS "moderation_queue_select_self_or_admin" ON public.moderation_queue';
+  EXECUTE $pol$CREATE POLICY "moderation_queue_select_self_or_admin"
+    ON public.moderation_queue FOR SELECT
+    USING (user_id = (SELECT auth.uid()) OR public.is_admin())$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "moderation_queue_insert_self_or_admin" ON public.moderation_queue';
+  EXECUTE $pol$CREATE POLICY "moderation_queue_insert_self_or_admin"
+    ON public.moderation_queue FOR INSERT
+    WITH CHECK (user_id = (SELECT auth.uid()) OR public.is_admin())$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "moderation_queue_update_admin_only" ON public.moderation_queue';
+  EXECUTE $pol$CREATE POLICY "moderation_queue_update_admin_only"
+    ON public.moderation_queue FOR UPDATE
+    USING (public.is_admin())
+    WITH CHECK (public.is_admin())$pol$;
+
+  EXECUTE 'DROP POLICY IF EXISTS "moderation_queue_delete_admin_only" ON public.moderation_queue';
+  EXECUTE $pol$CREATE POLICY "moderation_queue_delete_admin_only"
+    ON public.moderation_queue FOR DELETE
+    USING (public.is_admin())$pol$;
+END $$;
+
+-- ── vapi_sms_sessions ────────────────────────────────────────────────────────
+-- Backend-only table (VAPI/SMS webhook flows). No client access; explicit
+-- service_role policy only.
+DO $$
+BEGIN
+  IF to_regclass('public.vapi_sms_sessions') IS NULL THEN RETURN; END IF;
+
+  EXECUTE 'DROP POLICY IF EXISTS "vapi_sms_sessions_service_role_all" ON public.vapi_sms_sessions';
+  EXECUTE $pol$CREATE POLICY "vapi_sms_sessions_service_role_all"
+    ON public.vapi_sms_sessions
+    TO service_role
+    USING (true) WITH CHECK (true)$pol$;
+END $$;
+
+-- ── Safety net: every remaining RLS-on table with zero policies ─────────────
+-- Gives service_role an explicit full-access policy and logs the table so the
+-- gap is visible in migration output. Client-facing access for these tables
+-- must still be designed table-by-table — this intentionally does NOT open
+-- them to anon/authenticated.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT c.oid::regclass AS tbl
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND c.relrowsecurity
+      AND NOT EXISTS (SELECT 1 FROM pg_policy p WHERE p.polrelid = c.oid)
+  LOOP
+    EXECUTE format(
+      'CREATE POLICY "service_role_all" ON %s TO service_role USING (true) WITH CHECK (true)',
+      r.tbl
+    );
+    RAISE NOTICE 'RLS table with no policies — added service_role policy, client policies still needed: %', r.tbl;
+  END LOOP;
+END $$;


### PR DESCRIPTION
Fixes the P0 issues from the email-functions/security audit.

## Issue 1 — `trial-reminder-emails` 404
The daily/weekly lifecycle cron (`run_lifecycle_campaign_jobs()`) invoked a `trial-reminder-emails` edge function that has never existed in the repo or on Supabase. `run-lifecycle-campaigns` already produces the trial-ending cadence (segment "Therapist - Trial Ending", flow `trial_ending`), so the migration `20260725100000` removes the dead invocation instead of adding a wrapper.

## Issue 2 — `process-lifecycle-email-queue` HTTP 500
The most likely cause is missing function secrets: the worker throws (and 500s) when `RESEND_API_KEY` or `UNSUBSCRIBE_HMAC_SECRET` is unset. The function now:
- returns **503 `configuration_error` naming the missing env var(s)** instead of an opaque 500, so the failing cron run is diagnosable straight from the logs;
- survives non-JSON Resend gateway responses (a `.json()` parse crash previously produced a confusing per-row error).

**Ops follow-up (cannot be done from the repo):** verify secrets with `supabase secrets list` and set any missing ones — `supabase secrets set RESEND_API_KEY=... UNSUBSCRIBE_HMAC_SECRET=... --project-ref ijsdpozjfjjufjsoexod`.

## Issue 3 — invalid UUIDs (`fallback-bruno-santos`, `fallback-kevin-os`)
These are **in-code demo fallback profiles** (`src/app/_lib/directory-fallback.ts`), not database rows — so the suggested `DELETE ... WHERE id::text LIKE 'fallback-%'` has nothing to delete; the errors come from the app passing those ids into uuid-typed queries. `directory.ts` now short-circuits:
- `getProfilePhotos` serves the bundled fallback avatar without touching the DB for non-UUID ids;
- `getProfilePhotosBatch` filters non-UUID ids defensively (one bad id previously 22P02'd the whole chunked query);
- `getImportedReviews` returns `[]` for non-UUID ids;
- the duplicate `UUID_RE` declarations are consolidated.

## Issue 5 — SECURITY DEFINER Stripe RPCs callable by anon
Two gaps made the July revoke (`20260721193547`) ineffective, which is why the audit still flagged these:
1. The 20260626 migration created the RPCs with **different signatures** (text user ids); the July `CREATE OR REPLACE` with new signatures *overloaded* rather than replaced them, leaving the legacy anon-callable versions in place.
2. Postgres grants function `EXECUTE` to `PUBLIC` by default and `anon` inherits from `PUBLIC` — revoking only from `anon, authenticated` left the inherited grant intact.

Migration `20260725100100` drops the legacy overloads, revokes `EXECUTE` **from `PUBLIC`** (plus anon/authenticated), grants `service_role` only, and adds an in-function `assert_service_role_caller()` guard (defense in depth; permits service-role JWTs and direct DB connections, blocks anon/authenticated PostgREST calls even if a grant reappears).

## Issue 4 — RLS enabled with zero policies
Migration `20260725100200` adds minimal explicit policies (all blocks guarded with `to_regclass`, idempotent):

| Table | Policies |
|---|---|
| `therapist_photos` | owner/admin CRUD + public read of `approved` photos |
| `therapist_subscriptions` | owner (via `profiles` / `therapist_profiles`) + admin read; writes stay service-role only |
| `checkout_sessions` | owner + admin read; writes stay service-role only |
| `moderation_queue` | re-asserts the repo policies (self/admin select+insert, admin update/delete) missing from the live DB |
| `vapi_sms_sessions` | explicit `service_role`-only policy (backend-only table) |

A final sweep adds a `service_role_all` policy to **any remaining** RLS-on/zero-policy table and emits a `NOTICE` per table, so the rest of the 13 flagged tables become visible in migration output without being blindly opened to clients.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint src/app/_lib/directory.ts` — clean
- `pnpm run build` — passes
- `pnpm-lock.yaml` untouched (no dependency changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016muYaLgxiaJXVCuNDQtJWF

---
_Generated by [Claude Code](https://claude.ai/code/session_016muYaLgxiaJXVCuNDQtJWF)_