### PR TITLE
Add sourceProfile prop to ProfileStructuredData component

### DIFF
--- a/src/components/profile/ProfileStructuredData.tsx
+++ b/src/components/profile/ProfileStructuredData.tsx
@@ -39,7 +39,7 @@ function buildOfferCatalog(profile: ProfileViewModel) {
   return { "@type": "OfferCatalog", name: `${profile.name} massage services`, itemListElement: offers };
 }
 
-export function ProfileStructuredData({ profile }: { profile: ProfileViewModel }) {
+export function ProfileStructuredData({ profile, sourceProfile }: { profile: ProfileViewModel; sourceProfile?: Record<string, unknown> }) {
   const address = { "@type": "PostalAddress", addressLocality: profile.city, addressRegion: profile.state, addressCountry: profile.country };
   const contactPoint = [profile.phone && { "@type": "ContactPoint", telephone: profile.phone, contactType: "phone" }, profile.email && { "@type": "ContactPoint", email: profile.email, contactType: "email" }].filter(Boolean);
   const credentials = buildCredentials(profile);


### PR DESCRIPTION
Closed as obsolete during repository consolidation. The optional sourceProfile prop was not tied to a validated current-main consumer and should not remain as an isolated stale API change.