### PR TITLE
fix: grant is_admin() execute to anon so public profile reads pass RLS

### DIFF
--- a/supabase/migrations/20260725220000_grant_is_admin_execute_to_anon.sql
+++ b/supabase/migrations/20260725220000_grant_is_admin_execute_to_anon.sql
@@ -1,0 +1,21 @@
+-- Follow-up to 20260725190000_fix_profiles_public_read_policy.sql.
+--
+-- The recreated profiles_public_read_active policy calls public.is_admin(),
+-- but the anon role had no EXECUTE grant on that function. PostgREST then
+-- failed every anonymous read of public.profiles with
+-- "42501: permission denied for function is_admin" — worse than the zero-row
+-- behavior the policy was meant to fix. A policy's USING expression runs with
+-- the privileges of the querying role, so every role that can SELECT the
+-- table needs EXECUTE on functions the policy references.
+--
+-- is_admin() only reports whether auth.uid() belongs to an admin; for anon it
+-- returns false, so granting EXECUTE exposes nothing.
+
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc
+    WHERE proname = 'is_admin' AND pronamespace = 'public'::regnamespace
+  ) THEN
+    GRANT EXECUTE ON FUNCTION public.is_admin() TO anon, authenticated;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Follow-up to #597. The recreated `profiles_public_read_active` policy references `public.is_admin()`, but the `anon` role had no EXECUTE grant on that function — a policy's `USING` expression runs with the querying role's privileges, so every anonymous read of `public.profiles` failed with `42501: permission denied for function is_admin` (worse than the zero-row behavior the policy fixed).

New migration `20260725220000_grant_is_admin_execute_to_anon.sql` grants EXECUTE on `public.is_admin()` to `anon` and `authenticated`. `is_admin()` only reports whether `auth.uid()` is an admin — it returns false for anon, so nothing is exposed.

## Production state

The Supabase GitHub integration failed to auto-apply migrations on the #597 merge ("Remote migration versions not found in local migrations directory" — there is pre-existing drift: 8 remote migrations missing from the repo and 11 repo migrations unrecorded remotely). Both the #597 policy migration and this grant were therefore applied to production manually via the Supabase management API and recorded in `supabase_migrations.schema_migrations`. Verified live: the anon key now reads exactly the 9 approved+public profiles, anonymous writes are still rejected (401), and `/explore` is absent from the production sitemap while still served with `X-Robots-Tag: noindex, follow`.

This PR only makes the repo's migration chain match what production already runs.

## Validation

- `npx tsc --noEmit` passes (SQL-only change; no app code touched).
- Live anon probe: `content-range: 0-0/9` on `profiles`, insert rejected with 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MED7dRvj51P1K1Qk17rwnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MED7dRvj51P1K1Qk17rwnq)_