### PR TITLE
3D profile pills, explore location finder, search geolocation, mobile fixes

### DIFF
--- a/src/app/_components/PublicTherapistCard.tsx
+++ b/src/app/_components/PublicTherapistCard.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ArrowUpRight, MapPin, Check, Plane } from "lucide-react";
+import { ArrowUpRight, MapPin, Check, Plane, Sparkles } from "lucide-react";
 import { useMemo } from "react";
 import type { PublicTherapist } from "@/app/_lib/directory";
 import { getTravelVisit } from "@/app/_lib/travel-status";
@@ -143,6 +143,14 @@ export function PublicTherapistCard({ therapist, priority = false }: { therapist
                 size="sm"
                 icon={<Check size={10} />}
                 label="Verified"
+              />
+            )}
+            {isNewProfile && (
+              <Pill
+                variant="new"
+                size="sm"
+                icon={<Sparkles size={10} strokeWidth={2.5} />}
+                label="New"
               />
             )}
           </div>

--- a/src/app/explore/ExploreLocationFinder.tsx
+++ b/src/app/explore/ExploreLocationFinder.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, LoaderCircle, LocateFixed, MapPin, MapPinned } from "lucide-react";
+import { useGeolocation } from "@/hooks/useGeolocation";
+import { formatCityLabel, type CityData } from "@/data/cities";
+import { cn } from "@/lib/utils";
+
+const normalize = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+
+function matchCityInput(input: string, cities: CityData[]): CityData | null {
+  const normalized = normalize(input);
+  if (!normalized) return null;
+
+  // Accept "Austin", "Austin, TX", "Austin TX", or the slug form.
+  const [namePart, statePart] = normalized.split(",").map((part) => part.trim());
+  const stateCode = (statePart || "").toUpperCase();
+
+  return (
+    cities.find(
+      (city) =>
+        normalize(city.name) === namePart &&
+        (!statePart || city.stateCode.toLowerCase() === statePart),
+    ) ||
+    cities.find((city) => normalize(formatCityLabel(city.name, city.stateCode)) === normalized) ||
+    cities.find((city) => city.slug === normalized.replace(/\s+/g, "-")) ||
+    (stateCode ? null : cities.find((city) => normalize(city.name) === normalized)) ||
+    null
+  );
+}
+
+export function ExploreLocationFinder({ cities }: { cities: CityData[] }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [locating, setLocating] = useState(false);
+  const { city: detectedCity, status, error, requestLocation } = useGeolocation({
+    autoLocate: true,
+    storageKey: "mm:explore:location-city",
+  });
+
+  const suggestions = useMemo(
+    () => cities.map((city) => formatCityLabel(city.name, city.stateCode)),
+    [cities],
+  );
+
+  const goToCity = (city: CityData) => {
+    router.push(`/${city.slug}`);
+  };
+
+  const handleUseMyLocation = async () => {
+    setInputError(null);
+    setLocating(true);
+    try {
+      const resolved = await requestLocation(true);
+      if (resolved) {
+        goToCity(resolved);
+      }
+    } finally {
+      setLocating(false);
+    }
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const matched = matchCityInput(query, cities);
+    if (!matched) {
+      setInputError("We couldn't find that city yet — try picking one from the list below.");
+      return;
+    }
+    setInputError(null);
+    goToCity(matched);
+  };
+
+  return (
+    <div className="rounded-2xl border border-[#E8E8E8] bg-white p-4 shadow-[0_1px_2px_rgba(17,17,17,0.04),0_12px_32px_rgba(17,17,17,0.05)] sm:p-5">
+      <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8E8E8E]">
+        Find therapists near you
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <div className="flex min-w-0 flex-1 items-center gap-2.5 rounded-xl border border-[#D9D9D9] bg-[#FAFAFA] px-3.5 py-3 transition-colors focus-within:border-accent focus-within:ring-[3px] focus-within:ring-accent/[0.18]">
+          <MapPin className="h-4 w-4 shrink-0 text-[#8E8E8E]" strokeWidth={2.25} />
+          <input
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setInputError(null);
+            }}
+            list="explore-finder-cities"
+            placeholder="Enter your city"
+            aria-label="Search for your city"
+            className="w-full bg-transparent text-sm font-medium text-[#111111] outline-none placeholder:text-[#8E8E8E]"
+          />
+          <datalist id="explore-finder-cities">
+            {suggestions.map((label) => (
+              <option key={label} value={label} />
+            ))}
+          </datalist>
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="inline-flex flex-1 items-center justify-center gap-2 rounded-xl bg-accent px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#6E1521] sm:flex-none"
+          >
+            Browse
+            <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleUseMyLocation()}
+            disabled={locating}
+            className={cn(
+              "inline-flex flex-1 items-center justify-center gap-2 rounded-xl border border-[#D9D9D9] bg-white px-4 py-3 text-sm font-semibold text-[#111111] transition-colors hover:border-accent hover:text-accent sm:flex-none",
+              locating && "cursor-wait opacity-70",
+            )}
+          >
+            {locating ? (
+              <LoaderCircle className="h-4 w-4 animate-spin" strokeWidth={2.25} />
+            ) : (
+              <LocateFixed className="h-4 w-4" strokeWidth={2.25} />
+            )}
+            <span className="whitespace-nowrap">Use my location</span>
+          </button>
+        </div>
+      </form>
+
+      {inputError ? (
+        <p className="mt-2.5 text-xs font-medium text-accent">{inputError}</p>
+      ) : null}
+      {!inputError && (status === "denied" || status === "error" || status === "unsupported") && error ? (
+        <p className="mt-2.5 text-xs font-medium text-[#6F6F6F]">{error}</p>
+      ) : null}
+
+      {detectedCity ? (
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+          <p className="text-xs text-[#6F6F6F]">
+            Near you:{" "}
+            <span className="font-semibold text-[#111111]">
+              {formatCityLabel(detectedCity.name, detectedCity.stateCode)}
+            </span>
+          </p>
+          <button
+            type="button"
+            onClick={() => goToCity(detectedCity)}
+            className="inline-flex items-center gap-1 text-xs font-semibold text-accent transition-colors hover:text-[#6E1521]"
+          >
+            Browse therapists
+            <ArrowRight className="h-3.5 w-3.5" strokeWidth={2.5} />
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push(`/explore/usa/${detectedCity.slug}`)}
+            className="inline-flex items-center gap-1 text-xs font-semibold text-[#6F6F6F] transition-colors hover:text-[#111111]"
+          >
+            <MapPinned className="h-3.5 w-3.5" strokeWidth={2.25} />
+            Map view
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/explore/ExploreLocationFinder.tsx
+++ b/src/app/explore/ExploreLocationFinder.tsx
@@ -80,7 +80,7 @@ export function ExploreLocationFinder({ cities }: { cities: CityData[] }) {
 
   return (
     <div className="rounded-2xl border border-[#E8E8E8] bg-white p-4 shadow-[0_1px_2px_rgba(17,17,17,0.04),0_12px_32px_rgba(17,17,17,0.05)] sm:p-5">
-      <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8E8E8E]">
+      <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#6F6F6F]">
         Find therapists near you
       </p>
 
@@ -96,7 +96,7 @@ export function ExploreLocationFinder({ cities }: { cities: CityData[] }) {
             list="explore-finder-cities"
             placeholder="Enter your city"
             aria-label="Search for your city"
-            className="w-full bg-transparent text-sm font-medium text-[#111111] outline-none placeholder:text-[#8E8E8E]"
+            className="w-full bg-transparent text-sm font-medium text-[#111111] outline-none placeholder:text-[#6F6F6F]"
           />
           <datalist id="explore-finder-cities">
             {suggestions.map((label) => (

--- a/src/app/explore/ExplorePageClient.tsx
+++ b/src/app/explore/ExplorePageClient.tsx
@@ -331,6 +331,8 @@ function ViewToggle({
             key={item.value}
             type="button"
             onClick={() => onChange(item.value)}
+            aria-label={`${item.label} view`}
+            title={`${item.label} view`}
             className={cn(
               "inline-flex items-center gap-2 rounded-full px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] transition",
               active
@@ -338,8 +340,8 @@ function ViewToggle({
                 : "text-text-secondary hover:text-text-primary",
             )}
           >
-            <Icon className="h-4 w-4" />
-            {item.label}
+            <Icon className="h-4 w-4 shrink-0" />
+            <span className="hidden sm:inline">{item.label}</span>
           </button>
         );
       })}
@@ -1388,7 +1390,7 @@ export default function ExplorePageClient({
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr),minmax(320px,420px)]">
             <div>
               <span className="eyebrow-chip">Premium Local Discovery Engine</span>
-              <h1 className="mt-5 max-w-3xl text-4xl font-semibold tracking-[-0.05em] text-text-primary md:text-6xl">
+              <h1 className="mt-5 max-w-3xl text-3xl font-semibold tracking-[-0.05em] text-text-primary sm:text-4xl md:text-6xl">
                 Explore by the signals that actually convert.
               </h1>
               <p className="mt-5 max-w-2xl text-base leading-7 text-text-secondary md:text-lg">
@@ -1487,7 +1489,7 @@ export default function ExplorePageClient({
               ))}
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <Select
                 value={filters.sort}
                 onValueChange={(value) => handleSortChange(value as ExploreFilters["sort"])}

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -4,6 +4,7 @@ import { JsonLd } from "@/app/_components/JsonLd";
 import { createPageMetadata, buildBreadcrumbJsonLd } from "@/app/_lib/seo";
 import { getCities } from "@/app/_lib/directory";
 import { cityDisplayName } from "@/data/cities";
+import { ExploreLocationFinder } from "./ExploreLocationFinder";
 
 const FEATURED_CITY_SLUGS = [
   "atlanta",
@@ -75,21 +76,25 @@ export default function ExplorePage() {
         ])}
       />
 
-      <section className="mx-auto max-w-7xl px-4 py-12 sm:px-6">
-        <h1 className="font-display text-4xl font-semibold tracking-tight">
+      <section className="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-12">
+        <h1 className="font-display text-3xl font-semibold tracking-tight sm:text-4xl">
           Explore
         </h1>
         <p className="mt-1 text-muted-foreground">
           Find therapists by city or state.
         </p>
 
+        <div className="mt-6">
+          <ExploreLocationFinder cities={allCities} />
+        </div>
+
         <h2 className="mt-10 font-display text-2xl font-semibold">Cities</h2>
-        <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+        <div className="mt-4 grid grid-cols-1 gap-2 min-[420px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
           {featuredCities.map((city) => (
             <Link
               key={city!.slug}
               href={`/${city!.slug}`}
-              className="rounded-lg border border-border bg-card px-3 py-2 text-sm transition-colors hover:border-primary/40"
+              className="truncate rounded-lg border border-border bg-card px-3 py-2.5 text-sm transition-colors hover:border-primary/40"
             >
               {cityDisplayName(city!.name, city!.stateCode)}{" "}
               <span className="text-muted-foreground">{city!.stateCode}</span>
@@ -103,7 +108,7 @@ export default function ExplorePage() {
             <Link
               key={state.stateCode}
               href={`/states/${toStateSlug(state.stateName)}`}
-              className="rounded-lg border border-border bg-card px-3 py-2 text-sm transition-colors hover:border-primary/40"
+              className="truncate rounded-lg border border-border bg-card px-3 py-2.5 text-sm transition-colors hover:border-primary/40"
             >
               {state.stateName}
             </Link>

--- a/src/components/sections/AdvancedDirectoryFilter.tsx
+++ b/src/components/sections/AdvancedDirectoryFilter.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { MapPin, Search, SlidersHorizontal, X } from "lucide-react";
+import { LoaderCircle, LocateFixed, MapPin, Search, SlidersHorizontal, X } from "lucide-react";
 import { useState } from "react";
 import type { TherapistTier } from "@/app/_lib/directory";
 import type { CityData } from "@/data/cities";
 import { formatCityLabel } from "@/data/cities";
+import { useGeolocation } from "@/hooks/useGeolocation";
 
 export type DirectorySession = "" | "home-visit" | "incall";
 type DirectoryObjectiveId =
@@ -182,6 +183,20 @@ export function AdvancedDirectoryFilter({
         filters.lgbtqAffirming,
     ),
   );
+  const [locating, setLocating] = useState(false);
+  const { requestLocation } = useGeolocation({ autoLocate: false });
+
+  const handleUseMyLocation = async () => {
+    setLocating(true);
+    try {
+      const detected = await requestLocation(true);
+      if (detected) {
+        onChange({ city: detected.name });
+      }
+    } finally {
+      setLocating(false);
+    }
+  };
 
   const activeObjective = resolveDirectoryObjective(filters.goal, filters.modality);
   const matchedCity = cities.find(
@@ -232,15 +247,29 @@ export function AdvancedDirectoryFilter({
                 </div>
               </div>
 
-              <div className="hidden min-w-[190px] items-center gap-3 rounded-[1.35rem] border border-slate-200/80 bg-white/72 px-4 py-3 shadow-[var(--shadow-md)] backdrop-blur-xl sm:flex">
-                <MapPin className="h-4 w-4 shrink-0 text-slate-400" />
+              <button
+                type="button"
+                onClick={() => void handleUseMyLocation()}
+                disabled={locating}
+                title="Use my location"
+                className="flex min-w-[190px] items-center gap-3 rounded-[1.35rem] border border-slate-200/80 bg-white/72 px-4 py-3 text-left shadow-[var(--shadow-md)] backdrop-blur-xl transition-colors hover:border-slate-300 disabled:cursor-wait"
+              >
+                {locating ? (
+                  <LoaderCircle className="h-4 w-4 shrink-0 animate-spin text-slate-400" />
+                ) : filters.city ? (
+                  <MapPin className="h-4 w-4 shrink-0 text-slate-400" />
+                ) : (
+                  <LocateFixed className="h-4 w-4 shrink-0 text-slate-400" />
+                )}
                 <div className="min-w-0">
                   <p className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-slate-400">
                     Location
                   </p>
-                  <p className="mt-1 truncate font-sans text-sm font-medium text-slate-900">{cityLabel}</p>
+                  <p className="mt-1 truncate font-sans text-sm font-medium text-slate-900">
+                    {locating ? "Detecting…" : filters.city ? cityLabel : "Use my location"}
+                  </p>
                 </div>
-              </div>
+              </button>
 
               <button
                 type="button"

--- a/src/components/ui/pill.tsx
+++ b/src/components/ui/pill.tsx
@@ -1,25 +1,33 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+// Dimensional pill treatment: a soft top highlight, a shaded lower lip, and a
+// short drop shadow give every pill a subtle raised "candy" profile without
+// leaving the brand's restrained look.
+const LIGHT_DEPTH =
+  "shadow-[inset_0_1px_0_rgba(255,255,255,0.95),inset_0_-1.5px_2px_rgba(17,17,17,0.07),0_1px_1.5px_rgba(17,17,17,0.1),0_2px_5px_rgba(17,17,17,0.07)]";
+const DARK_DEPTH =
+  "shadow-[inset_0_1px_0_rgba(255,255,255,0.3),inset_0_-1.5px_2px_rgba(0,0,0,0.3),0_1.5px_2px_rgba(17,17,17,0.16),0_3px_8px_rgba(139,30,45,0.3)]";
+
 const pillVariants = cva(
   "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition-colors",
   {
     variants: {
       variant: {
         // Status pills
-        available: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
-        visiting: "bg-sky-50 text-sky-700 ring-1 ring-sky-200",
-        new: "bg-accent text-white",
-        featured: "bg-amber-50 text-amber-700 ring-1 ring-amber-200",
+        available: `bg-gradient-to-b from-emerald-50 to-emerald-100 text-emerald-800 ring-1 ring-emerald-200/90 ${LIGHT_DEPTH}`,
+        visiting: `bg-gradient-to-b from-sky-50 to-sky-100 text-sky-800 ring-1 ring-sky-200/90 ${LIGHT_DEPTH}`,
+        new: `bg-gradient-to-b from-[#A32B3C] to-accent text-white ring-1 ring-[#6E1521]/45 ${DARK_DEPTH}`,
+        featured: `bg-gradient-to-b from-amber-50 to-amber-100 text-amber-800 ring-1 ring-amber-200/90 ${LIGHT_DEPTH}`,
 
         // Trust pills
-        verified: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
-        location: "bg-slate-100 text-slate-700 ring-1 ring-slate-200",
-        lgbtq: "bg-rose-50 text-rose-700 ring-1 ring-rose-200",
-        community: "bg-purple-50 text-purple-700 ring-1 ring-purple-200",
+        verified: `bg-gradient-to-b from-emerald-50 to-emerald-100 text-emerald-800 ring-1 ring-emerald-200/90 ${LIGHT_DEPTH}`,
+        location: `bg-gradient-to-b from-white to-slate-100 text-slate-700 ring-1 ring-slate-200/90 ${LIGHT_DEPTH}`,
+        lgbtq: `bg-gradient-to-b from-rose-50 to-rose-100 text-rose-700 ring-1 ring-rose-200/90 ${LIGHT_DEPTH}`,
+        community: `bg-gradient-to-b from-purple-50 to-purple-100 text-purple-700 ring-1 ring-purple-200/90 ${LIGHT_DEPTH}`,
 
         // Service pills
-        service: "bg-slate-100 text-slate-700 ring-1 ring-slate-200",
+        service: `bg-gradient-to-b from-white to-slate-100 text-slate-700 ring-1 ring-slate-200/90 ${LIGHT_DEPTH}`,
       },
       size: {
         sm: "text-[10px] px-2 py-1",


### PR DESCRIPTION
## 1. Dimensional "3D" profile pills

The flat tag pills on therapist cards (`src/components/ui/pill.tsx`) now have a premium raised profile: a top-to-bottom gradient surface, a glossy inset top highlight, a shaded lower lip, and a short two-layer drop shadow. All existing variants get the treatment automatically (Available Now, Visiting Now/Soon, Verified, LGBTQ+ Safe Space, service tags, Featured), staying inside the current hues so nothing reads garish.

- The **New** pill (solid brand-red, previously defined but never rendered) is now wired into `PublicTherapistCard` with a lucide `Sparkles` icon for profiles created within the last 30 days — it uses a darker red gradient with its own depth shadow.

## 2. `/explore` now asks for location

New client component `ExploreLocationFinder` at the top of the Explore landing page:

- **Use my location** — browser geolocation via the existing `useGeolocation` hook (reverse-geocode to the nearest supported city, IP-based fallback when permission is denied), then routes to that city's directory page.
- **City search** — autocomplete input over all supported cities (accepts "Austin", "Austin, TX", or slug form) with a Browse CTA.
- When a location is already known (stored or auto-detected with granted permission), a "Near you: City, ST" row offers one-tap **Browse therapists** and **Map view** (`/explore/usa/[city]`) links.

The page also gets mobile polish: single-column city grid under 420px with truncation, tighter paddings, smaller heading on phones.

## 3. Explore discovery UI (`/explore/usa/[city]`) mobile fixes

- The Grid / Cards / Map / Swipe view toggle no longer overflows narrow screens — labels collapse to icons below `sm`, with `aria-label`/`title` kept for accessibility.
- Hero heading steps down to `text-3xl` on phones; the sort/filter row wraps instead of clipping.

## 4. `/search` asks for location

The read-only "Location" tile in the directory filter bar is now a **Use my location** button (and is no longer hidden on mobile). Tapping it runs geolocation detection and applies the visitor's city to the search filters, with a spinner while detecting. The expanded City select still allows manual override.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on all six changed files — clean
- `pnpm run build` — succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01S25U8zQZ923GwV61ZtoKhB)_