### PR TITLE
SEO: gate thin profiles and enrich provider structured data

### DIFF
--- a/src/app/_lib/profile-seo-quality.ts
+++ b/src/app/_lib/profile-seo-quality.ts
@@ -1,0 +1,114 @@
+type ProfileLike = Record<string, unknown>;
+
+export type ProfileSeoQuality = {
+  score: number;
+  indexEligible: boolean;
+  completedChecks: string[];
+  missingChecks: string[];
+};
+
+const MIN_INDEX_SCORE = 70;
+
+function text(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function list(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value.filter(Boolean);
+  if (typeof value === "string") return value.split(",").map((item) => item.trim()).filter(Boolean);
+  return [];
+}
+
+function truthy(value: unknown) {
+  return value === true || (typeof value === "number" && value > 0) || text(value).length > 0;
+}
+
+export function evaluateProfileSeoQuality(profile: ProfileLike): ProfileSeoQuality {
+  const checks = [
+    {
+      label: "Add an original bio of at least 150 words",
+      weight: 20,
+      passed: text(profile.bio).split(/\s+/).filter(Boolean).length >= 150,
+    },
+    {
+      label: "Add a unique profile headline",
+      weight: 10,
+      passed: text(profile.headline).length >= 20,
+    },
+    {
+      label: "Add city and state",
+      weight: 10,
+      passed: Boolean(text(profile.city) && (text(profile.state) || text(profile.state_code))),
+    },
+    {
+      label: "Add at least three real profile photos",
+      weight: 15,
+      passed:
+        list(profile.gallery_photos).length + list(profile.gallery_images).length >= 2 &&
+        Boolean(text(profile.profile_photo) || text(profile.profile_photo_url) || text(profile.avatar_url)),
+    },
+    {
+      label: "List at least three services or specialties",
+      weight: 15,
+      passed:
+        new Set([
+          ...list(profile.services),
+          ...list(profile.service_categories),
+          ...list(profile.specialties),
+          ...list(profile.massage_techniques),
+        ]).size >= 3,
+    },
+    {
+      label: "Add incall, outcall, or service-area details",
+      weight: 10,
+      passed:
+        truthy(profile.incall_price) ||
+        truthy(profile.outcall_price) ||
+        truthy(profile.incall_available) ||
+        truthy(profile.outcall_available) ||
+        list(profile.areas_served).length > 0 ||
+        list(profile.service_areas).length > 0,
+    },
+    {
+      label: "Add rates or session details",
+      weight: 10,
+      passed:
+        truthy(profile.starting_price) ||
+        truthy(profile.incall_price) ||
+        truthy(profile.outcall_price) ||
+        list(profile.pricing_sessions).length > 0,
+    },
+    {
+      label: "Add current availability or business hours",
+      weight: 5,
+      passed:
+        truthy(profile.available_now) ||
+        list(profile.availability_days).length > 0 ||
+        Boolean(profile.business_hours && typeof profile.business_hours === "object"),
+    },
+    {
+      label: "Add a trust signal or verification detail",
+      weight: 5,
+      passed:
+        truthy(profile.is_verified_identity) ||
+        truthy(profile.is_verified_profile) ||
+        text(profile.verification_status) === "verified" ||
+        list(profile.training).length > 0 ||
+        list(profile.education).length > 0,
+    },
+  ];
+
+  const score = checks.reduce((total, check) => total + (check.passed ? check.weight : 0), 0);
+  const hasIdentity = Boolean(text(profile.display_name) || text(profile.full_name) || text(profile.name));
+  const hasContact = Boolean(text(profile.phone) || text(profile.email_address) || text(profile.whatsapp_number));
+  const indexEligible = score >= MIN_INDEX_SCORE && hasIdentity && hasContact;
+
+  return {
+    score,
+    indexEligible,
+    completedChecks: checks.filter((check) => check.passed).map((check) => check.label),
+    missingChecks: checks.filter((check) => !check.passed).map((check) => check.label),
+  };
+}
+
+export const PROFILE_INDEX_MIN_SCORE = MIN_INDEX_SCORE;

--- a/src/app/therapists/[slug]/page.tsx
+++ b/src/app/therapists/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   getPublicTherapistBySlug,
   getPublicTherapists,
 } from "@/app/_lib/directory";
+import { evaluateProfileSeoQuality } from "@/app/_lib/profile-seo-quality";
 import { buildBreadcrumbJsonLd, createPageMetadata } from "@/app/_lib/seo";
 import { ProfileStructuredData } from "@/components/profile/ProfileStructuredData";
 import { buildProfileFaq } from "@/components/profile/profile-faq";
@@ -38,6 +39,8 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
   }
 
   const profile = buildProfileViewModel(dbProfile);
+  const seoQuality = evaluateProfileSeoQuality(dbProfile as unknown as Record<string, unknown>);
+  const shouldIndex = !dbProfile.is_demo && seoQuality.indexEligible;
 
   return {
     title: profile.seoTitle,
@@ -57,9 +60,8 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
       description: profile.seoDescription,
       images: [profile.ogImage],
     },
-    robots: dbProfile.is_demo
-      ? { index: false, follow: false }
-      : {
+    robots: shouldIndex
+      ? {
           index: true,
           follow: true,
           googleBot: {
@@ -69,7 +71,8 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
             "max-snippet": -1,
             "max-video-preview": -1,
           },
-        },
+        }
+      : { index: false, follow: true },
   };
 }
 
@@ -114,7 +117,10 @@ export default async function TherapistPage({ params }: { params: Promise<Params
       <ProfileViewTracker profileId={dbProfile.id} source="direct" />
       {dbProfile.is_demo && <DemoProfileBanner />}
       <JsonLd data={buildBreadcrumbJsonLd([{ name: "Home", path: "/" }, { name: "Therapists", path: "/therapists" }, ...(matchedCity ? [{ name: matchedCity.name, path: `/${matchedCity.slug}` }] : []), { name: profile.name, path: profilePath }])} />
-      <ProfileStructuredData profile={profile} />
+      <ProfileStructuredData
+        profile={profile}
+        sourceProfile={dbProfile as unknown as Record<string, unknown>}
+      />
       <VoxProfile
         profile={profile}
         faqItems={faqItems}

--- a/src/components/profile/ProfileStructuredData.tsx
+++ b/src/components/profile/ProfileStructuredData.tsx
@@ -3,6 +3,8 @@ import type { ProfileViewModel } from "./profile-utils";
 
 type Credential = { "@type": string; credentialCategory: string; name: string; description: string };
 
+type SourceProfile = Record<string, unknown>;
+
 function buildCredentials(profile: ProfileViewModel) {
   const credentials: Credential[] = [];
   if (profile.isVerified) {
@@ -39,50 +41,84 @@ function buildOfferCatalog(profile: ProfileViewModel) {
   return { "@type": "OfferCatalog", name: `${profile.name} massage services`, itemListElement: offers };
 }
 
-export function ProfileStructuredData({ profile }: { profile: ProfileViewModel }) {
+function dateValue(value: unknown) {
+  if (typeof value !== "string" || !value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function verifiedSameAs(sourceProfile: SourceProfile) {
+  const values = [sourceProfile.website, sourceProfile.instagram, sourceProfile.facebook, sourceProfile.linkedin]
+    .filter((value): value is string => typeof value === "string" && /^https?:\/\//i.test(value));
+  return values.length ? Array.from(new Set(values)) : undefined;
+}
+
+export function ProfileStructuredData({
+  profile,
+  sourceProfile = {},
+}: {
+  profile: ProfileViewModel;
+  sourceProfile?: SourceProfile;
+}) {
   const address = { "@type": "PostalAddress", addressLocality: profile.city, addressRegion: profile.state, addressCountry: profile.country };
   const contactPoint = [profile.phone && { "@type": "ContactPoint", telephone: profile.phone, contactType: "phone" }, profile.email && { "@type": "ContactPoint", email: profile.email, contactType: "email" }].filter(Boolean);
   const credentials = buildCredentials(profile);
   const offerCatalog = buildOfferCatalog(profile);
   const allServices = Array.from(new Set([...profile.services, ...profile.specialties, ...profile.massageTypes]));
+  const dateCreated = dateValue(sourceProfile.created_at || sourceProfile.member_since);
+  const dateModified = dateValue(sourceProfile.updated_at || sourceProfile.last_active_at);
+  const sameAs = verifiedSameAs(sourceProfile);
+
+  const person = {
+    "@type": "Person",
+    "@id": `${profile.canonicalUrl}#provider`,
+    identifier: profile.id,
+    name: profile.name,
+    image: profile.galleryImages.length ? profile.galleryImages : [profile.profilePhotoUrl],
+    address,
+    knowsLanguage: profile.languages,
+    knowsAbout: allServices.length ? allServices : undefined,
+    sameAs,
+    ...(credentials.length ? { hasCredential: credentials } : {}),
+  };
 
   const data = [
     {
       "@context": "https://schema.org",
       "@type": "ProfilePage",
+      "@id": `${profile.canonicalUrl}#profile-page`,
+      identifier: profile.id,
       name: profile.seoTitle,
       description: profile.seoDescription,
       url: profile.canonicalUrl,
-      image: profile.ogImage,
-      mainEntity: {
-        "@type": "Person",
-        name: profile.name,
-        image: profile.profilePhotoUrl,
-        address,
-        knowsLanguage: profile.languages,
-        knowsAbout: allServices.length ? allServices : undefined,
-        ...(credentials.length ? { hasCredential: credentials } : {}),
-      },
+      image: profile.galleryImages.length ? profile.galleryImages : [profile.ogImage],
+      dateCreated,
+      dateModified,
+      mainEntity: person,
     },
     {
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
+      "@id": `${profile.canonicalUrl}#business`,
+      identifier: profile.id,
       name: profile.name,
       description: profile.seoDescription,
-      image: profile.ogImage,
+      image: profile.galleryImages.length ? profile.galleryImages : [profile.ogImage],
       url: profile.canonicalUrl,
       address,
       areaServed: profile.serviceAreas,
       priceRange: profile.startingPrice,
       contactPoint,
+      sameAs,
       ...(offerCatalog ? { hasOfferCatalog: offerCatalog } : {}),
     },
     {
       "@context": "https://schema.org",
       "@type": "Service",
+      "@id": `${profile.canonicalUrl}#service`,
       name: `${profile.name} massage services`,
       description: `${profile.services.join(", ")} in ${profile.city}, ${profile.state}`,
-      provider: { "@type": "Person", name: profile.name },
+      provider: { "@id": `${profile.canonicalUrl}#provider` },
       areaServed: profile.serviceAreas,
       serviceType: profile.services,
     },

--- a/tests/unit/profile-seo-quality.test.ts
+++ b/tests/unit/profile-seo-quality.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateProfileSeoQuality,
+  PROFILE_INDEX_MIN_SCORE,
+} from "@/app/_lib/profile-seo-quality";
+
+const longBio = Array.from({ length: 160 }, (_, index) => `word${index}`).join(" ");
+
+function completeProfile() {
+  return {
+    display_name: "Marcus",
+    bio: longBio,
+    headline: "Experienced massage therapist serving Dallas",
+    city: "Dallas",
+    state: "TX",
+    profile_photo: "https://example.com/profile.jpg",
+    gallery_photos: ["https://example.com/2.jpg", "https://example.com/3.jpg"],
+    services: ["Deep tissue", "Sports massage", "Swedish massage"],
+    incall_available: true,
+    starting_price: 150,
+    availability_days: ["Monday", "Tuesday"],
+    verification_status: "verified",
+    phone: "+12145550100",
+  };
+}
+
+describe("evaluateProfileSeoQuality", () => {
+  it("allows a complete, contactable public profile to be indexed", () => {
+    const result = evaluateProfileSeoQuality(completeProfile());
+
+    expect(result.score).toBe(100);
+    expect(result.indexEligible).toBe(true);
+    expect(result.missingChecks).toEqual([]);
+  });
+
+  it("keeps thin profiles public but out of search indexing", () => {
+    const result = evaluateProfileSeoQuality({
+      display_name: "Marcus",
+      city: "Dallas",
+      state: "TX",
+      phone: "+12145550100",
+    });
+
+    expect(result.score).toBeLessThan(PROFILE_INDEX_MIN_SCORE);
+    expect(result.indexEligible).toBe(false);
+    expect(result.missingChecks).toContain("Add an original bio of at least 150 words");
+  });
+
+  it("requires a direct contact method even when content score is high", () => {
+    const profile = completeProfile();
+    delete (profile as Partial<typeof profile>).phone;
+
+    const result = evaluateProfileSeoQuality(profile);
+
+    expect(result.score).toBe(100);
+    expect(result.indexEligible).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- adds a transparent 100-point profile SEO quality model
- keeps incomplete profiles public while applying `noindex,follow`
- requires a minimum quality score plus provider identity and contact method before indexing
- enriches ProfilePage, Person, LocalBusiness, and Service structured data with stable identifiers, dates, multiple images, linked entity IDs, and verified external URLs
- adds unit coverage for complete, thin, and non-contactable profiles

## Why

This prevents thin provider pages from entering Google prematurely while making eligible profiles richer and easier for search engines to understand.

## Validation

Please run the repository's required lint, typecheck, unit/API tests, sitemap validation, release audit, and build checks. Merge only when all required checks are green.