### PR TITLE
Add branded favicon and social URL preview

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "MasseurMatch - City-First Massage Directory",
   "short_name": "MasseurMatch",
   "description": "Find massage therapists by city, specialty, and profile quality through a city-first public directory.",
-  "start_url": "/?v=20260508b",
+  "start_url": "/?v=20260731mm",
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait-primary",
@@ -13,14 +13,10 @@
   "categories": ["health", "lifestyle", "business"],
   "icons": [
     {
-      "src": "/favicon.svg?v=20260508b",
-      "sizes": "any",
-      "type": "image/svg+xml"
-    },
-    {
-      "src": "/favicon.ico?v=20260508b",
-      "sizes": "64x64 32x32 16x16",
-      "type": "image/x-icon"
+      "src": "https://res.cloudinary.com/dyfxkq2nk/image/upload/v1785553494/ChatGPT_Image_Jul_31_2026_10_04_01_PM_1_akq6hj.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,14 +15,20 @@ import "@/styles/homepage-mobile-hotfix.css";
 import { satoshi } from "./fonts";
 import SmoothScroll from "@/components/motion/SmoothScroll";
 
+const BRAND_ICON_URL =
+  "https://res.cloudinary.com/dyfxkq2nk/image/upload/v1785553494/ChatGPT_Image_Jul_31_2026_10_04_01_PM_1_akq6hj.png";
+const SOCIAL_PREVIEW_URL =
+  "https://res.cloudinary.com/dyfxkq2nk/image/upload/v1785553494/ChatGPT_Image_Jul_31_2026_07_31_32_PM_tsdzpd.png";
+
 const rootMetadata = createPageMetadata({
   title: "MasseurMatch — Premium Directory of LGBTQ+-Affirming Male Massage Therapists",
   description:
     "AI-powered verified therapist discovery — a premium directory of male massage therapists you can trust.",
   path: "/",
+  image: SOCIAL_PREVIEW_URL,
 });
 
-const faviconVersion = "20260603mm";
+const faviconVersion = "20260731mm";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -30,9 +36,9 @@ export const metadata: Metadata = {
   manifest: `/manifest.json?v=${faviconVersion}`,
   category: "wellness",
   icons: {
-    icon: [{ url: `/favicon.ico?v=${faviconVersion}`, type: "image/x-icon" }],
-    shortcut: `/favicon.ico?v=${faviconVersion}`,
-    apple: `/favicon.ico?v=${faviconVersion}`,
+    icon: [{ url: BRAND_ICON_URL, type: "image/png" }],
+    shortcut: BRAND_ICON_URL,
+    apple: BRAND_ICON_URL,
   },
   ...rootMetadata,
   alternates: {

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -2,11 +2,15 @@ import type { Metadata } from "next";
 import { createPageMetadata } from "@/app/_lib/seo";
 import { SignupShell } from "./_components/signup-shell";
 
+const SIGNUP_SOCIAL_IMAGE =
+  "https://res.cloudinary.com/dyfxkq2nk/image/upload/c_fill,g_center,w_1200,h_630,q_auto:best/v1785553494/ChatGPT_Image_Jul_31_2026_07_31_32_PM_tsdzpd.png";
+
 export const metadata: Metadata = createPageMetadata({
-  title: "Sign Up",
+  title: "Join MasseurMatch — Create Your Therapist Profile",
   description:
-    "Create your professional profile on MasseurMatch, verify your identity, and start getting discovered by clients near you.",
+    "Create your MasseurMatch profile, verify your identity, and get discovered by clients looking for LGBTQ+-affirming male massage therapists.",
   path: "/signup",
+  image: SIGNUP_SOCIAL_IMAGE,
   keywords: [
     "massage therapist sign up",
     "get listed as a massage therapist",


### PR DESCRIPTION
Updates MasseurMatch branding for shared links and installed/browser icons.

Changes:
- Uses the supplied Cloudinary icon for favicon, shortcut icon, and Apple touch icon
- Uses the supplied Cloudinary image as the homepage Open Graph and Twitter preview
- Updates the web app manifest to use the new branded icon
- Bumps the favicon/manifest cache version