### PR TITLE
Dashboard & directory fixes: date save, trial photo cap, mobile tabs, visiting tags

### DIFF
--- a/src/app/_components/PublicTherapistCard.tsx
+++ b/src/app/_components/PublicTherapistCard.tsx
@@ -3,9 +3,10 @@
 import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ArrowUpRight, MapPin, Check } from "lucide-react";
+import { ArrowUpRight, MapPin, Check, Plane } from "lucide-react";
 import { useMemo } from "react";
 import type { PublicTherapist } from "@/app/_lib/directory";
+import { getTravelVisit } from "@/app/_lib/travel-status";
 import { Pill } from "@/components/ui/pill";
 import {
   getPublicProfileName,
@@ -57,17 +58,12 @@ export function PublicTherapistCard({ therapist, priority = false }: { therapist
   }, [therapist.created_at]);
 
   const travelBadge = useMemo(() => {
-    const schedule = therapist.travel_schedule;
-    if (!Array.isArray(schedule) || schedule.length === 0) return null;
-    const now = Date.now();
-    for (const entry of schedule) {
-      const start = new Date(entry.start_date).getTime();
-      const end = new Date(entry.end_date).getTime();
-      if (now >= start && now <= end) return { label: "Traveling", city: entry.city };
-      const daysUntil = (start - now) / (1000 * 60 * 60 * 24);
-      if (daysUntil > 0 && daysUntil <= 14) return { label: "Arriving soon", city: entry.city };
-    }
-    return null;
+    const visit = getTravelVisit(therapist.travel_schedule);
+    if (!visit) return null;
+    return {
+      label: visit.status === "now" ? "Visiting Now" : "Visiting Soon",
+      city: visit.entry.city,
+    };
   }, [therapist.travel_schedule]);
 
   const startingPrice = getStartingPrice(therapist);
@@ -123,13 +119,22 @@ export function PublicTherapistCard({ therapist, priority = false }: { therapist
           )}
 
           {/* Top badge row */}
-          <div className="absolute inset-x-2 top-2 flex gap-1.5">
+          <div className="absolute inset-x-2 top-2 flex flex-wrap gap-1.5">
             {availableNow && (
               <Pill
                 variant="available"
                 size="sm"
                 icon={<span className="h-1.5 w-1.5 rounded-full bg-emerald-600" />}
                 label="Available Now"
+              />
+            )}
+            {travelBadge && (
+              <Pill
+                variant="visiting"
+                size="sm"
+                icon={<Plane size={10} strokeWidth={2.5} />}
+                label={travelBadge.label}
+                title={`${travelBadge.label} · ${travelBadge.city}`}
               />
             )}
             {isDirectoryListed && (

--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -4,6 +4,7 @@ import { unstable_cache } from "next/cache";
 import { createClient as createSupabaseJsClient } from "@supabase/supabase-js";
 
 import { US_CITIES } from "@/data/cities";
+import { getTravelVisit } from "@/app/_lib/travel-status";
 import { matchBodyTypeKeyword } from "@/lib/physical-profile";
 import { FALLBACK_PUBLIC_THERAPISTS } from "@/app/_lib/directory-fallback";
 import { PUBLIC_THERAPISTS_TAG } from "@/app/_lib/directory-cache";
@@ -260,6 +261,25 @@ export const getSitemapProfileSlugs = async (): Promise<Array<{ slug: string; up
   return out;
 };
 
+// Therapists visiting `cityName` on tour: an entry in travel_schedule for that
+// city that is either active now or starts within the lookahead window. The
+// date filtering happens in JS — travel_schedule is a JSONB array and PostgREST
+// can't range-compare inside it. Home-city residents are excluded (they're
+// already in the main city query, possibly on another page).
+async function fetchVisitingTherapists(cityName: string): Promise<PublicTherapist[]> {
+  const { data, error } = await buildPublicTherapistsQuery()
+    .not("travel_schedule", "is", null)
+    .limit(200);
+
+  if (error || !data) return [];
+
+  const cityKey = cityName.trim().toLowerCase();
+  return (data as unknown as PublicTherapist[])
+    .filter(isRoutableProfile)
+    .filter((p) => p.city?.trim().toLowerCase() !== cityKey)
+    .filter((p) => getTravelVisit(p.travel_schedule, cityName) !== null);
+}
+
 function isActivelyAvailable(profile: PublicTherapist) {
   return profile.available_now === true &&
     (profile.available_now_expires == null || new Date(profile.available_now_expires).getTime() > Date.now());
@@ -285,7 +305,11 @@ function applyFallbackFilters(items: PublicTherapist[], filters?: Parameters<typ
     if (name.includes("debug") || name.includes("test")) return false;
     if (profile.phone?.includes("555")) return false;
 
-    if (filters?.city && profile.city?.toLowerCase() !== filters.city.toLowerCase()) return false;
+    if (filters?.city) {
+      const livesThere = profile.city?.toLowerCase() === filters.city.toLowerCase();
+      const visitingThere = getTravelVisit(profile.travel_schedule, filters.city) !== null;
+      if (!livesThere && !visitingThere) return false;
+    }
     if (filters?.verified && profile.verification_status !== "verified") return false;
     if (filters?.availableToday && !isActivelyAvailable(profile)) return false;
     if (filters?.tier && profile.subscription_tier !== filters.tier) return false;
@@ -388,7 +412,25 @@ const fetchPublicTherapistsUncached = async (filters?: PublicTherapistFilters) =
 
   const { data: rawData, error, count } = await query;
   const routable = rawData ? (rawData as unknown as PublicTherapist[]).filter(isRoutableProfile) : [];
-  const data = sortPublicTherapists(routable);
+  let data = sortPublicTherapists(routable);
+  let visitorCount = 0;
+
+  // City listings must also surface therapists touring that city (active or
+  // upcoming travel_schedule entries). Appended on page 1 only so paginated
+  // reads never duplicate them.
+  if (!error && filters?.city && page === 1) {
+    try {
+      const visitors = await fetchVisitingTherapists(filters.city);
+      const seen = new Set(data.map((p) => p.id));
+      const extra = visitors.filter((v) => !seen.has(v.id));
+      if (extra.length > 0) {
+        visitorCount = extra.length;
+        data = sortPublicTherapists([...data, ...extra]);
+      }
+    } catch {
+      // Visitors are an enrichment — never fail the main listing over them.
+    }
+  }
 
   if (!error) {
     // Enrich profiles with their primary photos
@@ -405,7 +447,7 @@ const fetchPublicTherapistsUncached = async (filters?: PublicTherapistFilters) =
         console.log(`[getPublicTherapists] Enriched ${profileIds.length} profiles, found photos for ${photosMap.size} profiles`);
       }
     }
-    return { items: data, total: count ?? data.length, page, pageSize };
+    return { items: data, total: (count ?? routable.length) + visitorCount, page, pageSize };
   }
 
   if (process.env.NODE_ENV === 'development') {

--- a/src/app/_lib/store.ts
+++ b/src/app/_lib/store.ts
@@ -25,11 +25,14 @@ const PROFILE_SELECT = `
   updated_at, created_at
 `;
 
-const AVAILABLE_NOW_SELECT = "id, subscription_tier, available_now, available_now_expires";
+const AVAILABLE_NOW_SELECT =
+  "id, subscription_tier, subscription_status, current_period_end, available_now, available_now_expires";
 
 export type AvailableNowProfile = {
   id: string;
   subscription_tier: string | null;
+  subscription_status: string | null;
+  current_period_end: string | null;
   available_now: boolean | null;
   available_now_expires: string | null;
 };

--- a/src/app/_lib/travel-status.ts
+++ b/src/app/_lib/travel-status.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared travel-schedule status logic, safe for both server (directory
+ * queries) and client (therapist cards) use.
+ *
+ * A travel entry produces a "Visiting Now" state while today falls inside
+ * its date range (end date inclusive), and a "Visiting Soon" state from up
+ * to VISITING_LOOKAHEAD_DAYS ahead until one day prior to arrival — on the
+ * start date itself it flips to "Visiting Now".
+ */
+
+export interface TravelEntry {
+  city: string;
+  state?: string | null;
+  start_date: string;
+  end_date: string;
+}
+
+export const VISITING_LOOKAHEAD_DAYS = 14;
+
+export type TravelVisit = { status: "now" | "soon"; entry: TravelEntry };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the active or soonest-upcoming visit from a travel schedule.
+ * When `cityName` is given, only entries for that city are considered
+ * (case-insensitive match). An active visit always wins over an upcoming one.
+ */
+export function getTravelVisit(
+  schedule: TravelEntry[] | null | undefined,
+  cityName?: string | null,
+  nowMs: number = Date.now(),
+): TravelVisit | null {
+  if (!Array.isArray(schedule) || schedule.length === 0) return null;
+
+  const cityKey = cityName?.trim().toLowerCase() || null;
+  let soonest: TravelEntry | null = null;
+  let soonestStart = Number.POSITIVE_INFINITY;
+
+  for (const entry of schedule) {
+    if (!entry || typeof entry.city !== "string" || !entry.city.trim() || !entry.start_date || !entry.end_date) continue;
+    if (cityKey && entry.city.trim().toLowerCase() !== cityKey) continue;
+
+    const start = Date.parse(entry.start_date);
+    const end = Date.parse(entry.end_date);
+    if (Number.isNaN(start) || Number.isNaN(end)) continue;
+
+    // Date-only end dates parse to midnight; the visit lasts through that day.
+    const endExclusive = end + DAY_MS;
+    if (nowMs >= start && nowMs < endExclusive) {
+      return { status: "now", entry };
+    }
+    if (nowMs < start && start - nowMs <= VISITING_LOOKAHEAD_DAYS * DAY_MS && start < soonestStart) {
+      soonest = entry;
+      soonestStart = start;
+    }
+  }
+
+  return soonest ? { status: "soon", entry: soonest } : null;
+}

--- a/src/app/api/pro/profile/route.ts
+++ b/src/app/api/pro/profile/route.ts
@@ -364,7 +364,11 @@ const fullProfileSchema = z.object({
   studioHours: z.array(hoursEntrySchema).max(20).optional(),
   mobileHours: mobileHoursSchema.optional(),
 
-  startDate: z.string().max(7).optional().nullable(),
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}(-\d{2})?$/, "Expected YYYY-MM or YYYY-MM-DD")
+    .optional()
+    .nullable(),
   yearsExperience: z.number().int().min(0).max(80).optional().nullable(),
   heightInches: z.number().int().min(36).max(96).optional().nullable(),
   weightLb: z.number().int().min(60).max(600).optional().nullable(),
@@ -446,7 +450,12 @@ export async function PATCH(request: Request) {
     if (body.studioHours !== undefined) updates.studio_hours = body.studioHours;
     if (body.mobileHours !== undefined) updates.mobile_hours = body.mobileHours;
 
-    if (body.startDate !== undefined) updates.start_date = text(body.startDate);
+    if (body.startDate !== undefined) {
+      // start_date is timestamptz; pad month-only values so Postgres accepts them
+      const startDate = text(body.startDate);
+      updates.start_date =
+        startDate && /^\d{4}-\d{2}$/.test(startDate) ? `${startDate}-01` : startDate;
+    }
     if (body.yearsExperience !== undefined) updates.years_experience = body.yearsExperience;
     if (body.heightInches !== undefined) updates.height_inches = body.heightInches;
     if (body.weightLb !== undefined) updates.weight_lb = body.weightLb;

--- a/src/app/api/pro/subscription/route.ts
+++ b/src/app/api/pro/subscription/route.ts
@@ -22,17 +22,19 @@ export async function GET(request: Request) {
     const session = await requireRequestSession(request);
     const profile = await getAvailableNowProfile(session.userId);
     const planKey = normalizePlanKey(profile?.subscription_tier);
+    // During a Stripe trial the current period end IS the trial end.
+    const isTrial = planKey !== "free" && profile?.subscription_status === "trialing";
 
     return json({
       ok: true,
       subscribed: planKey !== "free",
       plan_key: planKey,
       plan_name: getPlanName(planKey),
-      subscription_end: null,
-      trial_end: null,
-      is_trial: false,
+      subscription_end: profile?.current_period_end ?? null,
+      trial_end: isTrial ? profile?.current_period_end ?? null : null,
+      is_trial: isTrial,
       has_founder_discount: false,
-      status: planKey === "free" ? "free" : "active",
+      status: planKey === "free" ? "free" : isTrial ? "trialing" : "active",
       config_error: null,
     });
   } catch (error) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -23,6 +23,10 @@ const PHOTO_LIMITS: Record<string, number> = {
   elite: 20,
 }
 
+// During the 14-day free trial paid tiers are capped at 4 photos;
+// the full plan allowance unlocks when the trial converts to active.
+const TRIAL_PHOTO_LIMIT = 4
+
 const VISIBILITY_LEVELS: Record<string, number> = {
   free: 1,
   standard: 2,
@@ -41,15 +45,20 @@ function buildSyncArgs(tier: string, sub: Stripe.Subscription, subscriptionStatu
       ? sub.customer
       : (sub.customer as Stripe.Customer | null)?.id ?? null
 
+  const status = subscriptionStatus ?? sub.status ?? null
+  const tierPhotoLimit = PHOTO_LIMITS[tier] ?? 2
+  const photoLimit =
+    status === 'trialing' && tier !== 'free' ? Math.min(tierPhotoLimit, TRIAL_PHOTO_LIMIT) : tierPhotoLimit
+
   return {
     p_user_id:                sub.metadata?.user_id ?? sub.metadata?.userId ?? null,
     p_stripe_customer_id:     customerId,
     p_stripe_subscription_id: sub.id,
     p_tier:                   tier,
-    p_photo_limit:            PHOTO_LIMITS[tier] ?? 2,
+    p_photo_limit:            photoLimit,
     p_visibility_level:       VISIBILITY_LEVELS[tier] ?? 1,
     p_current_period_end:     getCurrentPeriodEnd(sub),
-    p_subscription_status:    subscriptionStatus ?? null,
+    p_subscription_status:    status,
   }
 }
 
@@ -143,8 +152,7 @@ export async function POST(request: NextRequest) {
 
         const { error } = await supabase.rpc('sync_stripe_subscription', {
           ...buildSyncArgs(tier, sub),
-          p_user_id:             userId,
-          p_subscription_status: null,
+          p_user_id: userId,
         })
         if (error) throw error
         break

--- a/src/app/pro/inquiries/page.tsx
+++ b/src/app/pro/inquiries/page.tsx
@@ -136,12 +136,13 @@ export default function InquiriesDashboard() {
         </div>
 
         <Tabs value={selectedTab} onValueChange={setSelectedTab}>
-          <TabsList className="grid w-full grid-cols-5">
-            <TabsTrigger value="all">All</TabsTrigger>
-            <TabsTrigger value="new">New ({statusCounts.new})</TabsTrigger>
-            <TabsTrigger value="viewed">Viewed ({statusCounts.viewed})</TabsTrigger>
-            <TabsTrigger value="responded">Responded ({statusCounts.responded})</TabsTrigger>
-            <TabsTrigger value="archived">Archived ({statusCounts.archived})</TabsTrigger>
+          {/* Scrollable flex row on mobile — five forced grid columns overlap the nowrap labels */}
+          <TabsList className="flex w-full justify-start gap-1 overflow-x-auto sm:grid sm:grid-cols-5">
+            <TabsTrigger value="all" className="shrink-0">All</TabsTrigger>
+            <TabsTrigger value="new" className="shrink-0">New ({statusCounts.new})</TabsTrigger>
+            <TabsTrigger value="viewed" className="shrink-0">Viewed ({statusCounts.viewed})</TabsTrigger>
+            <TabsTrigger value="responded" className="shrink-0">Responded ({statusCounts.responded})</TabsTrigger>
+            <TabsTrigger value="archived" className="shrink-0">Archived ({statusCounts.archived})</TabsTrigger>
           </TabsList>
 
           <TabsContent value={selectedTab} className="space-y-4">

--- a/src/app/pro/listing/page.tsx
+++ b/src/app/pro/listing/page.tsx
@@ -423,9 +423,10 @@ function buildPayload(form: FormState) {
       ? { percent: Number(form.dayDiscountPercent), day: form.dayDiscountDay }
       : null;
 
+  // profiles.start_date is a timestamptz — a bare "YYYY-MM" is rejected by Postgres
   const startDate =
     form.startYear && form.startMonth
-      ? `${form.startYear}-${String(Number(form.startMonth)).padStart(2, "0")}`
+      ? `${form.startYear}-${String(Number(form.startMonth)).padStart(2, "0")}-01`
       : null;
 
   const mobileHours: MobileHours = form.mobileSameAsStudio

--- a/src/app/pro/photos/page.tsx
+++ b/src/app/pro/photos/page.tsx
@@ -63,7 +63,7 @@ function getProfileDisplayName(profile: Tables<"profiles"> | null) {
 export default function PhotoManagerPage() {
   const { toast } = useToast();
   const { profile, loading: profileLoading, updateProfile } = useProfile();
-  const { maxPhotos, planLabel, isLoading: limitsLoading } = usePlanLimits();
+  const { maxPhotos, planLabel, isTrial, isLoading: limitsLoading } = usePlanLimits();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [photos, setPhotos] = useState<PhotoRecord[]>([]);
@@ -180,7 +180,9 @@ export default function PhotoManagerPage() {
     if (remainingSlots <= 0) {
       toast({
         title: "Photo limit reached",
-        description: `Your ${planLabel} plan allows up to ${maxPhotos} photos.`,
+        description: isTrial
+          ? `During your free trial you can upload up to ${maxPhotos} photos. The full ${planLabel} allowance unlocks when your trial ends.`
+          : `Your ${planLabel} plan allows up to ${maxPhotos} photos.`,
         variant: "destructive",
       });
       event.target.value = "";
@@ -447,8 +449,10 @@ export default function PhotoManagerPage() {
           <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
             <h2 className="font-display text-lg font-medium text-slate-900">New photo</h2>
             <p className="mt-2 font-sans text-sm text-slate-500">
-              Current plan: <span className="font-semibold text-slate-900">{planLabel}</span>. You
-              can keep up to <span className="font-semibold text-slate-900">{maxPhotos}</span> photos.
+              Current plan: <span className="font-semibold text-slate-900">{planLabel}</span>
+              {isTrial ? " (free trial)" : ""}. You can keep up to{" "}
+              <span className="font-semibold text-slate-900">{maxPhotos}</span> photos
+              {isTrial ? " during your trial" : ""}.
             </p>
 
             <button

--- a/src/hooks/usePlanLimits.ts
+++ b/src/hooks/usePlanLimits.ts
@@ -174,14 +174,20 @@ const AVAILABLE_NOW_TIER_PRIORITY: Record<SupportedPlanKey, number> = {
   free: 99,
 };
 
-export const usePlanLimits = (): PlanLimits & { planKey: PlanKey; isLoading: boolean } => {
+/** Photo cap during the 14-day free trial; the full plan allowance unlocks once the trial converts. */
+export const TRIAL_MAX_PHOTOS = 4;
+
+export const usePlanLimits = (): PlanLimits & { planKey: PlanKey; isTrial: boolean; isLoading: boolean } => {
   const { subscription } = useAuth();
   const planKey = normalizePlanKey(subscription?.plan_key) || (subscription?.subscribed ? "standard" : null);
   const limits = PLAN_LIMITS[planKey || "free"] || FREE_LIMITS;
+  const isTrial = (subscription?.is_trial ?? false) && planKey !== null && planKey !== "free";
 
   return {
     ...limits,
+    maxPhotos: isTrial ? Math.min(limits.maxPhotos, TRIAL_MAX_PHOTOS) : limits.maxPhotos,
     planKey,
+    isTrial,
     isLoading: subscription?.loading ?? false,
   };
 };

--- a/tests/unit/travel-status.test.ts
+++ b/tests/unit/travel-status.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { getTravelVisit, VISITING_LOOKAHEAD_DAYS } from "@/app/_lib/travel-status";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Fixed reference time: 2026-07-25T12:00:00Z
+const NOW = Date.parse("2026-07-25T12:00:00Z");
+
+const entry = (city: string, start: string, end: string) => ({
+  city,
+  start_date: start,
+  end_date: end,
+});
+
+describe("getTravelVisit", () => {
+  it("returns null for empty or missing schedules", () => {
+    expect(getTravelVisit(null, null, NOW)).toBeNull();
+    expect(getTravelVisit(undefined, null, NOW)).toBeNull();
+    expect(getTravelVisit([], null, NOW)).toBeNull();
+  });
+
+  it("reports 'now' while today is inside the visit dates", () => {
+    const visit = getTravelVisit([entry("Denver", "2026-07-24", "2026-07-28")], null, NOW);
+    expect(visit?.status).toBe("now");
+    expect(visit?.entry.city).toBe("Denver");
+  });
+
+  it("treats the start and end dates as inclusive", () => {
+    const schedule = [entry("Denver", "2026-07-25", "2026-07-25")];
+    expect(getTravelVisit(schedule, null, NOW)?.status).toBe("now");
+  });
+
+  it("reports 'soon' until one day prior, then 'now' on arrival day", () => {
+    const schedule = [entry("Austin", "2026-07-26", "2026-07-30")];
+    // Day before arrival → still "soon"
+    expect(getTravelVisit(schedule, null, NOW)?.status).toBe("soon");
+    // Arrival day → "now"
+    expect(getTravelVisit(schedule, null, NOW + DAY_MS)?.status).toBe("now");
+  });
+
+  it("ignores visits beyond the lookahead window", () => {
+    const farStart = new Date(NOW + (VISITING_LOOKAHEAD_DAYS + 2) * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    const farEnd = new Date(NOW + (VISITING_LOOKAHEAD_DAYS + 5) * DAY_MS)
+      .toISOString()
+      .slice(0, 10);
+    expect(getTravelVisit([entry("Miami", farStart, farEnd)], null, NOW)).toBeNull();
+  });
+
+  it("ignores visits that already ended", () => {
+    expect(getTravelVisit([entry("Miami", "2026-07-01", "2026-07-05")], null, NOW)).toBeNull();
+  });
+
+  it("filters by city case-insensitively when a city is given", () => {
+    const schedule = [
+      entry("Austin", "2026-07-24", "2026-07-28"),
+      entry("Chicago", "2026-07-27", "2026-07-30"),
+    ];
+    expect(getTravelVisit(schedule, "austin", NOW)?.entry.city).toBe("Austin");
+    expect(getTravelVisit(schedule, "CHICAGO", NOW)?.status).toBe("soon");
+    expect(getTravelVisit(schedule, "Seattle", NOW)).toBeNull();
+  });
+
+  it("prefers an active visit over an upcoming one", () => {
+    const schedule = [
+      entry("Chicago", "2026-07-27", "2026-07-30"),
+      entry("Austin", "2026-07-24", "2026-07-28"),
+    ];
+    const visit = getTravelVisit(schedule, null, NOW);
+    expect(visit?.status).toBe("now");
+    expect(visit?.entry.city).toBe("Austin");
+  });
+
+  it("picks the soonest upcoming visit when several are pending", () => {
+    const schedule = [
+      entry("Chicago", "2026-07-30", "2026-08-02"),
+      entry("Austin", "2026-07-27", "2026-07-29"),
+    ];
+    const visit = getTravelVisit(schedule, null, NOW);
+    expect(visit?.status).toBe("soon");
+    expect(visit?.entry.city).toBe("Austin");
+  });
+
+  it("skips malformed entries without crashing", () => {
+    const schedule = [
+      { city: "Austin", start_date: "not-a-date", end_date: "2026-07-30" },
+      { city: "", start_date: "2026-07-24", end_date: "2026-07-28" },
+      entry("Denver", "2026-07-24", "2026-07-28"),
+    ];
+    expect(getTravelVisit(schedule, null, NOW)?.entry.city).toBe("Denver");
+  });
+});


### PR DESCRIPTION
## 1. Fix career start date save error (pro listing editor)

Saving the **Credentials** section failed with:

> Could not save — invalid input syntax for type timestamp with time zone: "2016-04"

The Career Start Date pickers (month + year) built the payload as `"YYYY-MM"`, but `profiles.start_date` is a `timestamptz` column, so Postgres rejects the month-only string and the whole save fails.

- **Client** (`src/app/pro/listing/page.tsx`): `buildPayload` now sends a full date, `YYYY-MM-01`.
- **API** (`src/app/api/pro/profile/route.ts`): the `startDate` zod field validates the shape (`YYYY-MM` or `YYYY-MM-DD`), and the PATCH handler pads month-only values to `YYYY-MM-01` before writing, so payloads from stale/cached clients still save.

## 2. Cap photo uploads at 4 during the 14-day free trial

Paid plans start with a 14-day Stripe trial (card optional), but trialing providers received the full plan photo allowance (6–20 photos) immediately. Now trialing providers can upload up to **4 photos**; the full allowance unlocks when the trial converts.

- **Stripe webhook**: records the subscription's real status (`trialing` was previously stored as `active` on create/checkout events) and writes `photo_limit = 4` while a paid tier is trialing.
- **Subscription API**: reports real `is_trial`, `trial_end`, and `subscription_end` (previously hardcoded to false/null).
- **`usePlanLimits`**: caps `maxPhotos` at `TRIAL_MAX_PHOTOS` (4) while trialing and exposes `isTrial`.
- **Photo manager**: copy and the limit toast explain the trial cap.

## 3. Fix overlapping inquiry filter tabs on mobile

The Contact Inquiries tab list forced five equal grid columns, so on narrow screens the nowrap labels overflowed and rendered on top of each other. The list is now a horizontally scrollable flex row on mobile, keeping the five-column grid from the `sm` breakpoint up.

## 4. Show touring masseurs in the destination city with "Visiting Now" / "Visiting Soon" tags

City directory listings only matched a therapist's **home** city, so a masseur with travel dates set never appeared in the destination city. The therapist card also computed a travel badge that was never rendered.

- **New shared helper** (`src/app/_lib/travel-status.ts`): resolves a travel schedule to **Visiting Now** (today inside the visit dates, inclusive) or **Visiting Soon** (upcoming within 14 days — shown until one day prior to arrival, flipping to Visiting Now on the start date).
- **City listings** (`getPublicTherapists`): now append therapists with an active or upcoming travel entry for the requested city — deduped against residents, tier-sorted, appended on page 1 only so pagination never duplicates them. The demo-data fallback filter matches the same way.
- **`PublicTherapistCard`**: renders the visiting pill (existing sky `visiting` variant, lucide `Plane` icon) in the photo badge row with the exact "Visiting Now" / "Visiting Soon" labels; the destination city appears in the tooltip.
- **Unit tests** (`tests/unit/travel-status.test.ts`): cover arrival-day flip, one-day-prior boundary, lookahead cutoff, city filtering, and malformed entries.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on all changed files — clean
- `npx vitest run` travel-status (10 passed) and stripe-business-logic (67 passed)
- `pnpm run build` — succeeds