### PR TITLE
fix: reconcile Supabase migration history so db push can apply pending migrations

### DIFF
--- a/.github/workflows/apply-supabase-migrations.yml
+++ b/.github/workflows/apply-supabase-migrations.yml
@@ -69,5 +69,31 @@ jobs:
       - name: Link project
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
 
+      # One-time baseline reconciliation. The remote history table records
+      # versions that were applied via the Supabase dashboard and have no file
+      # in this repo (db push then aborts with "Remote migration versions not
+      # found in local migrations directory"), while the repo migrations that
+      # predate this workflow were applied by hand and never recorded. Drop the
+      # dashboard-only rows, then record every local migration older than the
+      # baseline as applied — production already contains their schema (the DB
+      # contract check validates the app against PRODUCTION_SCHEMA_LOCK.sql).
+      # Once reconciled these repairs are no-ops, and db push applies only
+      # migrations newer than the baseline.
+      - name: Reconcile migration history
+        run: |
+          BASELINE=20260726000000
+          supabase migration repair --status reverted \
+            20260722203257 20260723071639 20260723152216 20260723175443 \
+            20260723231058 20260724004630 20260724022000 20260725170728 || true
+          applied=""
+          for f in supabase/migrations/*.sql; do
+            v=$(basename "$f" | cut -d_ -f1)
+            case "$v" in *[!0-9]*) continue ;; esac
+            if [ "$v" -lt "$BASELINE" ]; then applied="$applied $v"; fi
+          done
+          if [ -n "$applied" ]; then
+            supabase migration repair --status applied $applied || true
+          fi
+
       - name: Apply pending migrations
         run: supabase db push


### PR DESCRIPTION
## Problem

After #613 fixed the credentials and project-ref issues, the Apply Supabase Migrations workflow (run #5) got further and failed at `supabase db push`:

> `Remote migration versions not found in local migrations directory.`

The remote `schema_migrations` history records **eight versions applied via the Supabase dashboard** (`20260722203257 … 20260725170728`) that have no file in the repo, while the **147 repo migrations that predate this workflow** were applied by hand and never recorded. `db push` refuses to run until the two agree, so the pending `lgbtq_affirming` backfill migration still hasn't reached production.

## Fix

Add a "Reconcile migration history" step (one-time baseline, no-op afterwards) between `supabase link` and `supabase db push`:

- `migration repair --status reverted` drops the eight dashboard-only history rows (history metadata only — no schema change).
- `migration repair --status applied` records every local migration older than baseline `20260726000000` as applied. Production already contains their schema — the DB Contract CI check validates the app against `PRODUCTION_SCHEMA_LOCK.sql`, which mirrors production.
- `db push` then applies only migrations newer than the baseline — currently exactly one: `20260728220000_lgbtq_affirming_mandatory.sql`.

## Verification

- Workflow YAML parses cleanly.
- Only one local migration (`20260728220000`) is newer than the baseline, confirmed by listing `supabase/migrations/`.
- Checkout fix from #613 already verified working in production (live Stripe checkout URL returned).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnXnqEJbwH8MGo1esLxFp9)_