### PR TITLE
feat(admin): complete Email Center v2 with compliant queued delivery

### DIFF
--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -24,6 +24,7 @@ import {
   CalendarCheck,
   MessageSquare,
   Flag,
+  Mail,
 } from "lucide-react";
 
 const navSections = [
@@ -40,6 +41,7 @@ const navSections = [
   {
     title: "Communication",
     items: [
+      { href: "/admin/emails", label: "Email Center", icon: Mail },
       { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
       { href: "/admin/support", label: "Support", icon: LifeBuoy },
       { href: "/admin/bookings", label: "Bookings", icon: CalendarCheck },

--- a/src/app/admin/emails/AdminEmailCenter.tsx
+++ b/src/app/admin/emails/AdminEmailCenter.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  Loader2,
+  Mail,
+  RefreshCw,
+  Save,
+  Search,
+  Send,
+  ShieldCheck,
+  Users,
+  XCircle,
+} from "lucide-react";
+
+type Recipient = {
+  userId: string;
+  profileId: string;
+  name: string;
+  email: string;
+  city: string | null;
+  state: string | null;
+  profileStatus: string | null;
+  plan: string | null;
+  marketingOptIn: boolean;
+  suppressed: boolean;
+};
+
+type Template = {
+  id: string;
+  name: string;
+  description: string | null;
+  subject: string;
+  bodyHtml: string;
+  bodyText: string | null;
+  sendCategory: "marketing" | "transactional";
+  fromAddress: string | null;
+  replyTo: string | null;
+};
+
+type Campaign = {
+  id: string;
+  name: string;
+  subject: string;
+  sendCategory: string;
+  scheduledFor: string;
+  status: string;
+  createdAt: string;
+  total: number;
+  queued: number;
+  processing: number;
+  sent: number;
+  suppressed: number;
+  failed: number;
+};
+
+type Snapshot = {
+  recipients: Recipient[];
+  templates: Template[];
+  campaigns: Campaign[];
+  summary: { sent30d: number; failed30d: number; suppressed30d: number; complaints30d: number };
+};
+
+const DEFAULT_HTML = `<p>Hi {{name}},</p>
+<p>We have an update for your MasseurMatch profile.</p>
+<p><a href="https://www.masseurmatch.com/pro/dashboard">Open your dashboard</a></p>
+<p>Best,<br />MasseurMatch</p>`;
+
+const EMPTY_SNAPSHOT: Snapshot = {
+  recipients: [],
+  templates: [],
+  campaigns: [],
+  summary: { sent30d: 0, failed30d: 0, suppressed30d: 0, complaints30d: 0 },
+};
+
+async function api<T>(options: RequestInit = {}, query = ""): Promise<T> {
+  const response = await fetch(`/api/admin/emails${query}`, {
+    credentials: "include",
+    ...options,
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body.error || "Email Center request failed.");
+  return body as T;
+}
+
+function unique(values: Array<string | null>) {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value)))).sort();
+}
+
+export default function AdminEmailCenter() {
+  const [snapshot, setSnapshot] = useState<Snapshot>(EMPTY_SNAPSHOT);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [notice, setNotice] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const [campaignName, setCampaignName] = useState("");
+  const [subject, setSubject] = useState("");
+  const [bodyHtml, setBodyHtml] = useState(DEFAULT_HTML);
+  const [bodyText, setBodyText] = useState("");
+  const [sendCategory, setSendCategory] = useState<"marketing" | "transactional">("marketing");
+  const [fromAddress, setFromAddress] = useState("MasseurMatch Updates <updates@updates.masseurmatch.com>");
+  const [replyTo, setReplyTo] = useState("support@masseurmatch.com");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [templateId, setTemplateId] = useState("");
+  const [profileStatus, setProfileStatus] = useState("");
+  const [plan, setPlan] = useState("");
+  const [city, setCity] = useState("");
+  const [state, setState] = useState("");
+
+  const load = useCallback(async (search = "") => {
+    setLoading(true);
+    try {
+      const data = await api<{ ok: true } & Snapshot>({}, search ? `?q=${encodeURIComponent(search)}` : "");
+      setSnapshot({
+        recipients: data.recipients || [],
+        templates: data.templates || [],
+        campaigns: data.campaigns || [],
+        summary: data.summary || EMPTY_SNAPSHOT.summary,
+      });
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Unable to load Email Center." });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const recipients = useMemo(() => {
+    return snapshot.recipients.filter((recipient) => {
+      if (profileStatus && recipient.profileStatus !== profileStatus) return false;
+      if (plan && recipient.plan !== plan) return false;
+      if (city && recipient.city !== city) return false;
+      if (state && recipient.state !== state) return false;
+      return true;
+    });
+  }, [snapshot.recipients, profileStatus, plan, city, state]);
+
+  const selectedRecipients = useMemo(
+    () => snapshot.recipients.filter((recipient) => selected.includes(recipient.userId)),
+    [snapshot.recipients, selected],
+  );
+  const blockedSelected = selectedRecipients.filter((recipient) => recipient.suppressed || !recipient.marketingOptIn).length;
+  const statuses = unique(snapshot.recipients.map((recipient) => recipient.profileStatus));
+  const plans = unique(snapshot.recipients.map((recipient) => recipient.plan));
+  const cities = unique(snapshot.recipients.map((recipient) => recipient.city));
+  const states = unique(snapshot.recipients.map((recipient) => recipient.state));
+
+  const toggle = (userId: string) => {
+    setSelected((current) =>
+      current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId],
+    );
+  };
+
+  const selectVisible = () => {
+    setSelected((current) => Array.from(new Set([...current, ...recipients.map((recipient) => recipient.userId)])));
+  };
+
+  const applyTemplate = (id: string) => {
+    setTemplateId(id);
+    const template = snapshot.templates.find((item) => item.id === id);
+    if (!template) return;
+    setSubject(template.subject);
+    setBodyHtml(template.bodyHtml);
+    setBodyText(template.bodyText || "");
+    setSendCategory(template.sendCategory);
+    setFromAddress(template.fromAddress || fromAddress);
+    setReplyTo(template.replyTo || replyTo);
+  };
+
+  const saveTemplate = async () => {
+    setSaving(true);
+    setNotice(null);
+    try {
+      await api({
+        method: "POST",
+        body: JSON.stringify({
+          action: "save_template",
+          id: templateId || null,
+          name: campaignName || subject || "Email template",
+          description: "Saved from the Admin Email Center",
+          subject,
+          bodyHtml,
+          bodyText: bodyText || null,
+          sendCategory,
+          fromAddress,
+          replyTo,
+        }),
+      });
+      setNotice({ ok: true, text: "Template saved." });
+      await load(query);
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Template save failed." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const createCampaign = async () => {
+    setSending(true);
+    setNotice(null);
+    try {
+      const data = await api<{ campaign: { total: number; queued: number; suppressed: number } }>({
+        method: "POST",
+        body: JSON.stringify({
+          action: "create_campaign",
+          name: campaignName,
+          subject,
+          bodyHtml,
+          bodyText: bodyText || null,
+          sendCategory,
+          fromAddress,
+          replyTo,
+          scheduledFor: scheduledFor ? new Date(scheduledFor).toISOString() : null,
+          templateId: templateId || null,
+          userIds: selected,
+          profileStatuses: profileStatus ? [profileStatus] : [],
+          plans: plan ? [plan] : [],
+          cities: city ? [city] : [],
+          states: state ? [state] : [],
+        }),
+      });
+      setNotice({
+        ok: true,
+        text: `Campaign created: ${data.campaign.queued} queued, ${data.campaign.suppressed} suppressed, ${data.campaign.total} matched.`,
+      });
+      setSelected([]);
+      await load(query);
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Campaign creation failed." });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const cancelCampaign = async (campaignId: string) => {
+    try {
+      const data = await api<{ cancelled: number }>({
+        method: "POST",
+        body: JSON.stringify({ action: "cancel_campaign", campaignId }),
+      });
+      setNotice({ ok: true, text: `Campaign cancelled. ${data.cancelled} queued messages were stopped.` });
+      await load(query);
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Campaign cancellation failed." });
+    }
+  };
+
+  const hasAudience = selected.length > 0 || Boolean(profileStatus || plan || city || state);
+  const canSend = Boolean(campaignName.trim() && subject.trim() && bodyHtml.trim() && hasAudience && !sending);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Metric label="Sent · 30 days" value={snapshot.summary.sent30d} icon={CheckCircle2} />
+        <Metric label="Failed · 30 days" value={snapshot.summary.failed30d} icon={XCircle} />
+        <Metric label="Suppressed · 30 days" value={snapshot.summary.suppressed30d} icon={ShieldCheck} />
+        <Metric label="Complaints · 30 days" value={snapshot.summary.complaints30d} icon={AlertTriangle} />
+      </div>
+
+      {notice ? (
+        <div className={`rounded-2xl border p-4 text-sm ${notice.ok ? "border-emerald-200 bg-emerald-50 text-emerald-800" : "border-red-200 bg-red-50 text-red-800"}`}>
+          {notice.text}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 2xl:grid-cols-[390px_minmax(0,1fr)]">
+        <section className="overflow-hidden rounded-2xl border border-border bg-white shadow-sm">
+          <div className="border-b border-border p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="font-semibold text-slate-900">Audience</h2>
+                <p className="text-sm text-muted-foreground">{selected.length} explicitly selected</p>
+              </div>
+              <button type="button" onClick={selectVisible} className="text-sm font-semibold text-brand-secondary hover:underline">
+                Select visible
+              </button>
+            </div>
+            <div className="relative mt-4">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => event.key === "Enter" && void load(query)}
+                placeholder="Search people..."
+                className="w-full rounded-xl border border-slate-200 py-2.5 pl-9 pr-12 text-sm outline-none focus:border-brand-secondary"
+              />
+              <button type="button" onClick={() => void load(query)} className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg p-1.5 text-slate-500 hover:bg-slate-100">
+                <RefreshCw className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <Filter value={profileStatus} onChange={setProfileStatus} label="All statuses" values={statuses} />
+              <Filter value={plan} onChange={setPlan} label="All plans" values={plans} />
+              <Filter value={city} onChange={setCity} label="All cities" values={cities} />
+              <Filter value={state} onChange={setState} label="All states" values={states} />
+            </div>
+          </div>
+          <div className="max-h-[720px] overflow-y-auto p-2">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 p-10 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading audience</div>
+            ) : recipients.length === 0 ? (
+              <div className="p-10 text-center text-sm text-muted-foreground">No recipients match these filters.</div>
+            ) : recipients.map((recipient) => (
+              <label key={recipient.userId} className="flex cursor-pointer gap-3 rounded-xl p-3 hover:bg-slate-50">
+                <input type="checkbox" checked={selected.includes(recipient.userId)} onChange={() => toggle(recipient.userId)} className="mt-1 h-4 w-4 rounded border-slate-300" />
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-2">
+                    <span className="truncate text-sm font-semibold text-slate-900">{recipient.name}</span>
+                    {recipient.suppressed || !recipient.marketingOptIn ? <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" /> : null}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">{recipient.email}</span>
+                  <span className="block text-xs text-slate-400">{recipient.city || "No city"} · {recipient.profileStatus || "draft"} · {recipient.plan || "free"}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <div className="space-y-6">
+          <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+            <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="rounded-xl bg-brand-secondary/10 p-2.5 text-brand-secondary"><Mail className="h-5 w-5" /></div>
+                <div><h2 className="font-semibold text-slate-900">Campaign composer</h2><p className="text-sm text-muted-foreground">Queued through the compliant lifecycle delivery system.</p></div>
+              </div>
+              <select value={templateId} onChange={(event) => applyTemplate(event.target.value)} className="rounded-xl border border-slate-200 px-3 py-2 text-sm">
+                <option value="">Start without template</option>
+                {snapshot.templates.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}
+              </select>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field label="Campaign name"><input value={campaignName} onChange={(e) => setCampaignName(e.target.value)} placeholder="August profile update" className="input" /></Field>
+              <Field label="Category"><select value={sendCategory} onChange={(e) => setSendCategory(e.target.value as "marketing" | "transactional")} className="input"><option value="marketing">Marketing</option><option value="transactional">Transactional</option></select></Field>
+              <Field label="From"><input value={fromAddress} onChange={(e) => setFromAddress(e.target.value)} className="input" /></Field>
+              <Field label="Reply-to"><input value={replyTo} onChange={(e) => setReplyTo(e.target.value)} className="input" /></Field>
+            </div>
+            <Field label="Subject"><input value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="A quick update for {{name}}" className="input" /></Field>
+            <Field label="HTML content"><textarea value={bodyHtml} onChange={(e) => setBodyHtml(e.target.value)} rows={13} className="input font-mono text-sm" /></Field>
+            <Field label="Plain-text fallback"><textarea value={bodyText} onChange={(e) => setBodyText(e.target.value)} rows={4} className="input" placeholder="Optional. The worker can derive a fallback when omitted." /></Field>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field label="Schedule"><input type="datetime-local" value={scheduledFor} onChange={(e) => setScheduledFor(e.target.value)} className="input" /></Field>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+                <p className="font-semibold text-slate-900">Audience summary</p>
+                <p>{selected.length} selected · {recipients.length} visible by filters</p>
+                {blockedSelected > 0 ? <p className="mt-1 text-amber-700">{blockedSelected} selected contacts may be suppressed automatically.</p> : null}
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs text-muted-foreground">Variables: <code>{"{{name}}"}</code> and <code>{"{{city}}"}</code>. Marketing sends enforce opt-out, cooldown, suppression and unsubscribe rules.</p>
+              <div className="flex gap-2">
+                <button type="button" onClick={() => void saveTemplate()} disabled={saving || !subject || !bodyHtml} className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-700 disabled:opacity-50">
+                  {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />} Save template
+                </button>
+                <button type="button" onClick={() => void createCampaign()} disabled={!canSend} className="inline-flex items-center gap-2 rounded-xl bg-brand-secondary px-5 py-2.5 text-sm font-semibold text-white disabled:opacity-50">
+                  {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : scheduledFor ? <CalendarClock className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+                  {scheduledFor ? "Schedule campaign" : "Queue campaign"}
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+            <h2 className="mb-4 font-semibold text-slate-900">Preview</h2>
+            <div className="overflow-hidden rounded-xl border border-slate-200">
+              <div className="border-b border-slate-200 bg-slate-50 px-5 py-3 text-sm"><strong>Subject:</strong> {(subject || "No subject").replaceAll("{{name}}", "Bruno").replaceAll("{{city}}", "Dallas")}</div>
+              <div className="bg-white p-6 text-sm text-slate-700" dangerouslySetInnerHTML={{ __html: bodyHtml.replaceAll("{{name}}", "Bruno").replaceAll("{{city}}", "Dallas") }} />
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-3"><FileText className="h-5 w-5 text-brand-secondary" /><div><h2 className="font-semibold text-slate-900">Campaign history</h2><p className="text-sm text-muted-foreground">Live queue totals from the lifecycle email system.</p></div></div>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[900px] text-left text-sm">
+            <thead className="border-b border-slate-200 text-xs uppercase text-slate-500"><tr><th className="px-3 py-3">Campaign</th><th className="px-3 py-3">Status</th><th className="px-3 py-3">Scheduled</th><th className="px-3 py-3">Total</th><th className="px-3 py-3">Queued</th><th className="px-3 py-3">Sent</th><th className="px-3 py-3">Suppressed</th><th className="px-3 py-3">Failed</th><th className="px-3 py-3">Action</th></tr></thead>
+            <tbody className="divide-y divide-slate-100">
+              {snapshot.campaigns.length === 0 ? <tr><td colSpan={9} className="px-3 py-10 text-center text-muted-foreground">No campaigns yet.</td></tr> : snapshot.campaigns.map((campaign) => (
+                <tr key={campaign.id}><td className="px-3 py-4"><p className="font-semibold text-slate-900">{campaign.name}</p><p className="max-w-xs truncate text-xs text-muted-foreground">{campaign.subject}</p></td><td className="px-3 py-4"><span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold capitalize">{campaign.status}</span></td><td className="px-3 py-4 text-slate-600">{new Date(campaign.scheduledFor).toLocaleString()}</td><td className="px-3 py-4">{campaign.total}</td><td className="px-3 py-4">{campaign.queued + campaign.processing}</td><td className="px-3 py-4 text-emerald-700">{campaign.sent}</td><td className="px-3 py-4 text-amber-700">{campaign.suppressed}</td><td className="px-3 py-4 text-red-700">{campaign.failed}</td><td className="px-3 py-4">{["scheduled", "processing"].includes(campaign.status) && campaign.queued > 0 ? <button type="button" onClick={() => void cancelCampaign(campaign.id)} className="text-xs font-semibold text-red-700 hover:underline">Cancel queued</button> : <span className="text-xs text-slate-400">—</span>}</td></tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <style jsx>{`
+        :global(.input) { width: 100%; border-radius: 0.75rem; border: 1px solid rgb(226 232 240); padding: 0.625rem 0.75rem; font-weight: 400; outline: none; }
+        :global(.input:focus) { border-color: var(--brand-secondary, #8b1e2d); }
+      `}</style>
+    </div>
+  );
+}
+
+function Metric({ label, value, icon: Icon }: { label: string; value: number; icon: typeof Mail }) {
+  return <div className="rounded-2xl border border-border bg-white p-5 shadow-sm"><div className="flex items-center justify-between"><div><p className="text-sm text-muted-foreground">{label}</p><p className="mt-1 text-2xl font-bold text-slate-900">{value}</p></div><div className="rounded-xl bg-slate-100 p-2.5 text-slate-600"><Icon className="h-5 w-5" /></div></div></div>;
+}
+
+function Filter({ value, onChange, label, values }: { value: string; onChange: (value: string) => void; label: string; values: string[] }) {
+  return <select value={value} onChange={(event) => onChange(event.target.value)} className="rounded-xl border border-slate-200 px-2.5 py-2 text-xs"><option value="">{label}</option>{values.map((item) => <option key={item} value={item}>{item}</option>)}</select>;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return <label className="mt-4 block space-y-1.5 text-sm font-medium text-slate-700"><span>{label}</span>{children}</label>;
+}

--- a/src/app/admin/emails/page.tsx
+++ b/src/app/admin/emails/page.tsx
@@ -1,0 +1,17 @@
+import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+import AdminEmailCenter from "./AdminEmailCenter";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default function AdminEmailsPage() {
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="Email Center"
+        description="Build compliant campaigns, save templates, schedule delivery, and monitor the Resend lifecycle queue."
+      />
+      <AdminEmailCenter />
+    </div>
+  );
+}

--- a/src/app/api/admin/emails/route.ts
+++ b/src/app/api/admin/emails/route.ts
@@ -1,0 +1,160 @@
+export const dynamic = "force-dynamic";
+
+import { z } from "zod";
+
+import { assertRateLimit } from "@/app/_lib/security";
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+
+const campaignSchema = z.object({
+  action: z.literal("create_campaign"),
+  name: z.string().trim().min(2).max(120),
+  subject: z.string().trim().min(1).max(180),
+  bodyHtml: z.string().min(1).max(150_000),
+  bodyText: z.string().max(80_000).optional().nullable(),
+  sendCategory: z.enum(["marketing", "transactional"]),
+  fromAddress: z.string().trim().max(200).optional().nullable(),
+  replyTo: z.string().trim().email().optional().nullable(),
+  scheduledFor: z.string().datetime().optional().nullable(),
+  templateId: z.string().uuid().optional().nullable(),
+  userIds: z.array(z.string().uuid()).max(500).default([]),
+  profileStatuses: z.array(z.string().trim().min(1)).max(20).default([]),
+  plans: z.array(z.string().trim().min(1)).max(20).default([]),
+  cities: z.array(z.string().trim().min(1)).max(100).default([]),
+  states: z.array(z.string().trim().min(1)).max(100).default([]),
+});
+
+const templateSchema = z.object({
+  action: z.literal("save_template"),
+  id: z.string().uuid().optional().nullable(),
+  name: z.string().trim().min(2).max(120),
+  description: z.string().trim().max(500).optional().nullable(),
+  subject: z.string().trim().min(1).max(180),
+  bodyHtml: z.string().min(1).max(150_000),
+  bodyText: z.string().max(80_000).optional().nullable(),
+  sendCategory: z.enum(["marketing", "transactional"]),
+  fromAddress: z.string().trim().max(200).optional().nullable(),
+  replyTo: z.string().trim().email().optional().nullable(),
+});
+
+const cancelSchema = z.object({
+  action: z.literal("cancel_campaign"),
+  campaignId: z.string().uuid(),
+});
+
+const postSchema = z.discriminatedUnion("action", [campaignSchema, templateSchema, cancelSchema]);
+
+type RpcClient = ReturnType<typeof createSupabaseAdminClient> & {
+  rpc: (name: string, params?: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }>;
+};
+
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    assertRateLimit(request, "admin-email-center-read", { limit: 90, windowMs: 60_000 });
+
+    const url = new URL(request.url);
+    const query = url.searchParams.get("q")?.trim() || null;
+    const adminClient = createSupabaseAdminClient() as RpcClient;
+    const { data, error } = await adminClient.rpc("admin_email_center_snapshot", {
+      p_query: query,
+      p_limit: 500,
+    });
+
+    if (error) throw new RouteError(500, error.message);
+    return json({ ok: true, ...(data as Record<string, unknown>) });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-email-center-write", { limit: 20, windowMs: 60_000 });
+    const body = await parseJsonBody(request, postSchema);
+    const adminClient = createSupabaseAdminClient() as RpcClient;
+
+    if (body.action === "save_template") {
+      const { data, error } = await adminClient.rpc("admin_email_save_template", {
+        p_admin_user_id: admin.userId,
+        p_id: body.id || null,
+        p_name: body.name,
+        p_description: body.description || null,
+        p_subject: body.subject,
+        p_body_html: body.bodyHtml,
+        p_body_text: body.bodyText || null,
+        p_send_category: body.sendCategory,
+        p_from_address: body.fromAddress || null,
+        p_reply_to: body.replyTo || null,
+      });
+      if (error) throw new RouteError(500, error.message);
+
+      await recordAuditLog(admin.userId, "admin_email_template_saved", "email_template", String(data), {
+        name: body.name,
+        sendCategory: body.sendCategory,
+      });
+      return json({ ok: true, templateId: data });
+    }
+
+    if (body.action === "cancel_campaign") {
+      const { data, error } = await adminClient.rpc("admin_email_cancel_campaign", {
+        p_admin_user_id: admin.userId,
+        p_campaign_id: body.campaignId,
+      });
+      if (error) throw new RouteError(500, error.message);
+
+      await recordAuditLog(admin.userId, "admin_email_campaign_cancelled", "email_campaign", body.campaignId, {
+        cancelledQueuedMessages: data,
+      });
+      return json({ ok: true, cancelled: data });
+    }
+
+    const selectedAudience =
+      body.userIds.length + body.profileStatuses.length + body.plans.length + body.cities.length + body.states.length;
+    if (selectedAudience === 0) {
+      throw new RouteError(400, "Choose recipients or at least one audience filter.");
+    }
+    if (body.sendCategory === "transactional" && body.userIds.length === 0) {
+      throw new RouteError(400, "Transactional campaigns require explicitly selected recipients.");
+    }
+
+    const scheduledFor = body.scheduledFor || new Date().toISOString();
+    const { data, error } = await adminClient.rpc("admin_email_create_campaign", {
+      p_admin_user_id: admin.userId,
+      p_name: body.name,
+      p_subject: body.subject,
+      p_body_html: body.bodyHtml,
+      p_body_text: body.bodyText || null,
+      p_send_category: body.sendCategory,
+      p_from_address: body.fromAddress || null,
+      p_reply_to: body.replyTo || null,
+      p_scheduled_for: scheduledFor,
+      p_template_id: body.templateId || null,
+      p_user_ids: body.userIds,
+      p_profile_statuses: body.profileStatuses,
+      p_plans: body.plans,
+      p_cities: body.cities,
+      p_states: body.states,
+    });
+    if (error) throw new RouteError(500, error.message);
+
+    const result = data as Record<string, unknown>;
+    await recordAuditLog(admin.userId, "admin_email_campaign_created", "email_campaign", String(result.campaignId), {
+      name: body.name,
+      sendCategory: body.sendCategory,
+      scheduledFor,
+      total: result.total,
+      queued: result.queued,
+      suppressed: result.suppressed,
+    });
+
+    return json({ ok: true, campaign: result });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/supabase/migrations/20260804084500_admin_email_center_v2.sql
+++ b/supabase/migrations/20260804084500_admin_email_center_v2.sql
@@ -1,0 +1,392 @@
+-- Admin Email Center v2
+-- Durable campaigns/templates layered on the existing lifecycle queue.
+
+create table if not exists public.admin_email_templates (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  subject text not null,
+  body_html text not null,
+  body_text text,
+  send_category text not null default 'marketing' check (send_category in ('marketing', 'transactional')),
+  from_address text,
+  reply_to text,
+  is_active boolean not null default true,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.admin_email_campaigns (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  subject text not null,
+  body_html text not null,
+  body_text text,
+  send_category text not null check (send_category in ('marketing', 'transactional')),
+  from_address text,
+  reply_to text,
+  audience jsonb not null default '{}'::jsonb,
+  scheduled_for timestamptz not null default now(),
+  status text not null default 'draft' check (status in ('draft', 'scheduled', 'processing', 'completed', 'cancelled')),
+  template_id uuid references public.admin_email_templates(id) on delete set null,
+  created_by uuid references auth.users(id) on delete set null,
+  cancelled_by uuid references auth.users(id) on delete set null,
+  cancelled_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_admin_email_campaigns_created_at
+  on public.admin_email_campaigns(created_at desc);
+create index if not exists idx_admin_email_templates_updated_at
+  on public.admin_email_templates(updated_at desc);
+
+alter table public.admin_email_templates enable row level security;
+alter table public.admin_email_campaigns enable row level security;
+-- No direct client policies. All access is through admin-gated server routes.
+
+create or replace function public.admin_email_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_admin_email_templates_updated_at on public.admin_email_templates;
+create trigger trg_admin_email_templates_updated_at
+before update on public.admin_email_templates
+for each row execute function public.admin_email_touch_updated_at();
+
+drop trigger if exists trg_admin_email_campaigns_updated_at on public.admin_email_campaigns;
+create trigger trg_admin_email_campaigns_updated_at
+before update on public.admin_email_campaigns
+for each row execute function public.admin_email_touch_updated_at();
+
+create or replace function public.admin_email_center_snapshot(
+  p_query text default null,
+  p_limit integer default 250
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_query text := lower(trim(coalesce(p_query, '')));
+  v_limit integer := greatest(1, least(coalesce(p_limit, 250), 500));
+  v_result jsonb;
+begin
+  select jsonb_build_object(
+    'recipients', coalesce((
+      select jsonb_agg(row_to_json(r) order by r.updated_at desc)
+      from (
+        select
+          p.user_id as "userId",
+          p.id as "profileId",
+          coalesce(nullif(p.display_name, ''), nullif(p.full_name, ''), 'Provider') as name,
+          coalesce(u.email, p.email_address, p.email) as email,
+          p.city,
+          p.state,
+          p.profile_status as "profileStatus",
+          coalesce(p.subscription_tier, p._tier, 'free') as plan,
+          coalesce(mp.marketing_opt_in, true) as "marketingOptIn",
+          exists (
+            select 1 from public.email_suppressions es
+            where lower(es.email) = lower(coalesce(u.email, p.email_address, p.email, ''))
+              and es.is_active = true
+          ) as suppressed,
+          p.updated_at
+        from public.profiles p
+        left join auth.users u on u.id = p.user_id
+        left join public.marketing_preferences mp on mp.user_id = p.user_id
+        where p.user_id is not null
+          and coalesce(u.email, p.email_address, p.email) is not null
+          and (
+            v_query = '' or
+            lower(coalesce(p.display_name, '') || ' ' || coalesce(p.full_name, '') || ' ' ||
+              coalesce(u.email, p.email_address, p.email, '') || ' ' || coalesce(p.city, '') || ' ' ||
+              coalesce(p.state, '') || ' ' || coalesce(p.profile_status, '') || ' ' ||
+              coalesce(p.subscription_tier, p._tier, 'free')) like '%' || v_query || '%'
+          )
+        order by p.updated_at desc
+        limit v_limit
+      ) r
+    ), '[]'::jsonb),
+    'templates', coalesce((
+      select jsonb_agg(row_to_json(t) order by t.updated_at desc)
+      from (
+        select id, name, description, subject, body_html as "bodyHtml", body_text as "bodyText",
+          send_category as "sendCategory", from_address as "fromAddress", reply_to as "replyTo",
+          is_active as "isActive", created_at as "createdAt", updated_at as "updatedAt"
+        from public.admin_email_templates
+        where is_active = true
+        order by updated_at desc
+        limit 100
+      ) t
+    ), '[]'::jsonb),
+    'campaigns', coalesce((
+      select jsonb_agg(row_to_json(c) order by c.created_at desc)
+      from (
+        select
+          campaign.id,
+          campaign.name,
+          campaign.subject,
+          campaign.send_category as "sendCategory",
+          campaign.scheduled_for as "scheduledFor",
+          campaign.status,
+          campaign.created_at as "createdAt",
+          count(q.id)::int as total,
+          count(q.id) filter (where q.status = 'queued')::int as queued,
+          count(q.id) filter (where q.status = 'processing')::int as processing,
+          count(q.id) filter (where q.status = 'sent')::int as sent,
+          count(q.id) filter (where q.status = 'suppressed')::int as suppressed,
+          count(q.id) filter (where q.status = 'failed')::int as failed
+        from public.admin_email_campaigns campaign
+        left join public.lifecycle_email_queue q
+          on q.payload ->> 'campaign_id' = campaign.id::text
+        group by campaign.id
+        order by campaign.created_at desc
+        limit 50
+      ) c
+    ), '[]'::jsonb),
+    'summary', jsonb_build_object(
+      'sent30d', (select count(*) from public.lifecycle_email_log where status = 'sent' and created_at >= now() - interval '30 days'),
+      'failed30d', (select count(*) from public.lifecycle_email_log where status = 'failed' and created_at >= now() - interval '30 days'),
+      'suppressed30d', (select count(*) from public.lifecycle_email_log where status = 'suppressed' and created_at >= now() - interval '30 days'),
+      'complaints30d', (select count(*) from public.email_provider_events where event_type = 'complained' and created_at >= now() - interval '30 days')
+    )
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+create or replace function public.admin_email_save_template(
+  p_admin_user_id uuid,
+  p_id uuid,
+  p_name text,
+  p_description text,
+  p_subject text,
+  p_body_html text,
+  p_body_text text,
+  p_send_category text,
+  p_from_address text,
+  p_reply_to text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  if trim(coalesce(p_name, '')) = '' or trim(coalesce(p_subject, '')) = '' or trim(coalesce(p_body_html, '')) = '' then
+    raise exception 'Template name, subject and HTML body are required';
+  end if;
+  if p_send_category not in ('marketing', 'transactional') then
+    raise exception 'Invalid send category';
+  end if;
+
+  insert into public.admin_email_templates (
+    id, name, description, subject, body_html, body_text, send_category,
+    from_address, reply_to, created_by, updated_by
+  ) values (
+    coalesce(p_id, gen_random_uuid()), trim(p_name), nullif(trim(coalesce(p_description, '')), ''),
+    trim(p_subject), p_body_html, nullif(p_body_text, ''), p_send_category,
+    nullif(trim(coalesce(p_from_address, '')), ''), nullif(trim(coalesce(p_reply_to, '')), ''),
+    p_admin_user_id, p_admin_user_id
+  )
+  on conflict (id) do update set
+    name = excluded.name,
+    description = excluded.description,
+    subject = excluded.subject,
+    body_html = excluded.body_html,
+    body_text = excluded.body_text,
+    send_category = excluded.send_category,
+    from_address = excluded.from_address,
+    reply_to = excluded.reply_to,
+    updated_by = excluded.updated_by,
+    is_active = true
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+create or replace function public.admin_email_create_campaign(
+  p_admin_user_id uuid,
+  p_name text,
+  p_subject text,
+  p_body_html text,
+  p_body_text text,
+  p_send_category text,
+  p_from_address text,
+  p_reply_to text,
+  p_scheduled_for timestamptz,
+  p_template_id uuid,
+  p_user_ids uuid[],
+  p_profile_statuses text[],
+  p_plans text[],
+  p_cities text[],
+  p_states text[]
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_campaign_id uuid;
+  v_row record;
+  v_queue record;
+  v_total integer := 0;
+  v_queued integer := 0;
+  v_suppressed integer := 0;
+  v_scheduled_for timestamptz := coalesce(p_scheduled_for, now());
+begin
+  if trim(coalesce(p_name, '')) = '' or trim(coalesce(p_subject, '')) = '' or trim(coalesce(p_body_html, '')) = '' then
+    raise exception 'Campaign name, subject and HTML body are required';
+  end if;
+  if p_send_category not in ('marketing', 'transactional') then
+    raise exception 'Invalid send category';
+  end if;
+
+  insert into public.admin_email_campaigns (
+    name, subject, body_html, body_text, send_category, from_address, reply_to,
+    audience, scheduled_for, status, template_id, created_by
+  ) values (
+    trim(p_name), trim(p_subject), p_body_html, nullif(p_body_text, ''), p_send_category,
+    nullif(trim(coalesce(p_from_address, '')), ''), nullif(trim(coalesce(p_reply_to, '')), ''),
+    jsonb_build_object(
+      'userIds', coalesce(to_jsonb(p_user_ids), '[]'::jsonb),
+      'profileStatuses', coalesce(to_jsonb(p_profile_statuses), '[]'::jsonb),
+      'plans', coalesce(to_jsonb(p_plans), '[]'::jsonb),
+      'cities', coalesce(to_jsonb(p_cities), '[]'::jsonb),
+      'states', coalesce(to_jsonb(p_states), '[]'::jsonb)
+    ),
+    v_scheduled_for,
+    case when v_scheduled_for > now() then 'scheduled' else 'processing' end,
+    p_template_id,
+    p_admin_user_id
+  ) returning id into v_campaign_id;
+
+  for v_row in
+    select distinct on (p.user_id)
+      p.user_id,
+      coalesce(u.email, p.email_address, p.email) as email,
+      coalesce(nullif(p.display_name, ''), nullif(p.full_name, ''), 'there') as recipient_name,
+      p.city,
+      p.state,
+      p.profile_status,
+      coalesce(p.subscription_tier, p._tier, 'free') as plan
+    from public.profiles p
+    left join auth.users u on u.id = p.user_id
+    where p.user_id is not null
+      and coalesce(u.email, p.email_address, p.email) is not null
+      and (coalesce(array_length(p_user_ids, 1), 0) = 0 or p.user_id = any(p_user_ids))
+      and (coalesce(array_length(p_profile_statuses, 1), 0) = 0 or p.profile_status = any(p_profile_statuses))
+      and (coalesce(array_length(p_plans, 1), 0) = 0 or coalesce(p.subscription_tier, p._tier, 'free') = any(p_plans))
+      and (coalesce(array_length(p_cities, 1), 0) = 0 or p.city = any(p_cities))
+      and (coalesce(array_length(p_states, 1), 0) = 0 or p.state = any(p_states))
+    order by p.user_id, p.updated_at desc
+    limit 500
+  loop
+    v_total := v_total + 1;
+
+    select * into v_queue
+    from public.queue_lifecycle_email(
+      v_row.user_id,
+      v_row.email,
+      v_row.recipient_name,
+      'Admin Email Center',
+      'admin-' || v_campaign_id::text,
+      'admin_email_center',
+      coalesce(p_template_id::text, 'custom'),
+      p_send_category,
+      replace(replace(p_subject, '{{name}}', v_row.recipient_name), '{{city}}', coalesce(v_row.city, '')),
+      replace(replace(p_body_html, '{{name}}', v_row.recipient_name), '{{city}}', coalesce(v_row.city, '')),
+      case when p_body_text is null then null else replace(replace(p_body_text, '{{name}}', v_row.recipient_name), '{{city}}', coalesce(v_row.city, '')) end,
+      p_from_address,
+      p_reply_to,
+      jsonb_build_object(
+        'source', 'admin_email_center',
+        'campaign_id', v_campaign_id,
+        'profile_status', v_row.profile_status,
+        'plan', v_row.plan,
+        'city', v_row.city,
+        'state', v_row.state
+      ),
+      v_scheduled_for,
+      'admin-email:' || v_campaign_id::text || ':' || v_row.user_id::text
+    ) limit 1;
+
+    if v_queue.status = 'queued' then
+      v_queued := v_queued + 1;
+    else
+      v_suppressed := v_suppressed + 1;
+    end if;
+  end loop;
+
+  if v_total = 0 then
+    delete from public.admin_email_campaigns where id = v_campaign_id;
+    raise exception 'No eligible recipients matched the selected audience';
+  end if;
+
+  update public.admin_email_campaigns
+  set status = case
+    when v_queued = 0 then 'completed'
+    when v_scheduled_for > now() then 'scheduled'
+    else 'processing'
+  end
+  where id = v_campaign_id;
+
+  return jsonb_build_object(
+    'campaignId', v_campaign_id,
+    'total', v_total,
+    'queued', v_queued,
+    'suppressed', v_suppressed
+  );
+end;
+$$;
+
+create or replace function public.admin_email_cancel_campaign(
+  p_admin_user_id uuid,
+  p_campaign_id uuid
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_cancelled integer;
+begin
+  update public.lifecycle_email_queue
+  set status = 'skipped', suppression_reason = 'campaign_cancelled'
+  where payload ->> 'campaign_id' = p_campaign_id::text
+    and status = 'queued';
+  get diagnostics v_cancelled = row_count;
+
+  update public.admin_email_campaigns
+  set status = 'cancelled', cancelled_by = p_admin_user_id, cancelled_at = now()
+  where id = p_campaign_id;
+
+  return v_cancelled;
+end;
+$$;
+
+revoke all on function public.admin_email_center_snapshot(text, integer) from public, anon, authenticated;
+revoke all on function public.admin_email_save_template(uuid, uuid, text, text, text, text, text, text, text, text) from public, anon, authenticated;
+revoke all on function public.admin_email_create_campaign(uuid, text, text, text, text, text, text, text, timestamptz, uuid, uuid[], text[], text[], text[], text[]) from public, anon, authenticated;
+revoke all on function public.admin_email_cancel_campaign(uuid, uuid) from public, anon, authenticated;
+
+grant execute on function public.admin_email_center_snapshot(text, integer) to service_role;
+grant execute on function public.admin_email_save_template(uuid, uuid, text, text, text, text, text, text, text, text) to service_role;
+grant execute on function public.admin_email_create_campaign(uuid, text, text, text, text, text, text, text, timestamptz, uuid, uuid[], text[], text[], text[], text[]) to service_role;
+grant execute on function public.admin_email_cancel_campaign(uuid, uuid) to service_role;


### PR DESCRIPTION
## Summary

Builds the complete Admin Email Center on top of the existing lifecycle email queue instead of sending bulk mail directly from a browser request.

## Included

- New `/admin/emails` dashboard and admin navigation entry
- Recipient search and filters by profile status, plan, city, and state
- Explicit recipient selection or filtered audience campaigns
- Marketing vs transactional campaign controls
- Saved reusable templates
- HTML and plain-text content
- `{{name}}` and `{{city}}` personalization
- Immediate or scheduled campaigns
- Campaign cancellation for queued messages
- Campaign history with queued, processing, sent, suppressed, and failed counts
- 30-day send, failure, suppression, and complaint metrics
- Admin audit logging for campaign, template, and cancellation actions

## Deliverability and compliance

- Uses `lifecycle_email_queue` and the existing Resend worker
- Marketing sends pass through `queue_lifecycle_email`
- Honors marketing preferences, suppressions, unsubscribe status, cooldowns, monthly caps, holiday blackout, and complaint threshold
- Transactional bulk sends require explicit recipients
- RPCs are service-role only; browser clients cannot access campaign tables directly
- Maximum audience size is 500 per campaign
- Idempotency keys prevent duplicate queue entries

## Database

Adds:

- `admin_email_templates`
- `admin_email_campaigns`
- `admin_email_center_snapshot()`
- `admin_email_save_template()`
- `admin_email_create_campaign()`
- `admin_email_cancel_campaign()`

Migration: `20260804084500_admin_email_center_v2.sql`

## Files

- `src/app/admin/emails/page.tsx`
- `src/app/admin/emails/AdminEmailCenter.tsx`
- `src/app/api/admin/emails/route.ts`
- `src/app/admin/_components/AdminSidebar.tsx`
- `supabase/migrations/20260804084500_admin_email_center_v2.sql`

## Validation required

- CI/typecheck/lint/build
- Supabase migration application
- Admin auth smoke test
- Marketing suppression and unsubscribe smoke test
- Scheduled queue processing test
- Resend sender-domain verification for configured From addresses
