### PR TITLE
Harden middleware redirects, cookie scope, and deployment health checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,14 @@
 
 # ── App ──────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Local Next.js port. Keep aligned with package.json scripts when overriding.
+DEV_PORT=5000
+
+# Cookie scope for production only. Use .masseurmatch.com to share cookies across
+# the apex/www/admin hosts. Leave blank for Vercel preview/staging deployments so
+# cookies remain host-only and are not attached to an unrelated preview domain.
+COOKIE_DOMAIN=
+MM_COOKIE_DOMAIN=                       # legacy alias; COOKIE_DOMAIN takes precedence
 
 # ── Supabase ─────────────────────────────────────────────────────────────────
 # IMPORTANT: Both the bare and NEXT_PUBLIC_ variants must be set.
@@ -21,24 +29,24 @@ SITEMAP_SUPABASE_KEY=                     # [OPTIONAL] read-only key for sitemap
 # ── Demand Radar (external keyword trends data) ──────────────────────────────
 # Python collector (Windows Task Scheduler) inserts daily keyword trend data
 # into a separate Supabase project. These credentials allow the dashboard to read it.
-NEXT_PUBLIC_DEMAND_RADAR_URL=             # [OPTIONAL] https://ijsdpozjfjjufjsoexod.supabase.co (external Supabase URL)
+NEXT_PUBLIC_DEMAND_RADAR_URL=             # [OPTIONAL] external Supabase URL
 NEXT_PUBLIC_DEMAND_RADAR_KEY=             # [OPTIONAL] Demand Radar Supabase anon key
 
 # ── Monitoring ───────────────────────────────────────────────────────────────
 NEXT_PUBLIC_BUGSNAG_API_KEY=              # [OPTIONAL] browser error + performance monitoring
 
-# ── Session ───────────────────────────────────────────────────────────────────
-# Signs the mm_session cookie. MUST be set in production (≥32 random chars).
+# ── Session ──────────────────────────────────────────────────────────────────
+# Signs the mm_session cookie. MUST be set in production (>=32 random chars).
 MM_SESSION_SECRET=                        # [REQUIRED in production]
 SESSION_SECRET=                           # alias — set MM_SESSION_SECRET or this
 
-# ── CSRF Protection ────────────────────────────────────────────────────────────
+# ── CSRF Protection ──────────────────────────────────────────────────────────
 # Validates CSRF tokens in forms (login, signup, etc). MUST be set in production.
 # Generate: openssl rand -hex 32
 MM_CSRF_SECRET=                           # [REQUIRED in production]
 CSRF_SECRET=                              # alias — set MM_CSRF_SECRET or this
 
-# ── Stripe ────────────────────────────────────────────────────────────────────
+# ── Stripe ───────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=       # [REQUIRED] pk_live_... or pk_test_...
 STRIPE_SECRET_KEY=                        # [REQUIRED] sk_live_... or sk_test_...
 STRIPE_WEBHOOK_SECRET=                    # [REQUIRED] whsec_... from Stripe dashboard
@@ -54,66 +62,53 @@ STRIPE_PRICE_ELITE=                       # [REQUIRED] price_... for Elite plan
 # before going live or emails will not deliver.
 RESEND_API_KEY=                           # [REQUIRED] re_... from resend.com
 RESEND_FROM_EMAIL=MasseurMatch <concierge@masseurmatch.com>  # [REQUIRED] verified sender
-# Where admin alerts go (new accounts, new/updated support tickets, profiles
-# submitted for review). Defaults to admin@xrankflow.com if unset.
+# Where admin alerts go. Defaults to admin@xrankflow.com if unset.
 ADMIN_NOTIFICATION_EMAIL=admin@xrankflow.com
 
 # ── Google Maps ───────────────────────────────────────────────────────────────
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=          # [OPTIONAL] for map embeds (read by the app)
-NEXT_PUBLIC_GOOGLE_MAPS_KEY=              # [OPTIONAL] alias — some CI configs use this name
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=          # [OPTIONAL] for map embeds
+NEXT_PUBLIC_GOOGLE_MAPS_KEY=              # [OPTIONAL] alias
 
 # ── Cache revalidation ────────────────────────────────────────────────────────
 REVALIDATE_SECRET=                        # [OPTIONAL] secret for /api/revalidate
 
-# ── Twilio Verify / Messaging ─────────────────────────────────────────────────
-# TWILIO_AUTH_TOKEN is also required to validate signed requests sent to
-# POST /api/twilio/sms. Configure that exact URL under "A message comes in".
-TWILIO_ACCOUNT_SID=                       # [OPTIONAL] Twilio API operations
-TWILIO_AUTH_TOKEN=                        # [REQUIRED for inbound Twilio SMS webhook]
-TWILIO_VERIFY_SERVICE_SID=                # [OPTIONAL] future Verify features
-TWILIO_PHONE_NUMBER=                      # [OPTIONAL] outbound Twilio number
+# ── Twilio Verify ─────────────────────────────────────────────────────────────
+TWILIO_ACCOUNT_SID=                       # [OPTIONAL]
+TWILIO_AUTH_TOKEN=                        # [OPTIONAL]
+TWILIO_VERIFY_SERVICE_SID=                # [OPTIONAL]
+TWILIO_PHONE_NUMBER=                      # [OPTIONAL]
 
-# ── Cloudinary (Image uploads) ────────────────────────────────────────────────
-# Get these from https://cloudinary.com/console
-# Either set individual credentials OR the CLOUDINARY_URL environment variable
-CLOUDINARY_CLOUD_NAME=                    # [OPTIONAL] cloud name from dashboard
-CLOUDINARY_API_KEY=                       # [OPTIONAL] API key (or full cloudinary:// URL)
-CLOUDINARY_API_SECRET=                    # [OPTIONAL] API secret
-CLOUDINARY_URL=                           # [OPTIONAL] cloudinary://api_key:api_secret@cloud_name
+# ── Cloudinary ────────────────────────────────────────────────────────────────
+CLOUDINARY_CLOUD_NAME=                    # [OPTIONAL]
+CLOUDINARY_API_KEY=                       # [OPTIONAL]
+CLOUDINARY_API_SECRET=                    # [OPTIONAL]
+CLOUDINARY_URL=                           # [OPTIONAL]
 
 # ── Web Push ──────────────────────────────────────────────────────────────────
-NEXT_PUBLIC_VAPID_PUBLIC_KEY=             # [OPTIONAL] browser push notifications
-VAPID_PRIVATE_KEY=                        # [OPTIONAL] browser push notifications
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=             # [OPTIONAL]
+VAPID_PRIVATE_KEY=                        # [OPTIONAL]
 
-# ── AI / Content moderation ───────────────────────────────────────────────────
-OPENAI_API_KEY=                           # [OPTIONAL] Knotty AI assistant (primary LLM, gpt-4o-mini)
-GEMINI_API_KEY=                           # [OPTIONAL] Knotty fallback + Gemini AI features
-GOOGLE_API_KEY=                           # [OPTIONAL] Google APIs
-SIGHTENGINE_API_USER=                     # [OPTIONAL] photo moderation
-SIGHTENGINE_API_SECRET=                   # [OPTIONAL] photo moderation
-SERPAPI_API_KEY=                          # [OPTIONAL] SEO features
-FIRECRAWL_API_KEY=                        # [OPTIONAL] web scraping
+# ── AI / Content moderation ──────────────────────────────────────────────────
+OPENAI_API_KEY=                           # [OPTIONAL]
+GEMINI_API_KEY=                           # [OPTIONAL]
+GOOGLE_API_KEY=                           # [OPTIONAL]
+SIGHTENGINE_API_USER=                     # [OPTIONAL]
+SIGHTENGINE_API_SECRET=                   # [OPTIONAL]
+SERPAPI_API_KEY=                          # [OPTIONAL]
+FIRECRAWL_API_KEY=                        # [OPTIONAL]
 KNOTTY_LEARNING_ENABLED=false
 KNOTTY_DEBUG_RANKING=false
-# Shared secret sent by Vapi in Authorization: Bearer <secret> for inbound Knotty webhooks.
-# Generate with: openssl rand -hex 32
-VAPI_WEBHOOK_SECRET=                      # [REQUIRED for Knotty webhook events/tools]
-# Private Vapi API key used only server-side to call POST https://api.vapi.ai/chat.
-# This is different from VAPI_WEBHOOK_SECRET and must never be exposed to browsers.
-VAPI_PRIVATE_API_KEY=                     # [REQUIRED for Twilio -> Vapi Chat SMS fallback]
-VAPI_CHAT_ASSISTANT_ID=dee0ea0f-721b-4ad1-8ab6-2ee981851189
-VERIFICATION_API_KEY=                     # [OPTIONAL] reserved for Stripe Identity verification extensions; Stripe Identity itself uses STRIPE_SECRET_KEY
+VERIFICATION_API_KEY=                     # [OPTIONAL]
 
 # ── Internal API ──────────────────────────────────────────────────────────────
-INTERNAL_API_KEY=                         # [OPTIONAL] authenticates internal cron/worker endpoints (e.g. /api/internal/demand-scores)
+INTERNAL_API_KEY=                         # [OPTIONAL]
 
-# ── Seed credentials (scripts/seed-supabase.mjs only) ────────────────────────
+# ── Seed credentials ─────────────────────────────────────────────────────────
 SEED_ADMIN_EMAIL=admin@masseurmatch.com
 SEED_ADMIN_PASSWORD=
 SEED_THERAPIST_EMAIL=therapist@masseurmatch.com
 SEED_THERAPIST_PASSWORD=
 
 # ── Background jobs ──────────────────────────────────────────────────────────
-# Bearer token protecting /api/migrate/process. Vercel Cron sends it
-# automatically when set as a project env var. Generate: openssl rand -hex 32
+# Bearer token protecting /api/migrate/process. Generate: openssl rand -hex 32
 CRON_SECRET=

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MasseurMatch is a directory platform for independent massage therapists. Visitor
 
 ## Stack
 
-- Next.js 14 App Router
+- Next.js 15 App Router
 - React 18
 - TypeScript
 - Tailwind CSS
@@ -20,17 +20,22 @@ pnpm install
 pnpm dev
 ```
 
+The development server defaults to port `5000`. `DEV_PORT` is documented in `.env.example` for tooling and local configuration that needs to reference the same port.
+
 ## Checks
 
 ```bash
 pnpm typecheck
 pnpm lint
 pnpm build
+pnpm test
 ```
 
 ## Environment
 
 Copy `.env.example` to `.env.local` and supply the credentials for your deployment.
+
+For production, set `COOKIE_DOMAIN=.masseurmatch.com` when authentication cookies must be shared by the apex, `www`, and `admin` hosts. Leave `COOKIE_DOMAIN` and its `MM_COOKIE_DOMAIN` alias unset for Vercel preview or staging deployments so cookies remain host-only.
 
 ### Critical Production Environment Variables
 
@@ -41,7 +46,13 @@ The following variables **MUST** be set in production (Vercel Settings > Environ
 
 Both can also use their alias names `CSRF_SECRET` and `SESSION_SECRET`, but `MM_*` names are preferred.
 
-To validate that these are set in a deployment, visit `/api/health` — it returns 200 if all critical vars are present, 503 otherwise.
+Validate every deployment before promotion:
+
+```bash
+curl --fail-with-body https://your-deployment.example/api/health
+```
+
+`/api/health` returns HTTP `200` with `{ "ok": true }` when both critical secrets are available. It returns HTTP `503` with JSON containing `missing` and per-secret `checks` when configuration is incomplete, allowing deployment checks to fail fast.
 
 ## Notes
 

--- a/src/app/api/_lib/csrf.ts
+++ b/src/app/api/_lib/csrf.ts
@@ -15,6 +15,14 @@ function getCsrfSecret(): string | null {
   return null;
 }
 
+function getCookieDomain(): string | null {
+  // Optional env to override cookie domain in production. If unset, do not set Domain header
+  // which is safer for preview/staging domains.
+  const domain = envOptional(["COOKIE_DOMAIN", "MM_COOKIE_DOMAIN"]);
+  if (domain) return domain;
+  return null;
+}
+
 export function generateCsrfToken(): { token: string; cookie: string } {
   const secret = getCsrfSecret();
   if (!secret) {
@@ -50,7 +58,10 @@ export function generateCsrfToken(): { token: string; cookie: string } {
 
   if (secure) {
     cookieParts.push("Secure");
-    cookieParts.push("Domain=.masseurmatch.com");
+    const domain = getCookieDomain();
+    if (domain) {
+      cookieParts.push(`Domain=${domain}`);
+    }
   }
 
   return {
@@ -131,7 +142,10 @@ function clearCsrfCookie(): string {
 
   if (secure) {
     parts.push("Secure");
-    parts.push("Domain=.masseurmatch.com");
+    const domain = getCookieDomain();
+    if (domain) {
+      parts.push(`Domain=${domain}`);
+    }
   }
 
   return parts.join("; ");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,8 +7,43 @@ import {
 import { containsLangParam, removeLangSearchParam } from "@/app/_lib/route-normalization";
 import { updateSession, type EdgeSession } from "@/lib/supabase/middleware";
 
+const VALID_HOST_PATTERN = /^[a-z0-9.-]+(?::\d{1,5})?$/i;
+
+function firstForwardedValue(value: string | null): string | null {
+  const first = value?.split(",")[0]?.trim();
+  return first || null;
+}
+
+function getRequestProtocol(request: NextRequest): "http:" | "https:" {
+  const forwardedProtocol = firstForwardedValue(request.headers.get("x-forwarded-proto"))
+    ?.toLowerCase()
+    .replace(/:$/, "");
+
+  return forwardedProtocol === "http" ? "http:" : "https:";
+}
+
+function getRequestHost(request: NextRequest): string {
+  const forwardedHost = firstForwardedValue(request.headers.get("x-forwarded-host"));
+  const host = forwardedHost ?? firstForwardedValue(request.headers.get("host"));
+
+  if (host && VALID_HOST_PATTERN.test(host)) {
+    return host;
+  }
+
+  return request.nextUrl.host;
+}
+
+function absoluteRequestUrl(
+  path: string,
+  request: NextRequest,
+  host = getRequestHost(request),
+): URL {
+  const protocol = getRequestProtocol(request);
+  return new URL(path, `${protocol}//${host}`);
+}
+
 function permanentRedirect(path: string, request: NextRequest): NextResponse {
-  return NextResponse.redirect(new URL(path, request.url), { status: 301 });
+  return NextResponse.redirect(absoluteRequestUrl(path, request), { status: 301 });
 }
 
 // Carry any auth cookies that updateSession rotated (a refreshed access/refresh
@@ -23,8 +58,41 @@ function withSessionCookies(
   return response;
 }
 
-const PUBLIC_RATE_LIMIT = { windowMs: 60_000, max: 240 };
+const PUBLIC_RATE_LIMIT = {
+  windowMs: 60_000,
+  max: 240,
+  maxEntries: 10_000,
+  pruneIntervalMs: 60_000,
+};
+
+// Best-effort process-local protection only. Use Upstash/Redis (or another
+// shared store) for production rate limiting across serverless instances.
 const publicHits = new Map<string, { count: number; resetAt: number }>();
+let nextPublicHitsPruneAt = 0;
+
+function prunePublicHits(now: number): void {
+  if (now < nextPublicHitsPruneAt && publicHits.size <= PUBLIC_RATE_LIMIT.maxEntries) {
+    return;
+  }
+
+  for (const [ip, hit] of publicHits) {
+    if (now >= hit.resetAt) {
+      publicHits.delete(ip);
+    }
+  }
+
+  const overflow = publicHits.size - PUBLIC_RATE_LIMIT.maxEntries;
+  if (overflow > 0) {
+    let removed = 0;
+    for (const ip of publicHits.keys()) {
+      publicHits.delete(ip);
+      removed += 1;
+      if (removed >= overflow) break;
+    }
+  }
+
+  nextPublicHitsPruneAt = now + PUBLIC_RATE_LIMIT.pruneIntervalMs;
+}
 
 function getRequestIp(request: NextRequest): string {
   return request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? request.headers.get("x-real-ip") ?? "unknown";
@@ -37,6 +105,8 @@ function isPublicRateLimited(request: NextRequest): boolean {
 
   const ip = getRequestIp(request);
   const now = Date.now();
+  prunePublicHits(now);
+
   const current = publicHits.get(ip);
   if (!current || now >= current.resetAt) {
     publicHits.set(ip, { count: 1, resetAt: now + PUBLIC_RATE_LIMIT.windowMs });
@@ -119,7 +189,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 
-  const host = request.headers.get("host") ?? "";
+  const host = getRequestHost(request);
   const isAdminSubdomain =
     host.startsWith("admin.masseurmatch.com") || host.startsWith("admin.masseurmatch.local");
 
@@ -150,14 +220,14 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
       // Redirect to the login page on the *apex* host, not this admin host —
       // otherwise the login page itself is caught by this branch and loops.
       const baseHost = host.replace(/^admin\./, "");
-      const loginUrl = new URL(`${request.nextUrl.protocol}//${baseHost}/login`);
+      const loginUrl = absoluteRequestUrl("/login", request, baseHost);
       loginUrl.searchParams.set("redirect", adminPathname);
       return NextResponse.redirect(loginUrl);
     }
     if (session.role !== "admin") {
       const baseHost = host.replace(/^admin\./, "");
       return withSessionCookies(
-        NextResponse.redirect(new URL(`${request.nextUrl.protocol}//${baseHost}/`)),
+        NextResponse.redirect(absoluteRequestUrl("/", request, baseHost)),
         sessionResponse,
       );
     }
@@ -174,7 +244,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // to https://www.masseurmatch.com instead of https://www.masseurmatch.com/auth/callback).
   // Forward it to the real handler so the session exchange can complete.
   if (pathname === "/" && searchParams.has("code")) {
-    const callbackUrl = new URL("/auth/callback", request.url);
+    const callbackUrl = absoluteRequestUrl("/auth/callback", request);
     // Preserve all query params (code, next, error, etc.)
     searchParams.forEach((value, key) => {
       callbackUrl.searchParams.set(key, value);
@@ -207,7 +277,6 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   if (pathname === "/admin/reviews" || pathname.startsWith("/admin/reviews/")) {
     return permanentRedirect("/admin/moderation", request);
   }
-
 
   if (pathname === "/register") {
     return permanentRedirect("/signup/account", request);
@@ -328,39 +397,48 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   // public recruitment page instead of hitting a login wall, while providers
   // who are already signed in fall through to the portal hub below.
   if (pathname === "/pro/join" && !session) {
-    return NextResponse.redirect(new URL("/for-therapists", request.url));
+    return NextResponse.redirect(absoluteRequestUrl("/for-therapists", request));
   }
 
   if (pathname === "/pro" || pathname.startsWith("/pro/")) {
     if (!session) {
-      const loginUrl = new URL("/login", request.url);
+      const loginUrl = absoluteRequestUrl("/login", request);
       loginUrl.searchParams.set("redirect", pathname);
       return NextResponse.redirect(loginUrl);
     }
     if (session.role !== "provider" && session.role !== "admin") {
-      return withSessionCookies(NextResponse.redirect(new URL("/", request.url)), sessionResponse);
+      return withSessionCookies(
+        NextResponse.redirect(absoluteRequestUrl("/", request)),
+        sessionResponse,
+      );
     }
   }
 
   if (pathname === "/client" || pathname.startsWith("/client/")) {
     if (!session) {
-      const loginUrl = new URL("/login", request.url);
+      const loginUrl = absoluteRequestUrl("/login", request);
       loginUrl.searchParams.set("redirect", pathname);
       return NextResponse.redirect(loginUrl);
     }
     if (session.role !== "client") {
-      return withSessionCookies(NextResponse.redirect(new URL("/", request.url)), sessionResponse);
+      return withSessionCookies(
+        NextResponse.redirect(absoluteRequestUrl("/", request)),
+        sessionResponse,
+      );
     }
   }
 
   if (pathname === "/admin" || pathname.startsWith("/admin/")) {
     if (!session) {
-      const loginUrl = new URL("/login", request.url);
+      const loginUrl = absoluteRequestUrl("/login", request);
       loginUrl.searchParams.set("redirect", pathname);
       return NextResponse.redirect(loginUrl);
     }
     if (session.role !== "admin") {
-      return withSessionCookies(NextResponse.redirect(new URL("/", request.url)), sessionResponse);
+      return withSessionCookies(
+        NextResponse.redirect(absoluteRequestUrl("/", request)),
+        sessionResponse,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- builds absolute redirect URLs from validated forwarded host/protocol headers, with HTTPS as the safe protocol fallback
- caps and periodically prunes the process-local public rate-limit map
- documents that production rate limiting should use Upstash/Redis or another shared store
- replaces hardcoded CSRF cookie domain use with `COOKIE_DOMAIN` / `MM_COOKIE_DOMAIN` support
- documents `DEV_PORT`, production cookie scope, and host-only preview cookies in `.env.example`
- confirms `/api/health` validates `MM_CSRF_SECRET` and `MM_SESSION_SECRET`, returning clear HTTP 503 JSON when missing
- updates README validation commands and deployment health-check guidance

## Validation

CI should run:

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm validate:db-contract`
- `pnpm build`

Local execution was not available in this environment because outbound GitHub/package-registry network access is blocked, so GitHub Actions is the source of truth for install/build/test results.

Playwright/E2E and accessibility jobs remain conditional on a resolvable Vercel preview URL or configured `PLAYWRIGHT_BASE_URL`. No live Supabase, Stripe, Resend, migrations, or schema-lock operations were performed.

## Launch checklist

- [ ] Set `MM_CSRF_SECRET` in Vercel Production (or `CSRF_SECRET` alias)
- [ ] Set `MM_SESSION_SECRET` in Vercel Production (or `SESSION_SECRET` alias)
- [ ] Set `COOKIE_DOMAIN=.masseurmatch.com` in Production when cookies must span apex/www/admin
- [ ] Leave `COOKIE_DOMAIN` and `MM_COOKIE_DOMAIN` unset in Preview unless a custom preview domain intentionally needs cross-subdomain cookies
- [ ] Confirm Supabase, Stripe, Resend, and other required production variables are present
- [ ] Deploy preview and verify `GET /api/health` returns HTTP 200 with `{ "ok": true }`
- [ ] Verify an intentionally incomplete environment returns HTTP 503 JSON naming the missing critical secrets
- [ ] Verify admin-subdomain login redirects use HTTPS and return to the apex host
- [ ] Review conditional Playwright/a11y results if preview credentials and bypass configuration are available

## Manual actions remaining

- Vercel environment values must be configured outside the repository.
- Full third-party E2E coverage requires approved test credentials/bypass configuration.
- Production/staging migrations require separate explicit authorization and safe staging credentials.