### PR TITLE
Expose profile imports in Admin Dashboard navigation

### DIFF
--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -25,6 +25,7 @@ import {
   CalendarCheck,
   MessageSquare,
   Flag,
+  Import,
 } from "lucide-react";
 
 const navSections = [
@@ -66,6 +67,7 @@ const navSections = [
   {
     title: "Ops",
     items: [
+      { href: "/admin/migrations", label: "Imports", icon: Import },
       { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
       { href: "/admin/support", label: "Support", icon: LifeBuoy },
       { href: "/admin/verification", label: "Verification", icon: ShieldCheck },


### PR DESCRIPTION
Closed as superseded during repository consolidation. Its navigation change overlaps the broader admin information-architecture work and should be recreated from current main only if still required.