### PR TITLE
Trim whitespace from SUPABASE_PROJECT_REF in Supabase workflows

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -40,6 +40,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The variable has shipped with a trailing space before, which the CLI
+      # rejects as "Invalid project ref format" — strip all whitespace so a
+      # copy-paste artifact can't silently break the migration run.
+      - name: Normalize project ref
+        run: echo "SUPABASE_PROJECT_REF=$(printf '%s' "$SUPABASE_PROJECT_REF" | tr -d '[:space:]')" >> "$GITHUB_ENV"
+
       - name: Verify required config is present
         run: |
           missing=0

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -44,6 +44,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # The variable has shipped with a trailing space before, which the CLI
+      # rejects as "Invalid project ref format" — strip all whitespace so a
+      # copy-paste artifact can't silently break every deploy.
+      - name: Normalize project ref
+        run: echo "SUPABASE_PROJECT_REF=$(printf '%s' "$SUPABASE_PROJECT_REF" | tr -d '[:space:]')" >> "$GITHUB_ENV"
+
       - name: Verify required config is present
         run: |
           missing=0


### PR DESCRIPTION
Follow-up to #607. The first run of "Apply Supabase Migrations" surfaced two problems:

1. **`SUPABASE_DB_PASSWORD` is not set** in Actions secrets (the run's config check failed exactly as designed). This needs the secret added in repo settings — not fixable from the repo.
2. **The `SUPABASE_PROJECT_REF` Actions variable contains a trailing space** (`"ijsdpozjfjjufjsoexod "`). The Supabase CLI rejects it with `Invalid project ref format` — and the job logs show this has made **every `deploy-supabase-functions` run since Jul 23 fail**, so `auth-email-hook` deploys have been silently broken for days.

This PR fixes (2) in a way that can't regress: both workflows now strip all whitespace from the ref (`tr -d '[:space:]'`) before use, so a copy-paste artifact in the variable can't break deploys or migration runs. Merging re-triggers both workflows (their files are in their own `paths` filters): function deploys should go green immediately; the migration run still needs the `SUPABASE_DB_PASSWORD` secret first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016muYaLgxiaJXVCuNDQtJWF

---
_Generated by [Claude Code](https://claude.ai/code/session_016muYaLgxiaJXVCuNDQtJWF)_