### PR TITLE
fix(signup): stop raw "{}" from rendering as the signup error message

### DIFF
--- a/src/app/_lib/client-api.ts
+++ b/src/app/_lib/client-api.ts
@@ -27,6 +27,34 @@ async function parsePayload(response: Response) {
   }
 }
 
+function extractErrorMessage(payload: unknown, status: number): string {
+  const fallback = `Request failed with status ${status}.`;
+
+  if (typeof payload !== "object" || !payload || !("error" in payload)) {
+    return fallback;
+  }
+
+  const raw = (payload as { error: unknown }).error;
+  const candidate =
+    typeof raw === "string"
+      ? raw
+      : typeof raw === "object" &&
+          raw !== null &&
+          "message" in raw &&
+          typeof (raw as { message: unknown }).message === "string"
+        ? (raw as { message: string }).message
+        : "";
+
+  // Reject empty or JSON-shaped messages (e.g. a stringified error body such
+  // as "{}") so raw payloads never reach the UI.
+  const message = candidate.trim();
+  if (!message || message.startsWith("{") || message.startsWith("[")) {
+    return fallback;
+  }
+
+  return message;
+}
+
 function needsCsrfToken(url: string, method?: string): boolean {
   return (
     method === "POST" &&
@@ -74,12 +102,7 @@ export async function requestJson<T>(
   const payload = await parsePayload(response);
 
   if (!response.ok) {
-    const message =
-      typeof payload === "object" && payload && "error" in payload
-        ? String(payload.error)
-        : `Request failed with status ${response.status}.`;
-
-    throw new ApiError(message, response.status, payload);
+    throw new ApiError(extractErrorMessage(payload, response.status), response.status, payload);
   }
 
   return payload as T;

--- a/src/app/api/_lib/http.ts
+++ b/src/app/api/_lib/http.ts
@@ -84,9 +84,29 @@ function parseCookieHeader(header: string | null): Record<string, string> {
   }, {});
 }
 
+/**
+ * Guard user-facing error copy. Upstream libraries sometimes produce
+ * machine-shaped messages — supabase-js, for one, falls back to
+ * `JSON.stringify(body)` when an auth response has no message field, which
+ * surfaces as a literal "{}" in the UI. Reject empty or JSON-looking strings
+ * and use the provided fallback instead.
+ */
+export function toUserErrorMessage(raw: unknown, fallback: string): string {
+  if (typeof raw !== "string") {
+    return fallback;
+  }
+
+  const message = raw.trim();
+  if (!message || message.startsWith("{") || message.startsWith("[")) {
+    return fallback;
+  }
+
+  return message;
+}
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
-    return error.message;
+    return toUserErrorMessage(error.message, "Something went wrong. Please try again.");
   }
 
   return "Unknown error.";

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,4 +1,4 @@
-import { errorResponse, json, parseJsonBody } from "@/app/api/_lib/http";
+import { errorResponse, json, parseJsonBody, toUserErrorMessage } from "@/app/api/_lib/http";
 import { RouteError } from "@/app/api/_lib/http";
 import { assertRateLimit } from "@/app/_lib/security";
 import { authRegisterSchema } from "@/app/_lib/validation";
@@ -42,7 +42,10 @@ export async function POST(request: Request) {
           { status: 409 },
         );
       }
-      throw new RouteError(400, error?.message || "Could not create account.");
+      throw new RouteError(
+        400,
+        toUserErrorMessage(error?.message, "We couldn't create your account. Please try again."),
+      );
     }
 
     if (Array.isArray(data.user.identities) && data.user.identities.length === 0) {

--- a/src/app/signup/account/page.tsx
+++ b/src/app/signup/account/page.tsx
@@ -144,7 +144,9 @@ export default function SignupAccountPage() {
     try {
       const result = await signUp(form.email, form.password, form.fullName);
       if (result.error) {
-        setError(result.error.message);
+        setError(
+          result.error.message?.trim() || "We couldn't create your account. Please try again.",
+        );
         setLoading(false);
         return;
       }


### PR DESCRIPTION
## Problem

On the therapist signup page (`/signup/account`), tapping **Continue to Verification** could show a literal `{}` in the error box instead of a readable message (see mobile screenshot that reported this).

## Root cause

`supabase-js` builds `AuthApiError` messages as:

```
data.msg || data.message || data.error_description || data.error || JSON.stringify(body)
```

When GoTrue returns an unexpected/empty JSON body, the resulting message is the literal string `"{}"`. The register route (`src/app/api/auth/register/route.ts`) passed `error.message` straight through to the client (`throw new RouteError(400, error?.message || …)` — `"{}"` is truthy, so the fallback never applied), and the signup form rendered it verbatim. The login route already maps Supabase errors to friendly copy; register did not.

## Fix

- **`src/app/api/auth/register/route.ts`** — sanitize the Supabase error message via a new `toUserErrorMessage` helper; empty or JSON-shaped messages fall back to "We couldn't create your account. Please try again." Human-readable Supabase messages (e.g. password policy errors) still pass through.
- **`src/app/api/_lib/http.ts`** — new exported `toUserErrorMessage(raw, fallback)` guard, also applied to the generic 500 `errorResponse` path so no route can leak a JSON blob as user-facing copy.
- **`src/app/_lib/client-api.ts`** — `ApiError` message extraction is now defensive: accepts `payload.error` as a string or a `{ message }` object, rejects empty/JSON-shaped values, and falls back to `Request failed with status N.` (previously `String(payload.error)` could yield `[object Object]`).
- **`src/app/signup/account/page.tsx`** — final fallback to friendly copy if the returned error message is empty/whitespace.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on the four changed files — clean
- `pnpm run build` — passes
- Probed the production API shapes (CSRF failure, validation failure) to confirm normal error paths still return the same string messages, which continue to pass through unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGQbVBabwxTTviWJqcmeZ2)_