### PR TITLE
Fix Vercel runtime auth and imported review failures

### DIFF
--- a/src/app/about/about-content.tsx
+++ b/src/app/about/about-content.tsx
@@ -93,7 +93,7 @@ export default function AboutContent() {
       {/* Core pillars */}
       <section className="px-4 py-20 sm:px-6 lg:py-28">
         <div className="mx-auto max-w-[1100px]">
-          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#C84A5C]">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#D45B6D]">
             What we stand for
           </p>
           <h2 className="mt-3 font-display text-[clamp(1.75rem,3.5vw,2.75rem)] font-extrabold tracking-tight text-white">
@@ -124,7 +124,7 @@ export default function AboutContent() {
       <section className="border-t border-white/[0.08] px-4 py-20 sm:px-6 lg:py-28">
         <div className="mx-auto grid max-w-[1100px] gap-16 lg:grid-cols-2 lg:items-center">
           <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#C84A5C]">
+            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#D45B6D]">
               Why we exist
             </p>
             <h2 className="mt-3 font-display text-[clamp(1.75rem,3.5vw,2.5rem)] font-extrabold leading-tight tracking-tight text-white">

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
-import { createServerSupabase } from "@/lib/supabase/server";
 import { getUserRole } from "@/app/api/_lib/supabase-server";
 import { normalizeSessionRole } from "@/app/api/_lib/session";
+import { isExpectedInvalidSessionError } from "@/lib/supabase/auth-errors";
+import { createServerSupabase } from "@/lib/supabase/server";
 
 function dashboardPathForRole(role: string | null | undefined) {
   if (role === "client") return "/search";
@@ -18,14 +19,34 @@ function noStoreJson(body: unknown, init?: ResponseInit) {
   return response;
 }
 
+function signedOutResponse() {
+  return noStoreJson({ authenticated: false, dashboardPath: "/login" });
+}
+
 export async function GET() {
   const supabase = await createServerSupabase();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+
+  let user;
+  try {
+    const authResult = await supabase.auth.getUser();
+
+    if (authResult.error) {
+      if (!isExpectedInvalidSessionError(authResult.error)) {
+        console.error("[api/auth/me] Failed to verify session:", authResult.error);
+      }
+      return signedOutResponse();
+    }
+
+    user = authResult.data.user;
+  } catch (error) {
+    if (!isExpectedInvalidSessionError(error)) {
+      console.error("[api/auth/me] Failed to verify session:", error);
+    }
+    return signedOutResponse();
+  }
 
   if (!user) {
-    return noStoreJson({ authenticated: false, dashboardPath: "/login" });
+    return signedOutResponse();
   }
 
   // Prefer the app_metadata role (already verified with the user), but confirm

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,18 +1,26 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import type { EmailOtpType } from "@supabase/supabase-js";
-import { createServerSupabase } from "@/lib/supabase/server";
-import {
-  createAdminClient,
-} from "@/lib/supabase/admin";
-import { ensureUserProfileAndRole } from "@/app/api/_lib/supabase-server";
+import type { EmailOtpType, User } from "@supabase/supabase-js";
 import { assertRateLimit } from "@/app/_lib/security";
+import { ensureUserProfileAndRole } from "@/app/api/_lib/supabase-server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { isExpectedInvalidSessionError } from "@/lib/supabase/auth-errors";
+import { createServerSupabase } from "@/lib/supabase/server";
 
 function sanitizeRedirect(next: string | null): string {
   const fallback = "/pro/dashboard";
   if (!next) return fallback;
   if (!next.startsWith("/") || next.startsWith("//")) return fallback;
   return next;
+}
+
+function failedAuthRedirect(origin: string, type: EmailOtpType | null) {
+  if (type === "recovery") {
+    return NextResponse.redirect(
+      `${origin}/reset-password?error=access_denied&error_code=otp_expired`,
+    );
+  }
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
 }
 
 export async function GET(request: NextRequest) {
@@ -35,23 +43,30 @@ export async function GET(request: NextRequest) {
   // Cookie-bound client: exchangeCodeForSession / verifyOtp write the Supabase
   // auth cookies onto the response automatically.
   const supabase = await createServerSupabase();
-  const { data, error } = code
-    ? await supabase.auth.exchangeCodeForSession(code)
-    : await supabase.auth.verifyOtp({ type: type!, token_hash: tokenHash! });
+  let user: User | null = null;
 
-  const user = data?.user;
-  if (error || !user?.email) {
-    console.error("[auth/callback] error:", error?.message);
-    // Recovery links that fail here are almost always a single-use token that
-    // was already consumed (commonly by an email link-scanner pre-fetch). Send
-    // the user to the reset page with a clear, actionable error instead of the
-    // generic login failure.
-    if (type === "recovery") {
-      return NextResponse.redirect(
-        `${origin}/reset-password?error=access_denied&error_code=otp_expired`,
-      );
+  try {
+    const authResult = code
+      ? await supabase.auth.exchangeCodeForSession(code)
+      : await supabase.auth.verifyOtp({ type: type!, token_hash: tokenHash! });
+
+    if (authResult.error) {
+      if (!isExpectedInvalidSessionError(authResult.error)) {
+        console.error("[auth/callback] error:", authResult.error.message);
+      }
+      return failedAuthRedirect(origin, type);
     }
-    return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
+
+    user = authResult.data?.user ?? null;
+  } catch (error) {
+    if (!isExpectedInvalidSessionError(error)) {
+      console.error("[auth/callback] error:", error);
+    }
+    return failedAuthRedirect(origin, type);
+  }
+
+  if (!user?.email) {
+    return failedAuthRedirect(origin, type);
   }
 
   // Password recovery: the OTP is now verified and a recovery session cookie is

--- a/src/lib/supabase/auth-errors.ts
+++ b/src/lib/supabase/auth-errors.ts
@@ -1,0 +1,33 @@
+type AuthErrorLike = {
+  code?: unknown;
+  message?: unknown;
+  status?: unknown;
+};
+
+const EXPECTED_SESSION_ERROR_CODES = new Set([
+  "refresh_token_not_found",
+  "refresh_token_already_used",
+  "session_not_found",
+]);
+
+/**
+ * Supabase returns these errors when a browser keeps an expired or already
+ * rotated refresh-token cookie. They mean "signed out", not a server failure.
+ */
+export function isExpectedInvalidSessionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const candidate = error as AuthErrorLike;
+  const code = typeof candidate.code === "string" ? candidate.code.toLowerCase() : "";
+  if (EXPECTED_SESSION_ERROR_CODES.has(code)) return true;
+
+  const message =
+    typeof candidate.message === "string" ? candidate.message.toLowerCase() : "";
+
+  return (
+    message.includes("invalid refresh token") ||
+    message.includes("refresh token not found") ||
+    message.includes("refresh token already used") ||
+    message.includes("auth session missing")
+  );
+}

--- a/supabase/migrations/20260803211000_fix_imported_review_profile_stats.sql
+++ b/supabase/migrations/20260803211000_fix_imported_review_profile_stats.sql
@@ -1,0 +1,55 @@
+begin;
+
+-- Keep profile review aggregates valid when an imported review is inserted,
+-- unpublished, rerated, or deleted. AVG() returns NULL for an empty set, while
+-- profiles.average_rating and profiles.review_count are NOT NULL in production.
+create or replace function public.refresh_imported_review_profile_stats()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_profile_id uuid;
+  v_count integer;
+  v_average numeric;
+begin
+  v_profile_id := coalesce(new.profile_id, old.profile_id);
+
+  with all_public_reviews as (
+    select r.rating::numeric as rating
+    from public.reviews r
+    where r.profile_id = v_profile_id
+      and coalesce(r.is_public, false) = true
+      and coalesce(r.status, 'approved') in ('approved', 'published', 'active')
+      and r.rating is not null
+
+    union all
+
+    select ir.rating::numeric as rating
+    from public.imported_reviews ir
+    where ir.profile_id = v_profile_id
+      and coalesce(ir.is_public, false) = true
+      and ir.rating is not null
+  )
+  select count(*), round(avg(rating), 2)
+    into v_count, v_average
+  from all_public_reviews;
+
+  update public.profiles
+    set review_count = coalesce(v_count, 0),
+        average_rating = coalesce(v_average, 0),
+        updated_at = timezone('utc', now())
+  where id = v_profile_id;
+
+  return coalesce(new, old);
+end;
+$$;
+
+drop trigger if exists imported_reviews_refresh_profile_stats on public.imported_reviews;
+create trigger imported_reviews_refresh_profile_stats
+after insert or delete or update of is_public, rating
+on public.imported_reviews
+for each row execute function public.refresh_imported_review_profile_stats();
+
+commit;

--- a/tests/unit/supabase-auth-errors.test.ts
+++ b/tests/unit/supabase-auth-errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isExpectedInvalidSessionError } from "@/lib/supabase/auth-errors";
+
+describe("isExpectedInvalidSessionError", () => {
+  it.each([
+    "refresh_token_not_found",
+    "refresh_token_already_used",
+    "session_not_found",
+  ])("recognizes Supabase auth code %s", (code) => {
+    expect(isExpectedInvalidSessionError({ code })).toBe(true);
+  });
+
+  it.each([
+    "Invalid Refresh Token: Refresh Token Not Found",
+    "Refresh token already used",
+    "Auth session missing!",
+  ])("recognizes expected auth message %s", (message) => {
+    expect(isExpectedInvalidSessionError({ message })).toBe(true);
+  });
+
+  it("does not hide unrelated authentication or server errors", () => {
+    expect(isExpectedInvalidSessionError({ code: "unexpected_failure" })).toBe(false);
+    expect(isExpectedInvalidSessionError(new Error("Database unavailable"))).toBe(false);
+    expect(isExpectedInvalidSessionError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Audit scope

Audited recent Vercel deployments, build logs, production runtime error clusters, GitHub Actions, lint, TypeScript, unit/API tests, database contract checks, and the production Supabase trigger involved in review imports.

## Fixes

- Treat stale, missing, or already-rotated Supabase refresh tokens as a normal signed-out state in `/api/auth/me` instead of surfacing a runtime exception.
- Handle the same expected session failures in `/auth/callback` while preserving existing recovery and login redirects.
- Add focused unit coverage for expected versus unexpected authentication failures.
- Version the production-safe imported-review aggregate trigger so empty review sets write `0`, never `NULL`, to NOT NULL profile aggregate columns.

## Validation

The standard CI and Go Live Release Checks workflows should run lint, TypeScript, unit/API tests, sitemap validation, database contract validation, release audit, and production build. Vercel will also build the preview with the project’s production-equivalent build command.

No environment secrets or production configuration were modified.