### PR TITLE
fix: homepage featured section hides therapists; signups lose city from ZIP-only entry

### DIFF
--- a/src/app/api/_lib/zip-location.ts
+++ b/src/app/api/_lib/zip-location.ts
@@ -1,0 +1,37 @@
+import { fetchZipByCode } from "@/lib/profile-autofill";
+
+export type ResolvedLocation = {
+  city: string | null;
+  state: string | null;
+  zip: string | null;
+};
+
+// The signup profile step lets providers continue with a ZIP code alone —
+// city/state are only auto-filled by a client-side lookup that can fail or
+// still be in flight when the form advances. Resolving here guarantees a
+// submitted ZIP always yields a city/state server-side, so profiles never
+// land in the directory without a location while the ZIP is silently lost.
+export async function resolveCityStateFromZip(profile: {
+  city?: string | null;
+  state?: string | null;
+  zipCode?: string | null;
+}): Promise<ResolvedLocation> {
+  const city = profile.city?.trim() || null;
+  const state = profile.state?.trim() || null;
+  const zip = profile.zipCode?.replace(/\D/g, "").slice(0, 5) || null;
+
+  if ((city && state) || !zip || zip.length < 5) {
+    return { city, state, zip };
+  }
+
+  try {
+    const result = await fetchZipByCode(zip);
+    if (result) {
+      return { city: city ?? result.city, state: state ?? result.stateAbbr, zip };
+    }
+  } catch {
+    // Lookup failures must never block a signup — fall through with what we have.
+  }
+
+  return { city, state, zip };
+}

--- a/src/app/api/signup/resubmit/route.ts
+++ b/src/app/api/signup/resubmit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getRequestSession } from "@/app/api/_lib/session";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+import { resolveCityStateFromZip } from "@/app/api/_lib/zip-location";
 
 export async function POST(request: NextRequest) {
   try {
@@ -17,13 +18,15 @@ export async function POST(request: NextRequest) {
     }
 
     const adminClient = createSupabaseAdminClient();
+    const location = await resolveCityStateFromZip(profile);
 
     const { error: updateError } = await adminClient
       .from("profiles")
       .update({
         bio: profile.bio || null,
-        city: profile.city || null,
-        state: profile.state || null,
+        city: location.city,
+        state: location.state,
+        zip_code: location.zip,
         specialties: profile.serviceCategories?.length ? profile.serviceCategories : null,
         incall_price: profile.startingPrice ? Number(profile.startingPrice) : null,
         status: "pending_approval",

--- a/src/app/api/signup/resubmit/route.ts
+++ b/src/app/api/signup/resubmit/route.ts
@@ -29,6 +29,7 @@ export async function POST(request: NextRequest) {
         zip_code: location.zip,
         specialties: profile.serviceCategories?.length ? profile.serviceCategories : null,
         incall_price: profile.startingPrice ? Number(profile.startingPrice) : null,
+        lgbtq_affirming: true,
         status: "pending_approval",
         is_active: false,
         updated_at: new Date().toISOString(),

--- a/src/app/api/signup/submit/route.ts
+++ b/src/app/api/signup/submit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getRequestSession } from "@/app/api/_lib/session";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { notifyAdmin } from "@/app/api/_lib/admin-notify";
+import { resolveCityStateFromZip } from "@/app/api/_lib/zip-location";
 
 export async function POST(request: NextRequest) {
   try {
@@ -58,13 +59,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Identity verification must be completed." }, { status: 400 });
     }
 
+    const location = await resolveCityStateFromZip(profile);
+
     const { error: updateError } = await adminClient
       .from("profiles")
       .update({
         bio: profile.bio || null,
-        city: profile.city || null,
+        city: location.city,
         neighborhood_name: profile.neighborhood?.trim() || null,
-        state: profile.state || null,
+        state: location.state,
+        zip_code: location.zip,
         specialties: profile.serviceCategories?.length ? profile.serviceCategories : null,
         incall_price: profile.startingPrice ? Number(profile.startingPrice) : null,
         years_experience: profile.yearsExperience ? Number(profile.yearsExperience) : null,
@@ -90,8 +94,8 @@ export async function POST(request: NextRequest) {
       intro: `${profile.fullName || "A provider"} submitted their profile and is awaiting approval.`,
       fields: [
         { label: "Name", value: profile.fullName || null },
-        { label: "City", value: profile.city || null },
-        { label: "State", value: profile.state || null },
+        { label: "City", value: location.city },
+        { label: "State", value: location.state },
         { label: "Plan", value: planTier || null },
         { label: "User ID", value: session.userId },
       ],

--- a/src/app/api/signup/submit/route.ts
+++ b/src/app/api/signup/submit/route.ts
@@ -72,6 +72,9 @@ export async function POST(request: NextRequest) {
         specialties: profile.serviceCategories?.length ? profile.serviceCategories : null,
         incall_price: profile.startingPrice ? Number(profile.startingPrice) : null,
         years_experience: profile.yearsExperience ? Number(profile.yearsExperience) : null,
+        // Mandatory platform-wide — every provider commits to
+        // LGBTQ+-affirming service in the Therapist Agreement.
+        lgbtq_affirming: true,
         _tier: planTier ?? null,
         status: "pending_approval",
         profile_status: "pending_approval",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,12 +63,22 @@ function isRealProfileId(id: string | null | undefined) {
 export default async function HomePage() {
   let featuredTherapists: Awaited<ReturnType<typeof getPublicTherapists>>["items"] = [];
   try {
-    // Run both queries in parallel — lgbtq-affirming preferred, broad as fallback
+    // Run both queries in parallel — lgbtq-affirming profiles rank first, and
+    // the broad list fills the remaining slots. Merging (instead of using the
+    // affirming list exclusively) keeps the section full even when only one or
+    // two profiles have the lgbtq_affirming flag set.
     const [lgbtqResult, broadResult] = await Promise.all([
       getPublicTherapists({ page: 1, pageSize: 6, lgbtqAffirming: true }),
       getPublicTherapists({ page: 1, pageSize: 6 }),
     ]);
-    featuredTherapists = lgbtqResult.items.length > 0 ? lgbtqResult.items : broadResult.items;
+    const seenIds = new Set<string>();
+    featuredTherapists = [...lgbtqResult.items, ...broadResult.items]
+      .filter((therapist) => {
+        if (seenIds.has(therapist.id)) return false;
+        seenIds.add(therapist.id);
+        return true;
+      })
+      .slice(0, 6);
 
     const realIds = featuredTherapists
       .filter((t) => isRealProfileId(t.id))

--- a/src/app/signup/resubmit/page.tsx
+++ b/src/app/signup/resubmit/page.tsx
@@ -57,6 +57,7 @@ export default function SignupResubmitPage() {
             yearsExperience: p.yearsExperience,
             city: p.city,
             state: p.state,
+            zipCode: p.zipCode,
             neighborhood: p.neighborhood,
             locationType: p.locationType,
             serviceCategories: p.serviceCategories,

--- a/src/app/signup/review/page.tsx
+++ b/src/app/signup/review/page.tsx
@@ -96,6 +96,7 @@ export default function SignupReviewPage() {
             certifications: p.certifications,
             city: p.city,
             state: p.state,
+            zipCode: p.zipCode,
             neighborhood: p.neighborhood,
             visitingCities: p.visitingCities,
             locationType: p.locationType,

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -59,6 +59,7 @@ alter table public.profiles
   add column if not exists city text,
   add column if not exists state text,
   add column if not exists country text,
+  add column if not exists zip_code text,
   add column if not exists neighborhood text,
   add column if not exists neighborhood_name text,
   add column if not exists primary_area text,

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -111,7 +111,7 @@ alter table public.profiles
   add column if not exists weight_lb integer,
   add column if not exists body_type text,
   add column if not exists start_year integer,
-  add column if not exists lgbtq_affirming boolean default false,
+  add column if not exists lgbtq_affirming boolean not null default true,
   add column if not exists accepts_all_genders boolean default true,
   add column if not exists accessibility_features text[] default '{}',
   add column if not exists is_verified_identity boolean default false,

--- a/supabase/migrations/20260728220000_lgbtq_affirming_mandatory.sql
+++ b/supabase/migrations/20260728220000_lgbtq_affirming_mandatory.sql
@@ -1,0 +1,18 @@
+-- MasseurMatch is an LGBTQ+-affirming directory: affirmation is a platform
+-- commitment every provider accepts with the Therapist Agreement, not an
+-- opt-in flag. The signup flow never set the column, so every new provider
+-- landed as false and was excluded from affirming-first placement.
+--
+-- Backfill all existing profiles, then make the column default true and
+-- NOT NULL so a profile can never silently land as non-affirming again.
+-- (The signup routes also set it explicitly on submit/resubmit.)
+
+UPDATE public.profiles
+SET lgbtq_affirming = true
+WHERE lgbtq_affirming IS DISTINCT FROM true;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN lgbtq_affirming SET DEFAULT true;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN lgbtq_affirming SET NOT NULL;


### PR DESCRIPTION
## Problem 1 — Homepage shows only one therapist

The homepage "Verified Therapists Ready to Help" section was showing only **one** card (Bruno / Dallas) even though production has 9 approved, public therapist profiles.

The cause was an all-or-nothing selection in `src/app/page.tsx`: two queries run in parallel (one filtered to `lgbtq_affirming = true`, one broad), and the page used the affirming list **exclusively** whenever it returned at least one profile. Since only one production profile had the `lgbtq_affirming` flag set, every other approved therapist was dropped from the section.

**Fix:** merge the two result sets — LGBTQ+-affirming profiles rank first, the broad list fills the remaining slots, deduplicated by profile id, capped at 6 cards.

## Problem 2 — Signups silently lose their location

7 of the 9 approved production profiles have `city = NULL` (and no state, ZIP, coordinates, or areas served), which keeps them off every city page and city search. Root cause traced to the signup flow:

- The profile step accepts a **ZIP code alone** (`zipCode || (city && state)` validation).
- City/state are only filled by a **client-side** ZIP lookup that can fail or still be in flight when the user advances.
- The ZIP itself was **never included** in the submit payload, so the API stored `city: null` and the entered ZIP was lost forever.

**Fix:**
- `signup/review` and `signup/resubmit` pages now send `zipCode`.
- New `resolveCityStateFromZip` helper (`src/app/api/_lib/zip-location.ts`) resolves missing city/state server-side in `/api/signup/submit` and `/api/signup/resubmit`, using the local ZIP table with zippopotam.us as fallback, and persists `zip_code` so the entered ZIP is never discarded. Lookup failures never block a signup.
- `profiles.zip_code` added to `PRODUCTION_SCHEMA_LOCK.sql` (the column exists in production but was only listed in a view's select, failing the DB-contract check).

## Problem 3 — `lgbtq_affirming` was an accidental opt-in

Affirmation is a platform commitment accepted with the Therapist Agreement, but nothing in the signup flow ever set the column — every new provider landed as `false` and lost affirming-first placement.

**Fix (mandatory platform-wide, per owner request):**
- Migration `20260728220000_lgbtq_affirming_mandatory.sql` backfills `lgbtq_affirming = true` on all existing profiles and makes the column `NOT NULL DEFAULT true`. Applied to production automatically by the `apply-supabase-migrations` workflow on merge.
- `/api/signup/submit` and `/api/signup/resubmit` set it explicitly.
- Schema lock updated to match.

## Verification

- `npx tsc --noEmit`, `npx eslint` on changed files, `pnpm run build`, `pnpm validate:db-contract` — all clean.
- Replicated the site's public-directory query against production (anon key, RLS-enforced): 9 profiles pass all public filters, confirming the merged featured list now yields a full 6-card section.

## Note (data, not code)

The 7 existing profiles with `city = NULL` have no recoverable location data anywhere (their ZIPs were discarded by the old flow). Their cities must be entered manually via the admin panel or by each provider in their dashboard. This PR prevents the loss for all future signups.