### PR TITLE
Fix provider photo uploads and admin moderation sync

### DIFF
--- a/src/app/about/about-content.tsx
+++ b/src/app/about/about-content.tsx
@@ -9,14 +9,14 @@ import { IconArrowRight, IconGlobe, IconLock, IconShield, IconStar } from "@/com
 const ABOUT_COLORS = {
   background: "#0D0D0F",
   burgundy: "#A92D40",
-  highlight: "#C84A5C",
+  highlight: "#D65A6C",
 } as const;
 
 function Pillar({ icon: Icon, title, text }: { icon: React.ComponentType<{ size?: number; className?: string }>; title: string; text: string }) {
   return (
     <div className="flex flex-col gap-4 border border-white/[0.10] bg-white/[0.04] p-8 backdrop-blur-sm">
       <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/[0.10] bg-[#A92D40]/15">
-        <Icon size={20} className="text-[#C84A5C]" />
+        <Icon size={20} className="text-[#D65A6C]" />
       </div>
       <h3 className="font-display text-lg font-bold text-white">{title}</h3>
       <p className="text-sm leading-6 text-white/70">{text}</p>
@@ -61,12 +61,12 @@ export default function AboutContent() {
           transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
           className="relative mx-auto max-w-[1100px] text-center"
         >
-          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#C84A5C]">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#D65A6C]">
             Our Manifesto
           </p>
           <h1 className="mt-5 font-display text-[clamp(2.5rem,6vw,5.5rem)] font-extrabold leading-[1.02] tracking-tight text-white">
             <span className="block">Elevating the standard</span>
-            <span className="mt-2 block text-[#C84A5C]">of wellness discovery.</span>
+            <span className="mt-2 block text-[#D65A6C]">of wellness discovery.</span>
           </h1>
           <p className="mx-auto mt-7 max-w-2xl text-base leading-7 text-white/70 lg:text-lg">
             MasseurMatch is a premium US directory that connects clients with verified,
@@ -93,7 +93,7 @@ export default function AboutContent() {
       {/* Core pillars */}
       <section className="px-4 py-20 sm:px-6 lg:py-28">
         <div className="mx-auto max-w-[1100px]">
-          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#C84A5C]">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#D65A6C]">
             What we stand for
           </p>
           <h2 className="mt-3 font-display text-[clamp(1.75rem,3.5vw,2.75rem)] font-extrabold tracking-tight text-white">
@@ -124,7 +124,7 @@ export default function AboutContent() {
       <section className="border-t border-white/[0.08] px-4 py-20 sm:px-6 lg:py-28">
         <div className="mx-auto grid max-w-[1100px] gap-16 lg:grid-cols-2 lg:items-center">
           <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#C84A5C]">
+            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#D65A6C]">
               Why we exist
             </p>
             <h2 className="mt-3 font-display text-[clamp(1.75rem,3.5vw,2.5rem)] font-extrabold leading-tight tracking-tight text-white">
@@ -146,28 +146,28 @@ export default function AboutContent() {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div className="rounded-2xl border border-white/[0.10] bg-white/[0.04] p-5">
               <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#A92D40]/15">
-                <Users className="h-4 w-4 text-[#C84A5C]" strokeWidth={2.25} />
+                <Users className="h-4 w-4 text-[#D65A6C]" strokeWidth={2.25} />
               </div>
               <p className="mt-3 text-sm font-bold text-white">Independent therapists</p>
               <p className="mt-1 text-xs leading-5 text-white/65">Profiles owned by the professional — not a platform.</p>
             </div>
             <div className="rounded-2xl border border-white/[0.10] bg-white/[0.04] p-5">
               <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#A92D40]/15">
-                <IconGlobe size={16} className="text-[#C84A5C]" />
+                <IconGlobe size={16} className="text-[#D65A6C]" />
               </div>
               <p className="mt-3 text-sm font-bold text-white">Nationwide cities</p>
               <p className="mt-1 text-xs leading-5 text-white/65">National reach from Dallas to New York to LA and beyond.</p>
             </div>
             <div className="rounded-2xl border border-white/[0.10] bg-white/[0.04] p-5">
               <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#A92D40]/15">
-                <IconShield size={16} className="text-[#C84A5C]" />
+                <IconShield size={16} className="text-[#D65A6C]" />
               </div>
               <p className="mt-3 text-sm font-bold text-white">Identity verified</p>
               <p className="mt-1 text-xs leading-5 text-white/65">Each profile reviewed and approved before going live.</p>
             </div>
             <div className="rounded-2xl border border-white/[0.10] bg-white/[0.04] p-5">
               <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#A92D40]/15">
-                <IconShield size={16} className="text-[#C84A5C]" />
+                <IconShield size={16} className="text-[#D65A6C]" />
               </div>
               <p className="mt-3 text-sm font-bold text-white">LGBTQ+ affirming</p>
               <p className="mt-1 text-xs leading-5 text-white/65">Inclusive by design — every profile clearly marked.</p>

--- a/src/app/api/admin/approvals/[id]/route.ts
+++ b/src/app/api/admin/approvals/[id]/route.ts
@@ -4,7 +4,15 @@ import React from "react";
 import { requireAdminSession, createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { sendEmail } from "@/app/api/_lib/email";
 import { revalidatePublicDirectory } from "@/app/_lib/directory-cache";
+import { SUPABASE_PUBLIC_URL } from "@/integrations/supabase/client";
 import ProfileApprovedEmail from "@/emails/ProfileApprovedEmail";
+
+function resolvePhotoUrl(url: string | null, storagePath: string | null) {
+  if (url) return url;
+  if (!storagePath) return null;
+  if (/^https?:\/\//i.test(storagePath)) return storagePath;
+  return `${SUPABASE_PUBLIC_URL}/storage/v1/object/public/therapist-photos/${storagePath}`;
+}
 
 export async function GET(
   request: NextRequest,
@@ -37,7 +45,7 @@ export async function GET(
 
     const { data: photos } = await supabase
       .from("profile_photos")
-      .select("url")
+      .select("url, storage_path")
       .eq("profile_id", id)
       .order("sort_order", { ascending: true });
 
@@ -50,7 +58,9 @@ export async function GET(
       ok: true,
       profile: {
         ...profile,
-        photo_urls: photos?.map((p) => p.url) || [],
+        photo_urls: (photos ?? [])
+          .map((photo) => resolvePhotoUrl(photo.url, photo.storage_path))
+          .filter((url): url is string => Boolean(url)),
         document_urls: documents?.map((d) => d.url) || [],
       },
     });
@@ -87,10 +97,6 @@ export async function POST(
 
     const now = new Date().toISOString();
 
-    // Approval must also flip the fields the public directory reads
-    // (profile_status = "approved" AND visibility_status = "public"); setting
-    // only `status` left approved therapists invisible. Reject / changes hide
-    // the profile again.
     const visibility =
       action === "approve"
         ? { profile_status: "approved", visibility_status: "public", is_active: true, approved_at: now, approved_by: adminSession.userId }
@@ -109,10 +115,6 @@ export async function POST(
 
     if (error) throw error;
 
-    // A moderation decision changes the listable set the public directory
-    // caches (getPublicTherapists). Invalidate it so the newly approved (or
-    // newly hidden) profile appears/disappears immediately instead of waiting
-    // out the 60s revalidate window.
     revalidatePublicDirectory();
 
     if (action === "approve") {
@@ -134,7 +136,6 @@ export async function POST(
         });
       }
 
-      // Create in-app notification
       if (profile?.user_id) {
         await supabase.from("notifications").insert({
           user_id: profile.user_id,
@@ -145,7 +146,6 @@ export async function POST(
         });
       }
     } else if (action === "reject") {
-      // Create rejection notification
       const { data: profile } = await supabase
         .from("profiles")
         .select("user_id")

--- a/src/app/api/admin/profile/[id]/approve/route.ts
+++ b/src/app/api/admin/profile/[id]/approve/route.ts
@@ -32,11 +32,14 @@ export async function POST(
     const { error: updateError } = await adminClient
       .from("profiles")
       .update({
+        status: "approved",
         profile_status: "approved",
         visibility_status: "public",
         verification_status: "verified",
+        is_active: true,
         approved_at: now,
         approved_by: admin.userId,
+        rejection_reason: null,
         moderation_notes: body.reason || null,
         updated_at: now,
       })
@@ -46,13 +49,11 @@ export async function POST(
 
     revalidatePublicDirectory();
 
-    // Update profile_reviews
     await adminClient
       .from("profile_reviews")
       .update({ status: "approved", reviewed_at: now, reviewed_by: admin.userId })
       .eq("profile_id", profileId);
 
-    // Log admin action
     await adminClient.from("admin_actions").insert({
       action: "approve_profile",
       action_type: "approve_profile",
@@ -67,7 +68,6 @@ export async function POST(
       reason: body.reason,
     });
 
-    // Send Approval Email
     if (profile.email_address) {
       await sendEmail({
         to: profile.email_address,

--- a/src/app/api/provider/photos/[id]/route.ts
+++ b/src/app/api/provider/photos/[id]/route.ts
@@ -10,37 +10,50 @@ export async function DELETE(
     const { id: photoId } = await params;
     const adminClient = createSupabaseAdminClient();
 
-    // Verify ownership
-    const { data: profile } = await adminClient
+    const { data: profile, error: profileError } = await adminClient
       .from("profiles")
       .select("id")
       .eq("user_id", session.userId)
       .maybeSingle();
 
+    if (profileError) throw new RouteError(500, profileError.message);
     if (!profile) throw new RouteError(404, "Profile not found.");
 
     const { data: photo, error: fetchError } = await adminClient
-      .from("therapist_photos")
-      .select("id, storage_path")
+      .from("profile_photos")
+      .select("id, profile_id, user_id, storage_path")
       .eq("id", photoId)
+      .eq("profile_id", profile.id)
       .eq("user_id", session.userId)
       .maybeSingle();
 
     if (fetchError) throw new RouteError(500, fetchError.message);
     if (!photo) throw new RouteError(404, "Photo not found or access denied.");
 
-    // Attempt to remove from storage (best-effort)
-    if (photo.storage_path) {
-      await adminClient.storage.from("therapist-photos").remove([photo.storage_path]);
+    if (photo.storage_path && !/^https?:\/\//i.test(photo.storage_path)) {
+      const { error: storageError } = await adminClient.storage
+        .from("therapist-photos")
+        .remove([photo.storage_path]);
+
+      if (storageError) {
+        console.warn("[provider/photos/delete] Storage cleanup failed:", storageError.message);
+      }
     }
 
     const { error: deleteError } = await adminClient
-      .from("therapist_photos")
+      .from("profile_photos")
       .delete()
       .eq("id", photoId)
+      .eq("profile_id", profile.id)
       .eq("user_id", session.userId);
 
     if (deleteError) throw new RouteError(500, deleteError.message);
+
+    await adminClient
+      .from("moderation_queue")
+      .delete()
+      .eq("item_type", "photo")
+      .eq("target_id", photoId);
 
     return json({ ok: true, deleted: photoId });
   } catch (error) {

--- a/src/app/api/provider/photos/upload/route.ts
+++ b/src/app/api/provider/photos/upload/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
 
     const { data: profile, error: profileError } = await adminClient
       .from("profiles")
-      .select("id")
+      .select("id, display_name, full_name")
       .eq("user_id", session.userId)
       .maybeSingle();
 
@@ -41,28 +41,32 @@ export async function POST(request: Request) {
         upsert: false,
       });
 
-    let publicUrl = "";
     if (uploadError) {
-      // Storage not configured or bucket missing — store as pending without URL
-      console.warn("[provider/photos/upload] Storage upload failed:", uploadError.message);
-      publicUrl = "";
-    } else {
-      const { data: urlData } = adminClient.storage.from(bucket).getPublicUrl(fileName);
-      publicUrl = urlData?.publicUrl ?? "";
+      console.error("[provider/photos/upload] Storage upload failed:", uploadError.message);
+      throw new RouteError(503, "Photo storage is temporarily unavailable. Please try again.");
     }
 
-    // Count existing photos to determine sort_order
-    const { count } = await adminClient
+    const { data: urlData } = adminClient.storage.from(bucket).getPublicUrl(fileName);
+    const publicUrl = urlData?.publicUrl ?? "";
+
+    if (!publicUrl) {
+      await adminClient.storage.from(bucket).remove([fileName]);
+      throw new RouteError(500, "The photo was uploaded but no public URL was generated.");
+    }
+
+    const { count, error: countError } = await adminClient
       .from("profile_photos")
       .select("id", { count: "exact", head: true })
       .eq("profile_id", profile.id);
 
+    if (countError) {
+      await adminClient.storage.from(bucket).remove([fileName]);
+      throw new RouteError(500, countError.message);
+    }
+
     const sortOrder = count ?? 0;
     const isPrimary = sortOrder === 0;
 
-    // Cast: the generated Database types predate the profile_id column on
-    // profile_photos. (mime_type/file_size were dropped from the payload —
-    // the live table doesn't have them and the insert would 42703.)
     const { data: photoRow, error: insertError } = await (adminClient as any)
       .from("profile_photos")
       .insert({
@@ -73,20 +77,82 @@ export async function POST(request: Request) {
         is_primary: isPrimary,
         sort_order: sortOrder,
         moderation_status: "pending",
+        moderation_reason: "queued_for_ai_review",
       })
       .select("id, url, storage_path, is_primary, sort_order, moderation_status")
       .single();
 
-    if (insertError) throw new RouteError(500, insertError.message);
+    if (insertError || !photoRow) {
+      await adminClient.storage.from(bucket).remove([fileName]);
+      throw new RouteError(500, insertError?.message || "Could not register the uploaded photo.");
+    }
+
+    const snapshot = {
+      photoId: photoRow.id,
+      imageUrl: publicUrl,
+      isPrimary,
+      sortOrder,
+      displayName: profile.display_name || profile.full_name || null,
+      originalFileName: file.name,
+    };
+
+    const { error: queueError } = await (adminClient as any)
+      .from("moderation_queue")
+      .insert({
+        content_type: "photo",
+        profile_id: profile.id,
+        user_id: session.userId,
+        target_id: photoRow.id,
+        item_type: "photo",
+        source: "pro_photos",
+        field_name: null,
+        status: "pending",
+        priority: "normal",
+        moderation_provider: "sightengine",
+        moderation_reason: "queued_for_ai_review",
+        snapshot,
+        ai_response: null,
+      });
+
+    if (queueError) {
+      console.error("[provider/photos/upload] Could not create moderation queue item:", queueError.message);
+    }
+
+    const { data: moderationData, error: moderationError } = await adminClient.functions.invoke(
+      "moderate-photo",
+      {
+        body: {
+          photo_id: photoRow.id,
+          image_url: publicUrl,
+        },
+      },
+    );
+
+    if (moderationError) {
+      console.error("[provider/photos/upload] Automated moderation failed:", moderationError.message);
+      await (adminClient as any)
+        .from("profile_photos")
+        .update({
+          moderation_status: "pending",
+          moderation_reason: "manual_review_required",
+        })
+        .eq("id", photoRow.id);
+    }
+
+    const status = moderationError
+      ? "pending"
+      : moderationData?.approved === true
+        ? "approved"
+        : "pending";
 
     return json({
       ok: true,
       photo: {
         id: photoRow.id,
-        url: photoRow.url || photoRow.storage_path || "",
+        url: publicUrl,
         isPrimary: photoRow.is_primary ?? false,
         sortOrder: photoRow.sort_order ?? 0,
-        status: photoRow.moderation_status ?? "pending",
+        status,
       },
     });
   } catch (error) {

--- a/supabase/migrations/20260803195900_fix_photo_upload_moderation_contract.sql
+++ b/supabase/migrations/20260803195900_fix_photo_upload_moderation_contract.sql
@@ -1,0 +1,146 @@
+-- Repair the profile photo upload/moderation contract.
+--
+-- Problems addressed:
+-- 1. Providers could not reliably read/update their own pending photos because
+--    the surviving RLS policy only exposed approved photos publicly.
+-- 2. The moderation queue unique index allowed only one pending photo per
+--    profile/source, so additional uploads were never represented in admin.
+-- 3. profiles.is_verified_photos drifted from the real approved-photo count.
+
+begin;
+
+alter table public.profile_photos enable row level security;
+alter table public.moderation_queue enable row level security;
+
+grant select, insert, update, delete on public.profile_photos to authenticated;
+grant select, insert on public.moderation_queue to authenticated;
+
+-- Public users may only see approved photos.
+drop policy if exists profile_photos_public_read_approved on public.profile_photos;
+create policy profile_photos_public_read_approved
+on public.profile_photos
+for select
+using (moderation_status = 'approved');
+
+-- Providers must be able to manage and see every status for their own photos.
+drop policy if exists profile_photos_owner_select on public.profile_photos;
+create policy profile_photos_owner_select
+on public.profile_photos
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = profile_photos.profile_id
+      and (p.user_id = auth.uid() or p.id = auth.uid())
+  )
+);
+
+drop policy if exists profile_photos_owner_insert on public.profile_photos;
+create policy profile_photos_owner_insert
+on public.profile_photos
+for insert
+to authenticated
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = profile_photos.profile_id
+      and (p.user_id = auth.uid() or p.id = auth.uid())
+  )
+);
+
+drop policy if exists profile_photos_owner_update on public.profile_photos;
+create policy profile_photos_owner_update
+on public.profile_photos
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = profile_photos.profile_id
+      and (p.user_id = auth.uid() or p.id = auth.uid())
+  )
+);
+
+drop policy if exists profile_photos_owner_delete on public.profile_photos;
+create policy profile_photos_owner_delete
+on public.profile_photos
+for delete
+to authenticated
+using (user_id = auth.uid());
+
+-- Keep provider-created moderation items constrained to their own profile.
+drop policy if exists "Users can insert their own moderation queue items" on public.moderation_queue;
+drop policy if exists moderation_queue_insert_self_or_admin on public.moderation_queue;
+create policy moderation_queue_insert_self
+on public.moderation_queue
+for insert
+to authenticated
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = moderation_queue.profile_id
+      and (p.user_id = auth.uid() or p.id = auth.uid())
+  )
+);
+
+-- One profile can have many pending photo uploads. Deduplicate only the exact
+-- target photo, not the whole profile/source pair.
+drop index if exists public.idx_moderation_queue_pending_profile_source;
+create unique index if not exists idx_moderation_queue_pending_target
+on public.moderation_queue (item_type, source, target_id)
+where status = 'pending' and target_id is not null;
+
+-- Synchronize the profile badge from the actual approved photo count.
+create or replace function public.sync_profile_verified_photos()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  affected_profile_id uuid;
+begin
+  affected_profile_id := coalesce(new.profile_id, old.profile_id);
+
+  if affected_profile_id is not null then
+    update public.profiles p
+    set
+      is_verified_photos = exists (
+        select 1
+        from public.profile_photos pp
+        where pp.profile_id = affected_profile_id
+          and pp.moderation_status = 'approved'
+      ),
+      updated_at = timezone('utc', now())
+    where p.id = affected_profile_id;
+  end if;
+
+  return coalesce(new, old);
+end;
+$$;
+
+drop trigger if exists trg_sync_profile_verified_photos on public.profile_photos;
+create trigger trg_sync_profile_verified_photos
+after insert or update of moderation_status or delete on public.profile_photos
+for each row execute function public.sync_profile_verified_photos();
+
+-- Backfill existing profiles immediately.
+update public.profiles p
+set is_verified_photos = exists (
+  select 1
+  from public.profile_photos pp
+  where pp.profile_id = p.id
+    and pp.moderation_status = 'approved'
+);
+
+commit;


### PR DESCRIPTION
## What was broken

- The signup upload endpoint returned success even when Supabase Storage failed, creating broken photo rows.
- Signup photos were not consistently sent through Sightengine or added to the admin moderation queue.
- The moderation queue unique index allowed only one pending photo per profile/source.
- AI-approved photos did not synchronize `profiles.is_verified_photos`.
- The admin approval detail only read `profile_photos.url`, while Cloudinary uploads are commonly stored in `storage_path`.
- Provider photo deletion targeted the legacy `therapist_photos` table instead of `profile_photos`.
- A secondary profile approval endpoint did not set `status=approved` or `is_active=true`.

## Changes

- Fail the upload request clearly if Storage is unavailable; remove partial files/rows when registration fails.
- Queue every uploaded signup photo and invoke `moderate-photo` immediately.
- Add owner-safe RLS policies for pending/approved/rejected photos.
- Replace the queue uniqueness rule with one pending item per target photo.
- Add a database trigger and backfill to keep `is_verified_photos` aligned with approved photos.
- Resolve Cloudinary URLs and Supabase Storage paths correctly in admin approvals.
- Delete photos from the active `profile_photos` table and clean associated moderation items.
- Align all profile approval fields used by the public directory.

## Deployment requirement

The included Supabase migration must be applied for the RLS, queue index, and verification synchronization fixes to take effect.

## Validation

- Branch is 5 commits ahead of `main` and touches only the photo upload/moderation/approval contract.
- No direct push or merge to `main` was performed.