### PR TITLE
feat(admin): unified People CRM and Cloudinary photo controls

### DIFF
--- a/docs/CLOUDINARY_PHOTO_FLOW_AUDIT_2026-08-04.md
+++ b/docs/CLOUDINARY_PHOTO_FLOW_AUDIT_2026-08-04.md
@@ -1,0 +1,29 @@
+# Cloudinary Photo Flow Audit — 2026-08-04
+
+## Verified
+
+- Provider photo uploads are intended to go to Cloudinary.
+- Existing production photo records store Cloudinary secure URLs in `profile_photos.storage_path`.
+- Bruno and Rene/Rey have approved Cloudinary photos in `profile_photos`.
+- The `cloudinary-sign` Edge Function is active.
+- Production `cloudinary-sign` was updated to accept either the three direct Cloudinary credentials or `CLOUDINARY_URL`.
+
+## Data inconsistencies found
+
+- Some approved `profile_photos` rows do not have matching `moderation_queue` rows.
+- Some old `moderation_queue` rows point to photos that no longer exist.
+- Some approved profiles still have legacy `status = pending_approval` while `profile_status = approved`.
+
+## Operational rule
+
+The Admin must load the full gallery from `profile_photos`. A missing moderation queue row must never make an uploaded photo disappear from the Admin.
+
+`profile_status` is the canonical profile approval field. The legacy `status` field should not be used independently to determine approval or visibility.
+
+## Remaining implementation
+
+- Make queue insertion and status synchronization reliable for every Cloudinary upload.
+- Surface missing queue records as manual-review items.
+- Add orphan queue cleanup and reconciliation.
+- Add an authenticated end-to-end production upload test.
+- Build the full People CRM detail view with photos, profile state, account actions and secure password-reset delivery.

--- a/docs/UNIFIED_ADMIN_PEOPLE_CRM_PLAN.md
+++ b/docs/UNIFIED_ADMIN_PEOPLE_CRM_PLAN.md
@@ -1,0 +1,57 @@
+# Unified Admin People CRM
+
+## Goal
+
+Replace the separate Users and Therapists admin destinations with one People CRM that gives admins a complete operational view of each person and their therapist profile.
+
+## Current implementation in this branch
+
+- Adds `/admin/people`.
+- Replaces the Users and Therapists sidebar entries with People CRM.
+- Redirects `/admin/users` and `/admin/therapists` to `/admin/people`.
+- Loads account and therapist management data on one page.
+
+## Required follow-up before production merge
+
+### People record
+
+Create one consolidated record per person by joining the auth user, profile, roles, subscription, photos, moderation, reports and admin activity.
+
+### CRM actions
+
+- Search and filter by account type and status.
+- Open a person detail drawer or page.
+- Send password reset email without exposing a password.
+- Revoke sessions.
+- Edit account and profile fields.
+- Approve, reject, suspend or ban.
+- Manage subscription tier, discount and featured placement.
+- Add internal notes, tags and follow-up dates.
+- Show audit history.
+
+### Photos
+
+Use `profile_photos` as the source of truth for the person's complete gallery. `moderation_queue` must be treated as workflow state, not as the only way to discover photos.
+
+Expected flow:
+
+1. Authenticated provider requests a Cloudinary signature.
+2. Browser uploads directly to Cloudinary.
+3. Secure Cloudinary URL is inserted into `profile_photos.storage_path`.
+4. A moderation queue item is created for the photo.
+5. `moderate-photo` processes the image.
+6. Both `profile_photos` and `moderation_queue` receive the final status.
+7. If queue creation or automated moderation fails, keep the photo visible to admins and mark it for manual review.
+
+### Profile status
+
+`profile_status` is the canonical approval workflow field. The legacy `status` column must not independently control admin display or public visibility.
+
+Public listing state should be derived consistently from:
+
+- `profile_status`
+- `visibility_status`
+- `is_active`
+- suspension and ban flags
+
+Do not automatically alter existing production records until the reconciliation rules are implemented and reviewed.

--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -6,7 +6,6 @@ import { useAuth } from "@/contexts/AuthContext";
 import {
   LayoutDashboard,
   Users,
-  HeartHandshake,
   ShieldCheck,
   ShieldAlert,
   CreditCard,
@@ -29,29 +28,29 @@ import {
 
 const navSections = [
   {
-    title: "Core",
+    title: "Overview",
     items: [
       { href: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
-      { href: "/admin/users", label: "Users", icon: Users },
-      { href: "/admin/therapists", label: "Therapists", icon: HeartHandshake },
-      { href: "/admin/photos", label: "Photos", icon: ImageIcon },
-      { href: "/admin/moderation", label: "Moderation", icon: ShieldAlert },
+      { href: "/admin/people", label: "People CRM", icon: Users },
+      { href: "/admin/photos", label: "Photo Approvals", icon: ImageIcon },
+      { href: "/admin/moderation", label: "Approvals", icon: ShieldAlert },
       { href: "/admin/profile-reports", label: "Profile Reports", icon: Flag },
     ],
   },
   {
-    title: "Messaging",
+    title: "Communication",
     items: [
+      { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
+      { href: "/admin/support", label: "Support", icon: LifeBuoy },
       { href: "/admin/bookings", label: "Bookings", icon: CalendarCheck },
       { href: "/admin/sms", label: "SMS Auto-Reply", icon: MessageSquare },
     ],
   },
   {
-    title: "Business",
+    title: "Revenue",
     items: [
       { href: "/admin/billing", label: "Billing", icon: CreditCard },
       { href: "/admin/reports", label: "Reports", icon: BarChart3 },
-      { href: "/admin/logs", label: "Logs", icon: FileClock },
     ],
   },
   {
@@ -64,11 +63,10 @@ const navSections = [
     ],
   },
   {
-    title: "Ops",
+    title: "System",
     items: [
-      { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
-      { href: "/admin/support", label: "Support", icon: LifeBuoy },
       { href: "/admin/verification", label: "Verification", icon: ShieldCheck },
+      { href: "/admin/logs", label: "Logs", icon: FileClock },
       { href: "/admin/legal", label: "Legal", icon: FileText },
       { href: "/admin/settings", label: "Settings", icon: Settings },
     ],

--- a/src/app/admin/_components/AdminUsersManager.tsx
+++ b/src/app/admin/_components/AdminUsersManager.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { KeyRound, Search } from "lucide-react";
 
 import { postJson } from "@/app/_lib/client-api";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
 
 type AdminUser = {
@@ -24,33 +26,35 @@ function buildDrafts(users: AdminUser[]) {
   }, {});
 }
 
-export default function AdminUsersManager({
-  initialUsers,
-}: {
-  initialUsers: AdminUser[];
-}) {
+export default function AdminUsersManager({ initialUsers }: { initialUsers: AdminUser[] }) {
   const router = useRouter();
   const { toast } = useToast();
   const [drafts, setDrafts] = useState<Record<string, "admin" | "provider">>(() => buildDrafts(initialUsers));
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [resetBusyId, setResetBusyId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     setDrafts(buildDrafts(initialUsers));
   }, [initialUsers]);
 
+  const filteredUsers = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return initialUsers;
+
+    return initialUsers.filter((user) =>
+      [user.fullName, user.email, user.city, user.status, user.role, user.userId]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(query)),
+    );
+  }, [initialUsers, search]);
+
   const handleSave = async (userId: string) => {
     setBusyId(userId);
 
     try {
-      await postJson("/api/admin/users", {
-        userId,
-        role: drafts[userId],
-      });
-
-      toast({
-        title: "Role updated",
-        description: `Saved ${drafts[userId]} for ${userId}.`,
-      });
+      await postJson("/api/admin/users", { userId, role: drafts[userId] });
+      toast({ title: "Role updated", description: `Saved ${drafts[userId]} role.` });
       router.refresh();
     } catch (error) {
       toast({
@@ -63,25 +67,77 @@ export default function AdminUsersManager({
     }
   };
 
+  const handlePasswordReset = async (user: AdminUser) => {
+    if (!user.email) {
+      toast({ title: "No email available", variant: "destructive" });
+      return;
+    }
+
+    setResetBusyId(user.userId);
+    try {
+      await postJson("/api/admin/users/reset-password", { userId: user.userId });
+      toast({
+        title: "Password reset sent",
+        description: `A secure reset link was sent to ${user.email}.`,
+      });
+    } catch (error) {
+      toast({
+        title: "Could not send reset",
+        description: error instanceof Error ? error.message : "Unknown error.",
+        variant: "destructive",
+      });
+    } finally {
+      setResetBusyId(null);
+    }
+  };
+
   return (
     <div className="space-y-4">
-      {initialUsers.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No users found.</p>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search name, email, city, status or user ID..."
+          className="pl-10"
+        />
+      </div>
+
+      {filteredUsers.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No people found.</p>
       ) : null}
 
-      {initialUsers.map((user) => (
-        <article key={user.userId} className="rounded-lg border border-border p-4">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <p className="text-xs text-muted-foreground">
-                {user.email || "No email"} · {user.city || "No city"} · {user.status}
+      {filteredUsers.map((user) => (
+        <article key={user.userId} className="rounded-xl border border-border p-4">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="font-semibold">{user.fullName}</h2>
+                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+                  {user.status}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {user.email || "No email"} · {user.city || "No city"}
               </p>
-              <h2 className="mt-1 font-semibold">{user.fullName}</h2>
-              <p className="mt-2 text-sm text-muted-foreground">User ID: {user.userId}</p>
+              <p className="mt-2 break-all text-xs text-muted-foreground">User ID: {user.userId}</p>
+              <p className="break-all text-xs text-muted-foreground">Profile ID: {user.profileId}</p>
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!user.email || resetBusyId === user.userId}
+                onClick={() => void handlePasswordReset(user)}
+              >
+                <KeyRound className="mr-2 h-4 w-4" />
+                {resetBusyId === user.userId ? "Sending..." : "Password reset"}
+              </Button>
+
               <select
+                aria-label={`Role for ${user.fullName}`}
                 value={drafts[user.userId] || "provider"}
                 onChange={(event) =>
                   setDrafts((current) => ({
@@ -89,12 +145,18 @@ export default function AdminUsersManager({
                     [user.userId]: event.target.value as "admin" | "provider",
                   }))
                 }
-                className="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm"
               >
                 <option value="provider">Provider</option>
                 <option value="admin">Admin</option>
               </select>
-              <Button type="button" variant="outline" size="sm" disabled={busyId === user.userId} onClick={() => void handleSave(user.userId)}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={busyId === user.userId}
+                onClick={() => void handleSave(user.userId)}
+              >
                 {busyId === user.userId ? "Saving..." : "Save role"}
               </Button>
             </div>

--- a/src/app/admin/_lib/loaders.ts
+++ b/src/app/admin/_lib/loaders.ts
@@ -90,7 +90,6 @@ async function loadImportedReviews(): Promise<AdminLoadResult<AdminImportedRevie
         display_name: string | null;
         full_name: string | null;
         city: string | null;
-        status: string;
       }>;
 
       for (const profile of profileRows) {
@@ -184,7 +183,7 @@ export async function loadUsers(): Promise<AdminLoadResult<AdminUser>> {
       await Promise.all([
         adminClient
           .from("profiles")
-          .select("id, user_id, display_name, full_name, city, status, updated_at")
+          .select("id, user_id, display_name, full_name, city, profile_status, updated_at")
           .order("updated_at", { ascending: false })
           .limit(50),
         adminClient.from("user_roles").select("user_id, role, created_at").order("created_at", { ascending: false }),
@@ -213,12 +212,12 @@ export async function loadUsers(): Promise<AdminLoadResult<AdminUser>> {
     }
 
     return {
-      items: ((profiles || []) as Array<{ id: string; user_id: string; display_name: string | null; full_name: string | null; city: string | null; status: string }>).map((profile) => ({
+      items: ((profiles || []) as Array<{ id: string; user_id: string; display_name: string | null; full_name: string | null; city: string | null; profile_status: string }>).map((profile) => ({
         profileId: profile.id,
         userId: profile.user_id,
         fullName: profile.display_name || profile.full_name || "Unknown User",
         city: profile.city,
-        status: profile.status,
+        status: profile.profile_status,
         role: roleMap.get(profile.user_id) || null,
         email: emailMap.get(profile.user_id) || null,
       })),

--- a/src/app/admin/people/PeopleCrm.tsx
+++ b/src/app/admin/people/PeopleCrm.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ExternalLink, ImageIcon, KeyRound, Search, ShieldCheck, UserRound } from "lucide-react";
+
+import { postJson } from "@/app/_lib/client-api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import type { AdminPerson } from "./loadPeople";
+
+export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
+  const { toast } = useToast();
+  const [search, setSearch] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return people;
+    return people.filter((person) =>
+      [person.name, person.email, person.city, person.role, person.profileStatus, person.subscriptionTier, person.userId]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(query)),
+    );
+  }, [people, search]);
+
+  const sendPasswordReset = async (person: AdminPerson) => {
+    setBusyId(person.userId);
+    try {
+      await postJson("/api/admin/users/reset-password", { userId: person.userId });
+      toast({ title: "Password reset sent", description: `A secure reset email was sent to ${person.email || "the user"}.` });
+    } catch (error) {
+      toast({
+        title: "Could not send password reset",
+        description: error instanceof Error ? error.message : "Unknown error.",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="relative max-w-xl">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+        <Input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search by name, email, city, status or ID..."
+          className="pl-10"
+        />
+      </div>
+
+      <div className="grid gap-4">
+        {filtered.map((person) => {
+          const expanded = expandedId === person.profileId;
+          const primaryPhoto = person.photos.find((photo) => photo.isPrimary) || person.photos[0];
+          return (
+            <article key={person.profileId} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+              <button
+                type="button"
+                onClick={() => setExpandedId(expanded ? null : person.profileId)}
+                className="flex w-full items-center gap-4 p-5 text-left hover:bg-slate-50"
+              >
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-slate-100">
+                  {primaryPhoto ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={primaryPhoto.url} alt="" className="h-full w-full object-cover" />
+                  ) : (
+                    <UserRound className="h-6 w-6 text-slate-400" />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="truncate font-semibold text-slate-900">{person.name}</h2>
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{person.role || "provider"}</span>
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{person.profileStatus}</span>
+                  </div>
+                  <p className="mt-1 truncate text-sm text-slate-500">
+                    {person.email || "No email"} · {person.city || "No city"} · {person.photos.length} photo(s)
+                  </p>
+                </div>
+                <span className="text-xs font-medium text-slate-500">{expanded ? "Close" : "Open"}</span>
+              </button>
+
+              {expanded ? (
+                <div className="border-t border-slate-100 p-5">
+                  <div className="grid gap-5 lg:grid-cols-[1fr_1.4fr]">
+                    <div className="space-y-4">
+                      <div className="rounded-xl bg-slate-50 p-4 text-sm">
+                        <p><strong>User ID:</strong> {person.userId}</p>
+                        <p className="mt-1"><strong>Profile ID:</strong> {person.profileId}</p>
+                        <p className="mt-1"><strong>Plan:</strong> {person.subscriptionTier || "free"}</p>
+                        <p className="mt-1"><strong>Verification:</strong> {person.verificationStatus || "unverified"}</p>
+                        <p className="mt-1"><strong>Featured:</strong> {person.isFeatured ? "Yes" : "No"}</p>
+                        <p className="mt-1"><strong>Suspended:</strong> {person.isSuspended ? "Yes" : "No"}</p>
+                        <p className="mt-1"><strong>Banned:</strong> {person.isBanned ? "Yes" : "No"}</p>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={!person.email || busyId === person.userId}
+                          onClick={() => void sendPasswordReset(person)}
+                        >
+                          <KeyRound className="mr-2 h-4 w-4" />
+                          {busyId === person.userId ? "Sending..." : "Send password reset"}
+                        </Button>
+                        {person.slug ? (
+                          <Button type="button" variant="outline" asChild>
+                            <a href={`/therapists/${person.slug}`} target="_blank" rel="noreferrer">
+                              <ExternalLink className="mr-2 h-4 w-4" /> View public profile
+                            </a>
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="mb-3 flex items-center gap-2">
+                        <ImageIcon className="h-4 w-4 text-slate-500" />
+                        <h3 className="font-semibold">Cloudinary gallery</h3>
+                      </div>
+                      {person.photos.length ? (
+                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+                          {person.photos.map((photo) => (
+                            <div key={photo.id} className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+                              <div className="aspect-square bg-slate-100">
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img src={photo.url} alt="" className="h-full w-full object-cover" />
+                              </div>
+                              <div className="space-y-1 p-2 text-xs text-slate-600">
+                                <div className="flex items-center justify-between gap-2">
+                                  <span>{photo.moderationStatus}</span>
+                                  {photo.isPrimary ? <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" /> : null}
+                                </div>
+                                {photo.moderationReason ? <p className="truncate">{photo.moderationReason}</p> : null}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-slate-500">No photos registered in profile_photos.</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 ? <p className="text-sm text-slate-500">No people found.</p> : null}
+    </div>
+  );
+}

--- a/src/app/admin/people/PeopleCrm.tsx
+++ b/src/app/admin/people/PeopleCrm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ExternalLink, ImageIcon, KeyRound, Search, ShieldCheck, UserRound } from "lucide-react";
+import { Check, ExternalLink, ImageIcon, KeyRound, RefreshCw, Search, Star, Trash2, UserRound, X } from "lucide-react";
 
 import { postJson } from "@/app/_lib/client-api";
 import { Button } from "@/components/ui/button";
@@ -31,11 +31,20 @@ export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
       await postJson("/api/admin/users/reset-password", { userId: person.userId });
       toast({ title: "Password reset sent", description: `A secure reset email was sent to ${person.email || "the user"}.` });
     } catch (error) {
-      toast({
-        title: "Could not send password reset",
-        description: error instanceof Error ? error.message : "Unknown error.",
-        variant: "destructive",
-      });
+      toast({ title: "Could not send password reset", description: error instanceof Error ? error.message : "Unknown error.", variant: "destructive" });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const runPhotoAction = async (photoId: string, action: "approve" | "reject" | "set_primary" | "delete" | "reprocess") => {
+    setBusyId(photoId);
+    try {
+      await postJson("/api/admin/photos/action", { photoId, action });
+      toast({ title: "Photo updated", description: `Action ${action.replace("_", " ")} completed.` });
+      window.location.reload();
+    } catch (error) {
+      toast({ title: "Could not update photo", description: error instanceof Error ? error.message : "Unknown error.", variant: "destructive" });
     } finally {
       setBusyId(null);
     }
@@ -45,12 +54,7 @@ export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
     <div className="space-y-5">
       <div className="relative max-w-xl">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-        <Input
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search by name, email, city, status or ID..."
-          className="pl-10"
-        />
+        <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search by name, email, city, status or ID..." className="pl-10" />
       </div>
 
       <div className="grid gap-4">
@@ -59,18 +63,9 @@ export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
           const primaryPhoto = person.photos.find((photo) => photo.isPrimary) || person.photos[0];
           return (
             <article key={person.profileId} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-              <button
-                type="button"
-                onClick={() => setExpandedId(expanded ? null : person.profileId)}
-                className="flex w-full items-center gap-4 p-5 text-left hover:bg-slate-50"
-              >
+              <button type="button" onClick={() => setExpandedId(expanded ? null : person.profileId)} className="flex w-full items-center gap-4 p-5 text-left hover:bg-slate-50">
                 <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-slate-100">
-                  {primaryPhoto ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={primaryPhoto.url} alt="" className="h-full w-full object-cover" />
-                  ) : (
-                    <UserRound className="h-6 w-6 text-slate-400" />
-                  )}
+                  {primaryPhoto ? <img src={primaryPhoto.url} alt="" className="h-full w-full object-cover" /> : <UserRound className="h-6 w-6 text-slate-400" />}
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
@@ -78,9 +73,7 @@ export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
                     <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{person.role || "provider"}</span>
                     <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{person.profileStatus}</span>
                   </div>
-                  <p className="mt-1 truncate text-sm text-slate-500">
-                    {person.email || "No email"} · {person.city || "No city"} · {person.photos.length} photo(s)
-                  </p>
+                  <p className="mt-1 truncate text-sm text-slate-500">{person.email || "No email"} · {person.city || "No city"} · {person.photos.length} photo(s)</p>
                 </div>
                 <span className="text-xs font-medium text-slate-500">{expanded ? "Close" : "Open"}</span>
               </button>
@@ -98,53 +91,36 @@ export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
                         <p className="mt-1"><strong>Suspended:</strong> {person.isSuspended ? "Yes" : "No"}</p>
                         <p className="mt-1"><strong>Banned:</strong> {person.isBanned ? "Yes" : "No"}</p>
                       </div>
-
                       <div className="flex flex-wrap gap-2">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          disabled={!person.email || busyId === person.userId}
-                          onClick={() => void sendPasswordReset(person)}
-                        >
-                          <KeyRound className="mr-2 h-4 w-4" />
-                          {busyId === person.userId ? "Sending..." : "Send password reset"}
+                        <Button type="button" variant="outline" disabled={!person.email || busyId === person.userId} onClick={() => void sendPasswordReset(person)}>
+                          <KeyRound className="mr-2 h-4 w-4" />{busyId === person.userId ? "Sending..." : "Send password reset"}
                         </Button>
-                        {person.slug ? (
-                          <Button type="button" variant="outline" asChild>
-                            <a href={`/therapists/${person.slug}`} target="_blank" rel="noreferrer">
-                              <ExternalLink className="mr-2 h-4 w-4" /> View public profile
-                            </a>
-                          </Button>
-                        ) : null}
+                        {person.slug ? <Button type="button" variant="outline" asChild><a href={`/therapists/${person.slug}`} target="_blank" rel="noreferrer"><ExternalLink className="mr-2 h-4 w-4" />View public profile</a></Button> : null}
                       </div>
                     </div>
 
                     <div>
-                      <div className="mb-3 flex items-center gap-2">
-                        <ImageIcon className="h-4 w-4 text-slate-500" />
-                        <h3 className="font-semibold">Cloudinary gallery</h3>
-                      </div>
+                      <div className="mb-3 flex items-center gap-2"><ImageIcon className="h-4 w-4 text-slate-500" /><h3 className="font-semibold">Cloudinary gallery</h3></div>
                       {person.photos.length ? (
-                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
                           {person.photos.map((photo) => (
                             <div key={photo.id} className="overflow-hidden rounded-xl border border-slate-200 bg-white">
-                              <div className="aspect-square bg-slate-100">
-                                {/* eslint-disable-next-line @next/next/no-img-element */}
-                                <img src={photo.url} alt="" className="h-full w-full object-cover" />
-                              </div>
-                              <div className="space-y-1 p-2 text-xs text-slate-600">
-                                <div className="flex items-center justify-between gap-2">
-                                  <span>{photo.moderationStatus}</span>
-                                  {photo.isPrimary ? <ShieldCheck className="h-3.5 w-3.5 text-emerald-600" /> : null}
-                                </div>
+                              <div className="aspect-square bg-slate-100"><img src={photo.url} alt="" className="h-full w-full object-cover" /></div>
+                              <div className="space-y-2 p-3 text-xs text-slate-600">
+                                <div className="flex items-center justify-between gap-2"><span>{photo.moderationStatus}</span>{photo.isPrimary ? <span className="font-medium text-amber-700">Primary</span> : null}</div>
                                 {photo.moderationReason ? <p className="truncate">{photo.moderationReason}</p> : null}
+                                <div className="flex flex-wrap gap-1.5">
+                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "approve")}><Check className="h-3.5 w-3.5" /></Button>
+                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "reject")}><X className="h-3.5 w-3.5" /></Button>
+                                  <Button size="sm" variant="outline" disabled={busyId === photo.id || photo.isPrimary} onClick={() => void runPhotoAction(photo.id, "set_primary")}><Star className="h-3.5 w-3.5" /></Button>
+                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "reprocess")}><RefreshCw className="h-3.5 w-3.5" /></Button>
+                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "delete")}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                </div>
                               </div>
                             </div>
                           ))}
                         </div>
-                      ) : (
-                        <p className="text-sm text-slate-500">No photos registered in profile_photos.</p>
-                      )}
+                      ) : <p className="text-sm text-slate-500">No photos registered in profile_photos.</p>}
                     </div>
                   </div>
                 </div>
@@ -153,7 +129,6 @@ export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
           );
         })}
       </div>
-
       {filtered.length === 0 ? <p className="text-sm text-slate-500">No people found.</p> : null}
     </div>
   );

--- a/src/app/admin/people/README.md
+++ b/src/app/admin/people/README.md
@@ -1,0 +1,5 @@
+# People CRM implementation notes
+
+This route currently consolidates the existing account and therapist management surfaces.
+
+The next implementation pass should replace the two stacked legacy managers with a unified person table and detail view. Keep `profile_photos` as the complete photo source, and use `moderation_queue` only for moderation workflow state.

--- a/src/app/admin/people/loadPeople.ts
+++ b/src/app/admin/people/loadPeople.ts
@@ -1,0 +1,110 @@
+import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
+
+export type AdminPersonPhoto = {
+  id: string;
+  url: string;
+  isPrimary: boolean;
+  sortOrder: number;
+  moderationStatus: string;
+  moderationReason: string | null;
+};
+
+export type AdminPerson = {
+  userId: string;
+  profileId: string;
+  name: string;
+  email: string | null;
+  city: string | null;
+  role: "admin" | "provider" | null;
+  profileStatus: string;
+  subscriptionTier: string | null;
+  verificationStatus: string | null;
+  slug: string | null;
+  isFeatured: boolean;
+  isSuspended: boolean;
+  isBanned: boolean;
+  photos: AdminPersonPhoto[];
+};
+
+export async function loadPeople(): Promise<{ items: AdminPerson[]; error: string | null }> {
+  try {
+    const supabase = createSupabaseAdminClient();
+    const [{ data: profiles, error: profileError }, { data: roles, error: roleError }] = await Promise.all([
+      supabase
+        .from("profiles")
+        .select("id,user_id,display_name,full_name,email_address,city,slug,profile_status,subscription_tier,verification_status,is_featured,is_suspended,is_banned,updated_at")
+        .order("updated_at", { ascending: false })
+        .limit(200),
+      supabase.from("user_roles").select("user_id,role,created_at").order("created_at", { ascending: false }),
+    ]);
+
+    if (profileError) throw new Error(profileError.message);
+    if (roleError) throw new Error(roleError.message);
+
+    const profileRows = profiles ?? [];
+    const profileIds = profileRows.map((profile) => profile.id);
+    const userIds = profileRows.map((profile) => profile.user_id).filter((id): id is string => Boolean(id));
+
+    const [{ data: photos, error: photoError }, authUsers] = await Promise.all([
+      profileIds.length
+        ? supabase
+            .from("profile_photos")
+            .select("id,profile_id,storage_path,url,is_primary,sort_order,moderation_status,moderation_reason,created_at")
+            .in("profile_id", profileIds)
+            .order("sort_order", { ascending: true })
+        : Promise.resolve({ data: [], error: null }),
+      Promise.all(
+        userIds.map(async (userId) => {
+          const { data } = await supabase.auth.admin.getUserById(userId);
+          return [userId, data.user?.email ?? null] as const;
+        }),
+      ),
+    ]);
+
+    if (photoError) throw new Error(photoError.message);
+
+    const roleMap = new Map<string, "admin" | "provider" | null>();
+    for (const role of roles ?? []) {
+      if (!roleMap.has(role.user_id)) roleMap.set(role.user_id, role.role);
+    }
+
+    const emailMap = new Map(authUsers);
+    const photosByProfile = new Map<string, AdminPersonPhoto[]>();
+    for (const photo of photos ?? []) {
+      const resolvedUrl = photo.url || photo.storage_path || "";
+      if (!resolvedUrl) continue;
+      const list = photosByProfile.get(photo.profile_id) ?? [];
+      list.push({
+        id: photo.id,
+        url: resolvedUrl,
+        isPrimary: Boolean(photo.is_primary),
+        sortOrder: photo.sort_order ?? 0,
+        moderationStatus: photo.moderation_status || "pending",
+        moderationReason: photo.moderation_reason,
+      });
+      photosByProfile.set(photo.profile_id, list);
+    }
+
+    return {
+      items: profileRows.map((profile) => ({
+        userId: profile.user_id || profile.id,
+        profileId: profile.id,
+        name: profile.display_name || profile.full_name || "Unknown user",
+        email: emailMap.get(profile.user_id || "") || profile.email_address || null,
+        city: profile.city,
+        role: roleMap.get(profile.user_id || "") || null,
+        profileStatus: profile.profile_status || "draft",
+        subscriptionTier: profile.subscription_tier,
+        verificationStatus: profile.verification_status,
+        slug: profile.slug,
+        isFeatured: Boolean(profile.is_featured),
+        isSuspended: Boolean(profile.is_suspended),
+        isBanned: Boolean(profile.is_banned),
+        photos: photosByProfile.get(profile.id) ?? [],
+      })),
+      error: null,
+    };
+  } catch (error) {
+    return { items: [], error: error instanceof Error ? error.message : "Unknown error." };
+  }
+}

--- a/src/app/admin/people/loadPeople.ts
+++ b/src/app/admin/people/loadPeople.ts
@@ -26,6 +26,10 @@ export type AdminPerson = {
   photos: AdminPersonPhoto[];
 };
 
+function normalizeRole(role: string | null): AdminPerson["role"] {
+  return role === "admin" || role === "provider" ? role : null;
+}
+
 export async function loadPeople(): Promise<{ items: AdminPerson[]; error: string | null }> {
   try {
     const supabase = createSupabaseAdminClient();
@@ -42,7 +46,7 @@ export async function loadPeople(): Promise<{ items: AdminPerson[]; error: strin
     if (roleError) throw new Error(roleError.message);
 
     const profileRows = profiles ?? [];
-    const profileIds = profileRows.map((profile) => profile.id);
+    const profileIds = profileRows.map((profile) => profile.id).filter((id): id is string => Boolean(id));
     const userIds = profileRows.map((profile) => profile.user_id).filter((id): id is string => Boolean(id));
 
     const [{ data: photos, error: photoError }, authUsers] = await Promise.all([
@@ -63,14 +67,17 @@ export async function loadPeople(): Promise<{ items: AdminPerson[]; error: strin
 
     if (photoError) throw new Error(photoError.message);
 
-    const roleMap = new Map<string, "admin" | "provider" | null>();
+    const roleMap = new Map<string, AdminPerson["role"]>();
     for (const role of roles ?? []) {
-      if (!roleMap.has(role.user_id)) roleMap.set(role.user_id, role.role);
+      if (role.user_id && !roleMap.has(role.user_id)) {
+        roleMap.set(role.user_id, normalizeRole(role.role));
+      }
     }
 
-    const emailMap = new Map(authUsers);
+    const emailMap = new Map<string, string | null>(authUsers);
     const photosByProfile = new Map<string, AdminPersonPhoto[]>();
     for (const photo of photos ?? []) {
+      if (!photo.profile_id || !photo.id) continue;
       const resolvedUrl = photo.url || photo.storage_path || "";
       if (!resolvedUrl) continue;
       const list = photosByProfile.get(photo.profile_id) ?? [];
@@ -86,22 +93,27 @@ export async function loadPeople(): Promise<{ items: AdminPerson[]; error: strin
     }
 
     return {
-      items: profileRows.map((profile) => ({
-        userId: profile.user_id || profile.id,
-        profileId: profile.id,
-        name: profile.display_name || profile.full_name || "Unknown user",
-        email: emailMap.get(profile.user_id || "") || profile.email_address || null,
-        city: profile.city,
-        role: roleMap.get(profile.user_id || "") || null,
-        profileStatus: profile.profile_status || "draft",
-        subscriptionTier: profile.subscription_tier,
-        verificationStatus: profile.verification_status,
-        slug: profile.slug,
-        isFeatured: Boolean(profile.is_featured),
-        isSuspended: Boolean(profile.is_suspended),
-        isBanned: Boolean(profile.is_banned),
-        photos: photosByProfile.get(profile.id) ?? [],
-      })),
+      items: profileRows
+        .filter((profile): profile is typeof profile & { id: string } => Boolean(profile.id))
+        .map((profile) => {
+          const userId = profile.user_id || profile.id;
+          return {
+            userId,
+            profileId: profile.id,
+            name: profile.display_name || profile.full_name || "Unknown user",
+            email: emailMap.get(userId) || profile.email_address || null,
+            city: profile.city,
+            role: roleMap.get(userId) || null,
+            profileStatus: profile.profile_status || "draft",
+            subscriptionTier: profile.subscription_tier,
+            verificationStatus: profile.verification_status,
+            slug: profile.slug,
+            isFeatured: Boolean(profile.is_featured),
+            isSuspended: Boolean(profile.is_suspended),
+            isBanned: Boolean(profile.is_banned),
+            photos: photosByProfile.get(profile.id) ?? [],
+          } satisfies AdminPerson;
+        }),
       error: null,
     };
   } catch (error) {

--- a/src/app/admin/people/page.tsx
+++ b/src/app/admin/people/page.tsx
@@ -1,0 +1,45 @@
+import AdminUsersManager from "@/app/admin/_components/AdminUsersManager";
+import AdminTherapistsManager from "@/app/admin/_components/AdminTherapistsManager";
+import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+import { loadTherapists, loadUsers } from "@/app/admin/_lib/loaders";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function AdminPeoplePage() {
+  const [usersResult, therapistsResult] = await Promise.all([
+    loadUsers(),
+    loadTherapists(),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="People CRM"
+        description="Manage accounts, therapist profiles, photos, access and administrative actions from one place."
+      />
+
+      {usersResult.error || therapistsResult.error ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-muted-foreground">
+          Some people data could not be loaded. {usersResult.error || therapistsResult.error}
+        </div>
+      ) : null}
+
+      <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+        <div className="mb-5">
+          <h2 className="text-lg font-semibold">Accounts</h2>
+          <p className="text-sm text-muted-foreground">Search people, review account information and manage access roles.</p>
+        </div>
+        <AdminUsersManager initialUsers={usersResult.items} />
+      </section>
+
+      <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+        <div className="mb-5">
+          <h2 className="text-lg font-semibold">Therapist profiles and photos</h2>
+          <p className="text-sm text-muted-foreground">Moderate profiles, verification, visibility, plans and public listings.</p>
+        </div>
+        <AdminTherapistsManager initialTherapists={therapistsResult.items} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/people/page.tsx
+++ b/src/app/admin/people/page.tsx
@@ -1,45 +1,27 @@
-import AdminUsersManager from "@/app/admin/_components/AdminUsersManager";
-import AdminTherapistsManager from "@/app/admin/_components/AdminTherapistsManager";
 import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
-import { loadTherapists, loadUsers } from "@/app/admin/_lib/loaders";
+import PeopleCrm from "./PeopleCrm";
+import { loadPeople } from "./loadPeople";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default async function AdminPeoplePage() {
-  const [usersResult, therapistsResult] = await Promise.all([
-    loadUsers(),
-    loadTherapists(),
-  ]);
+  const result = await loadPeople();
 
   return (
     <div className="space-y-6">
       <AdminPageHeader
         title="People CRM"
-        description="Manage accounts, therapist profiles, photos, access and administrative actions from one place."
+        description="Manage accounts, therapist profiles, Cloudinary photos, access and administrative actions from one place."
       />
 
-      {usersResult.error || therapistsResult.error ? (
+      {result.error ? (
         <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-muted-foreground">
-          Some people data could not be loaded. {usersResult.error || therapistsResult.error}
+          People data could not be loaded. {result.error}
         </div>
       ) : null}
 
-      <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
-        <div className="mb-5">
-          <h2 className="text-lg font-semibold">Accounts</h2>
-          <p className="text-sm text-muted-foreground">Search people, review account information and manage access roles.</p>
-        </div>
-        <AdminUsersManager initialUsers={usersResult.items} />
-      </section>
-
-      <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
-        <div className="mb-5">
-          <h2 className="text-lg font-semibold">Therapist profiles and photos</h2>
-          <p className="text-sm text-muted-foreground">Moderate profiles, verification, visibility, plans and public listings.</p>
-        </div>
-        <AdminTherapistsManager initialTherapists={therapistsResult.items} />
-      </section>
+      <PeopleCrm people={result.items} />
     </div>
   );
 }

--- a/src/app/admin/therapists/page.tsx
+++ b/src/app/admin/therapists/page.tsx
@@ -1,26 +1,5 @@
-import AdminTherapistsManager from "@/app/admin/_components/AdminTherapistsManager";
-import { loadTherapists } from "@/app/admin/_lib/loaders";
-import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+import { redirect } from "next/navigation";
 
-export default async function AdminTherapistsPage() {
-  const { items, error } = await loadTherapists();
-
-  return (
-    <div className="space-y-6">
-      <AdminPageHeader
-        title="Therapists"
-        description="Moderate therapist profiles, verification state, availability, and featured placement."
-      />
-
-      {error ? (
-        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-muted-foreground">
-          Therapists could not be loaded from Supabase admin right now: {error}
-        </div>
-      ) : null}
-
-      <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
-        <AdminTherapistsManager initialTherapists={items} />
-      </div>
-    </div>
-  );
+export default function AdminTherapistsPage() {
+  redirect("/admin/people");
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,29 +1,5 @@
-import AdminUsersManager from "@/app/admin/_components/AdminUsersManager";
-import { loadUsers } from "@/app/admin/_lib/loaders";
-import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+import { redirect } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
-
-export default async function AdminUsersPage() {
-  const { items, error } = await loadUsers();
-
-  return (
-    <div className="space-y-6">
-      <AdminPageHeader
-        title="Users"
-        description="Review provider accounts and move them between provider and admin roles."
-      />
-
-      {error ? (
-        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-muted-foreground">
-          Users could not be loaded from Supabase admin right now: {error}
-        </div>
-      ) : null}
-
-      <div className="rounded-2xl border border-border bg-white p-6 shadow-sm">
-        <AdminUsersManager initialUsers={items} />
-      </div>
-    </div>
-  );
+export default function AdminUsersPage() {
+  redirect("/admin/people");
 }

--- a/src/app/api/admin/photos/action/route.ts
+++ b/src/app/api/admin/photos/action/route.ts
@@ -31,7 +31,9 @@ export async function POST(request: Request) {
 
     if (photoError) throw new RouteError(500, photoError.message);
     if (!photo) throw new RouteError(404, "Photo not found.");
+    if (!photo.profile_id) throw new RouteError(409, "Photo is not linked to a profile.");
 
+    const profileId = photo.profile_id;
     const imageUrl = photo.url || photo.storage_path || null;
     const now = new Date().toISOString();
 
@@ -39,7 +41,7 @@ export async function POST(request: Request) {
       const { error: resetError } = await supabase
         .from("profile_photos")
         .update({ is_primary: false })
-        .eq("profile_id", photo.profile_id);
+        .eq("profile_id", profileId);
       if (resetError) throw new RouteError(500, resetError.message);
 
       const { error } = await supabase
@@ -64,7 +66,7 @@ export async function POST(request: Request) {
         .from("moderation_queue")
         .upsert({
           content_type: "photo",
-          profile_id: photo.profile_id,
+          profile_id: profileId,
           user_id: photo.user_id,
           target_id: photo.id,
           item_type: "photo",
@@ -89,7 +91,7 @@ export async function POST(request: Request) {
         .from("moderation_queue")
         .upsert({
           content_type: "photo",
-          profile_id: photo.profile_id,
+          profile_id: profileId,
           user_id: photo.user_id,
           target_id: photo.id,
           item_type: "photo",
@@ -119,7 +121,7 @@ export async function POST(request: Request) {
     }
 
     await recordAuditLog(admin.userId, `photo_${body.action}`, "photo", body.photoId, {
-      profileId: photo.profile_id,
+      profileId,
       reason: body.reason || null,
     });
 

--- a/src/app/api/admin/photos/action/route.ts
+++ b/src/app/api/admin/photos/action/route.ts
@@ -1,0 +1,130 @@
+export const dynamic = "force-dynamic";
+
+import { z } from "zod";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+import { assertRateLimit } from "@/app/_lib/security";
+
+const schema = z.object({
+  photoId: z.string().uuid(),
+  action: z.enum(["approve", "reject", "set_primary", "delete", "reprocess"]),
+  reason: z.string().trim().max(500).optional(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-photo-action", { limit: 60, windowMs: 60_000 });
+    const body = await parseJsonBody(request, schema);
+    const supabase = createSupabaseAdminClient();
+
+    const { data: photo, error: photoError } = await supabase
+      .from("profile_photos")
+      .select("id,profile_id,user_id,storage_path,url,is_primary,sort_order")
+      .eq("id", body.photoId)
+      .maybeSingle();
+
+    if (photoError) throw new RouteError(500, photoError.message);
+    if (!photo) throw new RouteError(404, "Photo not found.");
+
+    const imageUrl = photo.url || photo.storage_path || null;
+    const now = new Date().toISOString();
+
+    if (body.action === "set_primary") {
+      const { error: resetError } = await supabase
+        .from("profile_photos")
+        .update({ is_primary: false })
+        .eq("profile_id", photo.profile_id);
+      if (resetError) throw new RouteError(500, resetError.message);
+
+      const { error } = await supabase
+        .from("profile_photos")
+        .update({ is_primary: true })
+        .eq("id", body.photoId);
+      if (error) throw new RouteError(500, error.message);
+    }
+
+    if (body.action === "approve" || body.action === "reject") {
+      const approved = body.action === "approve";
+      const { error } = await supabase
+        .from("profile_photos")
+        .update({
+          moderation_status: approved ? "approved" : "rejected",
+          moderation_reason: body.reason || (approved ? "admin_approved" : "admin_rejected"),
+        })
+        .eq("id", body.photoId);
+      if (error) throw new RouteError(500, error.message);
+
+      await supabase
+        .from("moderation_queue")
+        .upsert({
+          content_type: "photo",
+          profile_id: photo.profile_id,
+          user_id: photo.user_id,
+          target_id: photo.id,
+          item_type: "photo",
+          source: "admin_people_crm",
+          status: approved ? "approved" : "rejected",
+          moderation_provider: "admin",
+          moderation_reason: body.reason || (approved ? "admin_approved" : "admin_rejected"),
+          reviewed_at: now,
+          reviewed_by: admin.userId,
+          snapshot: imageUrl ? { photoId: photo.id, imageUrl } : { photoId: photo.id },
+        }, { onConflict: "target_id" });
+    }
+
+    if (body.action === "reprocess") {
+      if (!imageUrl) throw new RouteError(400, "Photo has no image URL.");
+      await supabase
+        .from("profile_photos")
+        .update({ moderation_status: "pending", moderation_reason: "queued_for_ai_review" })
+        .eq("id", body.photoId);
+
+      await supabase
+        .from("moderation_queue")
+        .upsert({
+          content_type: "photo",
+          profile_id: photo.profile_id,
+          user_id: photo.user_id,
+          target_id: photo.id,
+          item_type: "photo",
+          source: "admin_people_crm",
+          status: "pending",
+          moderation_provider: "sightengine",
+          moderation_reason: "queued_for_ai_review",
+          snapshot: { photoId: photo.id, imageUrl },
+        }, { onConflict: "target_id" });
+
+      const { error: invokeError } = await supabase.functions.invoke("moderate-photo", {
+        body: { photo_id: photo.id, image_url: imageUrl },
+      });
+      if (invokeError) {
+        await supabase
+          .from("profile_photos")
+          .update({ moderation_status: "pending", moderation_reason: "manual_review_required" })
+          .eq("id", body.photoId);
+        throw new RouteError(502, invokeError.message);
+      }
+    }
+
+    if (body.action === "delete") {
+      const { error } = await supabase.from("profile_photos").delete().eq("id", body.photoId);
+      if (error) throw new RouteError(500, error.message);
+      await supabase.from("moderation_queue").delete().eq("target_id", body.photoId);
+    }
+
+    await recordAuditLog(admin.userId, `photo_${body.action}`, "photo", body.photoId, {
+      profileId: photo.profile_id,
+      reason: body.reason || null,
+    });
+
+    return json({ ok: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/users/reset-password/route.ts
+++ b/src/app/api/admin/users/reset-password/route.ts
@@ -1,0 +1,69 @@
+export const dynamic = "force-dynamic";
+
+import React from "react";
+import { z } from "zod";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import { sendEmail } from "@/app/api/_lib/email";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+import { assertRateLimit } from "@/app/_lib/security";
+import ResetPasswordEmail from "@/emails/ResetPasswordEmail";
+
+const resetPasswordSchema = z.object({
+  userId: z.string().uuid(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-password-reset", { limit: 10, windowMs: 60_000 });
+    const body = await parseJsonBody(request, resetPasswordSchema);
+    const supabase = createSupabaseAdminClient();
+
+    const { data: userResult, error: userError } = await supabase.auth.admin.getUserById(body.userId);
+    if (userError || !userResult.user?.email) {
+      throw new RouteError(404, "User email could not be found.");
+    }
+
+    const requestUrl = new URL(request.url);
+    const redirectTo = new URL("/reset-password", requestUrl.origin).toString();
+    const { data, error: linkError } = await supabase.auth.admin.generateLink({
+      type: "recovery",
+      email: userResult.user.email,
+      options: { redirectTo },
+    });
+
+    const tokenHash = data?.properties?.hashed_token;
+    if (linkError || !tokenHash) {
+      throw new RouteError(500, linkError?.message || "Could not generate a reset link.");
+    }
+
+    const resetUrl = new URL("/reset-password", requestUrl.origin);
+    resetUrl.searchParams.set("token_hash", tokenHash);
+    resetUrl.searchParams.set("type", "recovery");
+
+    const sent = await sendEmail({
+      to: userResult.user.email,
+      subject: "Reset your MasseurMatch password",
+      react: React.createElement(ResetPasswordEmail, {
+        resetUrl: resetUrl.toString(),
+      }),
+    });
+
+    if (!sent.success) {
+      throw new RouteError(502, "The reset email could not be sent.");
+    }
+
+    await recordAuditLog(admin.userId, "send_password_reset", "user", body.userId, {
+      email: userResult.user.email,
+    });
+
+    return json({ ok: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
## Summary

Creates one unified Admin People CRM for MasseurMatch and makes Cloudinary photo management reliable from the admin surface.

## Admin People CRM

- Adds `/admin/people` as the central account and therapist management destination.
- Replaces separate Users and Therapists navigation entries with People CRM.
- Redirects legacy `/admin/users` and `/admin/therapists` routes to `/admin/people`.
- Displays one record per profile/person with search across name, email, city, role, profile status, plan and IDs.
- Shows account and profile identifiers, canonical `profile_status`, plan, verification, featured, suspended and banned state.
- Shows the gallery directly from `profile_photos`, so photos remain visible even if `moderation_queue` is missing or stale.

## Secure account actions

- Adds an admin-only password-reset action using Supabase recovery `token_hash` links and the existing Resend template.
- Applies rate limiting and records the action in the admin audit log.
- Never exposes or reads the user's current password.

## Cloudinary photo controls

- Displays Cloudinary images and moderation state inside the person's CRM detail.
- Adds admin actions to approve, reject, set primary, delete and reprocess a photo through Sightengine.
- Reconciles `moderation_queue` during approve/reject/reprocess actions and removes the queue item when a photo is deleted.
- Records photo actions in the audit log.

## Production operation completed

- Updated the active Supabase `cloudinary-sign` Edge Function to version 34.
- The function now supports either `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` or `CLOUDINARY_URL`.
- Bruno and Rene/Rey photos were verified as stored in Cloudinary and registered in `profile_photos`.

## Validation

- CI: passed
- Go Live Release Checks: passed
- Production build: passed
- Typecheck: passed
- Lint: passed
- Unit/API tests: passed
- E2E tests: passed
- Accessibility WCAG 2.1 AA: passed
- Database contract: passed
- Lockfile guard: passed
- Secret scan: passed
- AI Coach diagnostics: passed
- Vercel preview deployment: Ready
- Review threads / change requests: none

No production profile records were bulk-modified by this PR.