### PR TITLE
fix: unbreak subscription checkout and self-heal Supabase CI workflows

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -57,6 +57,11 @@ jobs:
           fi
           [ "$missing" -eq 0 ]
 
+      # Repo variables pasted with stray whitespace (e.g. a trailing space)
+      # make `supabase link` fail with "Invalid project ref format".
+      - name: Normalize project ref
+        run: echo "SUPABASE_PROJECT_REF=$(echo "$SUPABASE_PROJECT_REF" | tr -d '[:space:]')" >> "$GITHUB_ENV"
+
       - uses: supabase/setup-cli@v1
         with:
           version: latest

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -25,6 +25,8 @@ on:
       - "supabase/functions/process-lifecycle-email-queue/**"
       - "supabase/functions/lifecycle-unsubscribe/**"
       - "supabase/functions/run-lifecycle-campaigns/**"
+      - "supabase/functions/create-checkout/**"
+      - "supabase/functions/customer-portal/**"
       - "supabase/functions/_shared/**"
       - "supabase/config.toml"
       - ".github/workflows/deploy-supabase-functions.yml"
@@ -57,6 +59,11 @@ jobs:
           fi
           [ "$missing" -eq 0 ]
 
+      # Repo variables pasted with stray whitespace (e.g. a trailing space)
+      # make the CLI fail with "Invalid project ref format".
+      - name: Normalize project ref
+        run: echo "SUPABASE_PROJECT_REF=$(echo "$SUPABASE_PROJECT_REF" | tr -d '[:space:]')" >> "$GITHUB_ENV"
+
       - uses: supabase/setup-cli@v1
         with:
           version: latest
@@ -69,3 +76,8 @@ jobs:
           supabase functions deploy process-lifecycle-email-queue --project-ref "$SUPABASE_PROJECT_REF"
           supabase functions deploy lifecycle-unsubscribe --project-ref "$SUPABASE_PROJECT_REF"
           supabase functions deploy run-lifecycle-campaigns --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Deploy billing functions
+        run: |
+          supabase functions deploy create-checkout --project-ref "$SUPABASE_PROJECT_REF"
+          supabase functions deploy customer-portal --project-ref "$SUPABASE_PROJECT_REF"

--- a/src/app/pro/billing/page.tsx
+++ b/src/app/pro/billing/page.tsx
@@ -15,6 +15,25 @@ import { supabase } from "@/integrations/supabase/client";
 
 type Tier = SignupPlanTier;
 
+// supabase.functions.invoke wraps every non-2xx response in a generic
+// "Edge Function returned a non-2xx status code" error, hiding the real
+// message the function put in its JSON body ({ error }). Pull it out so the
+// toast tells the user (and us) what actually failed.
+async function resolveFunctionError(error: unknown): Promise<Error> {
+  const context = (error as { context?: Response })?.context;
+  if (context && typeof context.json === "function") {
+    try {
+      const body = await context.clone().json();
+      if (typeof body?.error === "string" && body.error) {
+        return new Error(body.error);
+      }
+    } catch {
+      // Body wasn't JSON — fall through to the generic message.
+    }
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 function toTier(value: string | null): Tier | null {
   if (value === "free" || value === "standard" || value === "pro" || value === "elite") {
     return value;
@@ -51,7 +70,7 @@ function ProBillingPageInner() {
         body: { plan_key: tier, return_path: "/pro/billing" },
       });
 
-      if (error) throw error;
+      if (error) throw await resolveFunctionError(error);
       if (data?.error) throw new Error(data.error);
 
       if (data?.url) {
@@ -87,7 +106,7 @@ function ProBillingPageInner() {
     try {
       const { data, error } = await supabase.functions.invoke("customer-portal");
 
-      if (error) throw error;
+      if (error) throw await resolveFunctionError(error);
       if (data?.error) throw new Error(data.error);
 
       if (data?.url) {

--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -54,7 +54,11 @@ function getConfiguredPriceId(planKey: string): string | null {
   const envName = PLAN_PRICE_ENV[planKey];
   if (!envName) return null;
   const priceId = Deno.env.get(envName)?.trim();
-  return priceId && priceId.startsWith("price_") ? priceId : null;
+  // Only accept a real-looking Stripe price ID. A placeholder value such as
+  // "price_…" passes a bare startsWith check and then 500s every checkout
+  // (free trials included) with Stripe's "No such price" — fall back to the
+  // metadata-based lookup instead.
+  return priceId && /^price_[A-Za-z0-9]+$/.test(priceId) ? priceId : null;
 }
 
 // Resolve the price for a plan: use the configured fixed price ID when set,


### PR DESCRIPTION
## Problem — every checkout fails ("Edge Function returned a non-2xx status code")

Verified live against production: `create-checkout` returns HTTP 500 `No such price: 'price_…'` for **all four plans** (free trial, standard, pro, elite). The entire subscription funnel is dead.

Root causes:

1. **Placeholder Stripe price secrets.** The Edge Function secrets `STRIPE_PRICE_STANDARD/PRO/ELITE` hold a literal placeholder (`price_…`). `getConfiguredPriceId` only checked `startsWith("price_")`, so the placeholder was sent to Stripe, which rejects every session. The correct live prices exist in Stripe ($39/$79/$99 monthly, products tagged `masseurmatch_plan` metadata) — the function's own metadata-based fallback would have found them.
2. **Billing functions never redeployed.** `deploy-supabase-functions.yml` did not cover `create-checkout`/`customer-portal`, so code fixes to them never reach production.
3. **`SUPABASE_PROJECT_REF` repo variable has a trailing space**, which fails `supabase link` with `Invalid project ref format` in both the migrations and functions workflows (confirmed in the Apply Supabase Migrations run #4 logs).
4. **Client hides the real error.** The billing page surfaced supabase-js's generic non-2xx message instead of the function's JSON `error` body.

## Fix

- `supabase/functions/create-checkout/index.ts`: validate configured price IDs with `^price_[A-Za-z0-9]+$`; malformed values (like the placeholder) fall back to the metadata-based Stripe lookup, which resolves the correct prices today with zero secret changes.
- `.github/workflows/deploy-supabase-functions.yml`: deploy `create-checkout` and `customer-portal` on merge (added to paths + a deploy step), so this fix and future ones ship automatically.
- Both Supabase workflows now strip whitespace from `SUPABASE_PROJECT_REF` before use.
- `src/app/pro/billing/page.tsx`: unwrap the Edge Function's JSON error body so toasts show the actual failure reason.

## Effect on merge (self-healing)

- The functions workflow fires (its file + `create-checkout` changed) → deploys the hardened function → checkout works for all plans.
- The migrations workflow fires (its file changed) → with the trimmed ref and the now-configured `SUPABASE_DB_PASSWORD`, the pending `lgbtq_affirming` migration finally applies.

Optionally, the placeholder secrets can later be set to the real curated price IDs (`price_1TkvMcLUTr1XrJODF8TSpohr` / `price_1T7lDBLUTr1XrJODA1xj0i2d` / `price_1TwTCmLUTr1XrJODrKz1F8Zo`) to skip the fallback lookup.

## Verification

- Reproduced the failure live: authenticated call to `create-checkout` → `No such price: 'price_…'` on all plans.
- Confirmed the correct prices/products exist in the Stripe account (live mode) with `masseurmatch_plan` metadata, so the fallback path resolves them.
- `npx tsc --noEmit`, `npx eslint` on changed files, `pnpm validate:db-contract`, `pnpm run build` — all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnXnqEJbwH8MGo1esLxFp9)_