### PR TITLE
Add CI workflow to apply Supabase migrations; auto-deploy lifecycle email functions

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -1,0 +1,68 @@
+name: Apply Supabase Migrations
+
+# Applies pending SQL migrations in supabase/migrations/ to the production
+# database, so schema changes merged to main can be rolled out without a
+# laptop (run it from the GitHub mobile app via Actions → this workflow →
+# Run workflow, or let the push trigger handle it on merge).
+#
+# Requirements (Settings → Secrets and variables → Actions):
+#   - Secret   SUPABASE_ACCESS_TOKEN — personal access token
+#              (Supabase → Account → Access Tokens). Already used by the
+#              deploy-supabase-functions workflow.
+#   - Secret   SUPABASE_DB_PASSWORD  — the database password
+#              (Supabase → Project Settings → Database; resettable there).
+#   - Variable SUPABASE_PROJECT_REF  — the production project ref.
+#
+# `supabase db push` only applies migrations missing from the remote
+# supabase_migrations.schema_migrations history, in version order — it is a
+# no-op when everything is already applied.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/apply-supabase-migrations.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: apply-supabase-migrations
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: supabase db push
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify required config is present
+        run: |
+          missing=0
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::Secret SUPABASE_ACCESS_TOKEN is not set — add it under Settings → Secrets and variables → Actions."
+            missing=1
+          fi
+          if [ -z "$SUPABASE_DB_PASSWORD" ]; then
+            echo "::error::Secret SUPABASE_DB_PASSWORD is not set — copy it from Supabase → Project Settings → Database (or reset it there) and add it under Settings → Secrets and variables → Actions."
+            missing=1
+          fi
+          if [ -z "$SUPABASE_PROJECT_REF" ]; then
+            echo "::error::Variable SUPABASE_PROJECT_REF is not set — add it under Settings → Secrets and variables → Actions → Variables."
+            missing=1
+          fi
+          [ "$missing" -eq 0 ]
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Apply pending migrations
+        run: supabase db push

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -1,8 +1,9 @@
 name: Deploy Supabase Functions
 
-# Auto-deploys the auth-email-hook Edge Function whenever its source lands on
-# main, so the deployed function never drifts from what's in the repo (the class
-# of bug that made confirmation links fail: a fix merged but never deployed).
+# Auto-deploys the auth-email-hook and lifecycle email Edge Functions whenever
+# their source lands on main, so the deployed functions never drift from what's
+# in the repo (the class of bug that made confirmation links fail: a fix merged
+# but never deployed).
 #
 # Requirements (set once in the repo settings):
 #   - Secret   SUPABASE_ACCESS_TOKEN  — a personal access token
@@ -21,6 +22,10 @@ on:
     branches: [main]
     paths:
       - "supabase/functions/auth-email-hook/**"
+      - "supabase/functions/process-lifecycle-email-queue/**"
+      - "supabase/functions/lifecycle-unsubscribe/**"
+      - "supabase/functions/run-lifecycle-campaigns/**"
+      - "supabase/functions/_shared/**"
       - "supabase/config.toml"
       - ".github/workflows/deploy-supabase-functions.yml"
   workflow_dispatch: {}
@@ -58,3 +63,9 @@ jobs:
 
       - name: Deploy auth-email-hook
         run: supabase functions deploy auth-email-hook --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Deploy lifecycle email functions
+        run: |
+          supabase functions deploy process-lifecycle-email-queue --project-ref "$SUPABASE_PROJECT_REF"
+          supabase functions deploy lifecycle-unsubscribe --project-ref "$SUPABASE_PROJECT_REF"
+          supabase functions deploy run-lifecycle-campaigns --project-ref "$SUPABASE_PROJECT_REF"


### PR DESCRIPTION
Follow-up to #598: the three migrations it merged (lifecycle cron fix, Stripe RPC lockdown, RLS policies) and the hardened `process-lifecycle-email-queue` function only exist in the repo — nothing applied them to the live project, and the existing deploy workflow only covers `auth-email-hook`. This adds a phone-friendly rollout path.

## New workflow: `apply-supabase-migrations.yml`
- Runs `supabase db push` against the production project.
- Triggers on merge to `main` when `supabase/migrations/**` changes, and on **manual dispatch** (GitHub app → Actions → "Apply Supabase Migrations" → Run workflow).
- `db push` only applies migrations missing from the remote `schema_migrations` history, so it's a no-op when everything is current.
- Fails early with explicit errors naming any missing config.

**Setup needed once (can be done from a phone browser):** add secret `SUPABASE_DB_PASSWORD` (Supabase → Project Settings → Database) under repo Settings → Secrets and variables → Actions. `SUPABASE_ACCESS_TOKEN` (secret) and `SUPABASE_PROJECT_REF` (variable) are already required by the existing functions-deploy workflow.

Because this workflow file is in its own `paths` filter, merging this PR triggers a run that applies the three pending migrations from #598.

## Extended: `deploy-supabase-functions.yml`
- Now also deploys `process-lifecycle-email-queue`, `lifecycle-unsubscribe`, and `run-lifecycle-campaigns` when their source (or `_shared/`) changes, so the hardened queue worker actually ships. Merging this PR triggers that deploy too (the workflow file itself is in the paths filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016muYaLgxiaJXVCuNDQtJWF

---
_Generated by [Claude Code](https://claude.ai/code/session_016muYaLgxiaJXVCuNDQtJWF)_