### PR TITLE
fix(tests): follow any-status host-canonicalization hops in SEO redirect specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,12 @@ The full stack already exists — do not rebuild it:
 - **CI enforces lockfile consistency** — each job runs `pnpm install --frozen-lockfile`,
   so lockfile mismatches are caught immediately in the PR.
 
+## Testing Guidelines
+
+**Test utilities rule**: If a helper function is used in more than one test file, it must live in `tests/helpers/` and both files import from there. Never duplicate test utility logic across multiple files — it causes drift and CI flakes.
+
+Example: `fetchCanonical` (follows Vercel's same-path cross-origin redirects transparently) lives in `tests/helpers/fetch-canonical.ts`. Both `redirects.spec.ts` and `seo-normalization.spec.ts` import it from there, not from duplicate inline implementations.
+
 ## Workflow
 
 - Dev branch for this work: `claude/repo-launch-readiness-KqLDX`.

--- a/tests/helpers/fetch-canonical.ts
+++ b/tests/helpers/fetch-canonical.ts
@@ -1,0 +1,45 @@
+import type { APIRequestContext } from "@playwright/test";
+
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+const MAX_INFRASTRUCTURE_REDIRECTS = 3;
+
+/**
+ * Follow infrastructure-level host canonicalization transparently so the test
+ * sees the application-level redirect. Vercel may use 301, 302, 307, or 308
+ * for a same-path cross-origin hop (e.g. apex → www), and that status may
+ * change independently of the application redirect configuration — so we skip
+ * any redirect whose path+query is unchanged but whose origin differs, and
+ * stop at the first response that isn't one.
+ */
+export async function fetchCanonical(
+  request: APIRequestContext,
+  url: string,
+): Promise<Awaited<ReturnType<APIRequestContext["get"]>>> {
+  let currentUrl = url;
+
+  for (let hop = 0; hop < MAX_INFRASTRUCTURE_REDIRECTS; hop += 1) {
+    const res = await request.get(currentUrl, { maxRedirects: 0 });
+    const location = res.headers()["location"];
+
+    if (!REDIRECT_STATUSES.has(res.status()) || !location) {
+      return res;
+    }
+
+    const sourceUrl = new URL(currentUrl);
+    const locationUrl = new URL(location, currentUrl);
+    const samePathAndQuery =
+      locationUrl.pathname === sourceUrl.pathname &&
+      locationUrl.search === sourceUrl.search;
+    const differentOrigin = locationUrl.origin !== sourceUrl.origin;
+
+    if (!samePathAndQuery || !differentOrigin) {
+      return res;
+    }
+
+    currentUrl = locationUrl.toString();
+  }
+
+  throw new Error(
+    `Exceeded ${MAX_INFRASTRUCTURE_REDIRECTS} same-path host redirects for ${url}`,
+  );
+}

--- a/tests/redirects.spec.ts
+++ b/tests/redirects.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect, type APIRequestContext } from "@playwright/test";
+import { test, expect } from "@playwright/test";
+
+import { fetchCanonical } from "./helpers/fetch-canonical";
 
 /**
  * CI gate: validates every entry in the redirects manifest.
@@ -10,48 +12,6 @@ import { test, expect, type APIRequestContext } from "@playwright/test";
  */
 
 type RedirectCase = [source: string, destination: string];
-
-const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
-const MAX_INFRASTRUCTURE_REDIRECTS = 3;
-
-/**
- * Follow infrastructure-level host canonicalization transparently so the test
- * sees the application-level redirect. Vercel may use 301, 302, 307, or 308
- * for a same-path cross-origin hop, and that status may change independently
- * of the application redirect configuration.
- */
-async function fetchCanonical(
-  request: APIRequestContext,
-  url: string,
-): Promise<Awaited<ReturnType<APIRequestContext["get"]>>> {
-  let currentUrl = url;
-
-  for (let hop = 0; hop < MAX_INFRASTRUCTURE_REDIRECTS; hop += 1) {
-    const res = await request.get(currentUrl, { maxRedirects: 0 });
-    const location = res.headers()["location"];
-
-    if (!REDIRECT_STATUSES.has(res.status()) || !location) {
-      return res;
-    }
-
-    const sourceUrl = new URL(currentUrl);
-    const locationUrl = new URL(location, currentUrl);
-    const samePathAndQuery =
-      locationUrl.pathname === sourceUrl.pathname &&
-      locationUrl.search === sourceUrl.search;
-    const differentOrigin = locationUrl.origin !== sourceUrl.origin;
-
-    if (!samePathAndQuery || !differentOrigin) {
-      return res;
-    }
-
-    currentUrl = locationUrl.toString();
-  }
-
-  throw new Error(
-    `Exceeded ${MAX_INFRASTRUCTURE_REDIRECTS} same-path host redirects for ${url}`,
-  );
-}
 
 // Mirror of src/app/_lib/redirects-manifest.ts — update both together.
 // The source of truth for intent is the TS file; these cases validate HTTP behaviour.

--- a/tests/seo-normalization.spec.ts
+++ b/tests/seo-normalization.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { fetchCanonical } from "./helpers/fetch-canonical";
 
 /**
  * SEO normalization redirects — each case must be a single-hop 301/308.
@@ -7,31 +9,6 @@ import { expect, test, type APIRequestContext } from "@playwright/test";
  * Canonical URL format: /{city-slug}  (e.g. /dallas)
  * Legacy formats redirect to canonical — never the other way around.
  */
-
-/**
- * Follow Vercel's infrastructure-level domain redirect (apex → www, 307)
- * transparently so the test sees the application-level redirect (301/308).
- * The apex domain `masseurmatch.com` redirects to `www.masseurmatch.com`
- * with a 307 before Next.js runs; we skip over that hop here.
- */
-async function fetchCanonical(
-  request: APIRequestContext,
-  url: string,
-): Promise<Awaited<ReturnType<APIRequestContext["get"]>>> {
-  const res = await request.get(url, { maxRedirects: 0 });
-  if (res.status() === 307 || res.status() === 302) {
-    const loc = res.headers()["location"];
-    if (loc) {
-      const locUrl = new URL(loc);
-      const srcUrl = new URL(url);
-      // Same path, different host → domain-level redirect; follow it once.
-      if (locUrl.pathname === srcUrl.pathname && locUrl.hostname !== srcUrl.hostname) {
-        return request.get(locUrl.origin + locUrl.pathname, { maxRedirects: 0 });
-      }
-    }
-  }
-  return res;
-}
 
 const CASES: Array<{ source: string; destination: string }> = [
   // /city/:slug → /:slug (old single-level prefix removal)


### PR DESCRIPTION
Closed after the validated redirect-test changes were ported directly to main in commits b372b40, 30743f2, and 97d8870.