### PR TITLE
Fix MM audit findings and integrate unmerged admin work

### DIFF
--- a/scripts/validate-db-contract.mjs
+++ b/scripts/validate-db-contract.mjs
@@ -193,10 +193,10 @@ function parseSchemaContract(sql) {
     }
   }
 
-  // CREATE [OR REPLACE] VIEW [schema.]view AS SELECT col1, col2, ...
+  // CREATE [OR REPLACE] VIEW [schema.]view [WITH (...)] AS SELECT col1, col2, ...
   // Register views so code that queries them doesn't trigger "missing table" errors.
   const createViewRegex = new RegExp(
-    `create\\s+(?:or\\s+replace\\s+)?(?:materialized\\s+)?view\\s+(?:if\\s+not\\s+exists\\s+)?(${TABLE_REF})\\s+as\\s+select\\s+([\\s\\S]*?)(?:from\\s|;)`,
+    `create\\s+(?:or\\s+replace\\s+)?(?:materialized\\s+)?view\\s+(?:if\\s+not\\s+exists\\s+)?(${TABLE_REF})(?:\\s+with\\s*\\([^;]*?\\))?\\s+as\\s+select\\s+([\\s\\S]*?)(?:from\\s|;)`,
     "gi"
   );
   let viewMatch;
@@ -206,7 +206,10 @@ function parseSchemaContract(sql) {
     // Extract column aliases from the SELECT list so column-level checks pass too.
     const selectList = viewMatch[2];
     for (const part of selectList.split(",")) {
-      const col = part.trim().replace(/\s+as\s+\S+$/, "").split(".").pop()?.trim().replace(/[^a-z0-9_]/gi, "");
+      const alias = part.trim().match(new RegExp(`\\s+as\\s+(${IDENT_TOKEN})\\s*$`, "i"))?.[1];
+      const col = alias
+        ? extractColumnName(alias)
+        : part.trim().split(".").pop()?.trim().replace(/[^a-z0-9_]/gi, "");
       if (col) addColumn(contract, table, col.toLowerCase());
     }
   }

--- a/src/app/_lib/directory.ts
+++ b/src/app/_lib/directory.ts
@@ -5,6 +5,7 @@ import { createClient as createSupabaseJsClient } from "@supabase/supabase-js";
 
 import { US_CITIES } from "@/data/cities";
 import { getTravelVisit } from "@/app/_lib/travel-status";
+import { getProfileIndexRobots } from "@/lib/index-eligibility";
 import { matchBodyTypeKeyword } from "@/lib/physical-profile";
 import { FALLBACK_PUBLIC_THERAPISTS } from "@/app/_lib/directory-fallback";
 import { PUBLIC_THERAPISTS_TAG } from "@/app/_lib/directory-cache";
@@ -62,7 +63,7 @@ const PUBLIC_PROFILE_SELECT = `
   years_experience, start_year, languages,
   subscription_tier, _tier, verification_status, is_featured,
   is_verified_identity, is_verified_profile,
-  avatar_url, review_count,
+  avatar_url, review_count, average_rating,
   promotions, updated_at, status, profile_status, visibility_status,
   is_suspended, is_banned, available_now, available_now_expires,
   lgbtq_affirming, business_hours, custom_faq, pricing_sessions, areas_served,
@@ -168,6 +169,7 @@ export interface PublicTherapist {
   start_year?: number | null;
   avatar_url?: string | null;
   review_count?: number | null;
+  average_rating?: number | null;
   _tier?: string | null;
   neighborhood_name?: string | null;
   primary_area?: string | null;
@@ -192,12 +194,13 @@ export interface PublicTherapist {
   identity_verified_at?: string | null;
 }
 
-interface ImportedReview {
+export interface PublicImportedReview {
   id: string;
   review_text: string;
   rating: number | null;
   reviewer_name: string | null;
   review_date: string | null;
+  public_label: string | null;
 }
 
 export const getCities = () => US_CITIES;
@@ -237,9 +240,9 @@ const isRoutableProfile = (p: PublicTherapist) =>
   (typeof p.slug === "string" && p.slug.length > 0) || (typeof p.id === "string" && UUID_RE.test(p.id));
 
 // Slugs for the sitemap, sourced from the SAME query that serves the public
-// profile route (`getPublicTherapistBySlug`). This guarantees every profile URL
-// in the sitemap actually resolves (no 404s) and every resolvable profile is
-// included — the two must never disagree. Real DB rows only; no demo fallback.
+// profile route (`getPublicTherapistBySlug`). Every sitemap URL must both
+// resolve and carry an indexable robots directive. Real DB rows only; no demo
+// fallback.
 // Missing slugs are filtered here (the sitemap-specific path) rather than in the
 // shared query, so slugless-but-UUID-routable profiles still appear in the
 // directory. Pages through all results so completeness holds beyond one page.
@@ -252,7 +255,11 @@ export const getSitemapProfileSlugs = async (): Promise<Array<{ slug: string; up
       .range(from, from + PAGE - 1);
     if (error || !data || data.length === 0) break;
     for (const row of data as unknown as PublicTherapist[]) {
-      if (typeof row.slug === "string" && row.slug.length > 0) {
+      if (
+        typeof row.slug === "string" &&
+        row.slug.length > 0 &&
+        getProfileIndexRobots(row) === "index, follow"
+      ) {
         out.push({ slug: row.slug, updated_at: row.updated_at ?? null });
       }
     }
@@ -537,17 +544,30 @@ export const getPublicTherapistBySlug = async (slug: string): Promise<PublicTher
   ) ?? null;
 };
 
-const getImportedReviews = async (profileId: string, limit = 5) => {
-  if (!isUuid(profileId)) return [] as ImportedReview[];
+export const getPublicImportedReviews = async (
+  profileId: string,
+  limit = 100,
+): Promise<PublicImportedReview[]> => {
+  if (!isUuid(profileId)) return [];
 
-  const { data } = await supabase
-    .from("imported_reviews")
-    .select("id, review_text, rating, reviewer_name, review_date")
+  const { data, error } = await supabase
+    .from("public_imported_reviews")
+    .select("id, review_text, rating, reviewer_name, review_date, public_label")
     .eq("profile_id", profileId)
+    .not("review_text", "is", null)
     .order("review_date", { ascending: false, nullsFirst: false })
-    .limit(limit);
+    .limit(Math.max(1, Math.min(limit, 100)));
 
-  return (data || []) as unknown as ImportedReview[];
+  if (error || !data) return [];
+
+  return data
+    .filter(
+      (review): review is typeof review & { id: string; review_text: string } =>
+        typeof review.id === "string" &&
+        typeof review.review_text === "string" &&
+        review.review_text.trim().length > 0,
+    )
+    .map((review) => ({ ...review, review_text: review.review_text.trim() }));
 };
 
 // Resolves the displayable image URL for a profile_photos row. The live

--- a/src/app/_lib/profile-metadata.ts
+++ b/src/app/_lib/profile-metadata.ts
@@ -34,7 +34,9 @@ export function getProfileRobotsMetadata(
  * Important for SEO to prevent duplicate content issues.
  */
 export function getProfileCanonicalUrl(slug: string, siteUrl: string): string {
-  return `${siteUrl}/therapists/${slug}`;
+  const normalizedSiteUrl = siteUrl.replace(/\/+$/, "");
+  const normalizedSlug = slug.replace(/^\/+|\/+$/g, "");
+  return `${normalizedSiteUrl}/therapists/${normalizedSlug}`;
 }
 
 /**

--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -24,6 +24,9 @@ import {
   CalendarCheck,
   MessageSquare,
   Flag,
+  Grid3X3,
+  Mail,
+  Workflow,
 } from "lucide-react";
 
 const navSections = [
@@ -31,6 +34,7 @@ const navSections = [
     title: "Overview",
     items: [
       { href: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
+      { href: "/admin/tools", label: "All Tools", icon: Grid3X3 },
       { href: "/admin/people", label: "People CRM", icon: Users },
       { href: "/admin/photos", label: "Photo Approvals", icon: ImageIcon },
       { href: "/admin/moderation", label: "Approvals", icon: ShieldAlert },
@@ -40,10 +44,12 @@ const navSections = [
   {
     title: "Communication",
     items: [
+      { href: "/admin/emails", label: "Email Center", icon: Mail },
       { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
       { href: "/admin/support", label: "Support", icon: LifeBuoy },
       { href: "/admin/bookings", label: "Bookings", icon: CalendarCheck },
       { href: "/admin/sms", label: "SMS Auto-Reply", icon: MessageSquare },
+      { href: "/admin/migrations", label: "Profile Imports", icon: Workflow },
     ],
   },
   {

--- a/src/app/admin/emails/AdminEmailCenter.tsx
+++ b/src/app/admin/emails/AdminEmailCenter.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  FileText,
+  Loader2,
+  Mail,
+  RefreshCw,
+  Save,
+  Search,
+  Send,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
+
+type Recipient = {
+  userId: string;
+  profileId: string;
+  name: string;
+  email: string;
+  city: string | null;
+  state: string | null;
+  profileStatus: string | null;
+  plan: string | null;
+  marketingOptIn: boolean;
+  suppressed: boolean;
+};
+
+type Template = {
+  id: string;
+  name: string;
+  description: string | null;
+  subject: string;
+  bodyHtml: string;
+  bodyText: string | null;
+  sendCategory: "marketing" | "transactional";
+  fromAddress: string | null;
+  replyTo: string | null;
+};
+
+type Campaign = {
+  id: string;
+  name: string;
+  subject: string;
+  sendCategory: string;
+  scheduledFor: string;
+  status: string;
+  createdAt: string;
+  total: number;
+  queued: number;
+  processing: number;
+  sent: number;
+  suppressed: number;
+  failed: number;
+};
+
+type Snapshot = {
+  recipients: Recipient[];
+  templates: Template[];
+  campaigns: Campaign[];
+  summary: { sent30d: number; failed30d: number; suppressed30d: number; complaints30d: number };
+};
+
+const DEFAULT_HTML = `<p>Hi {{name}},</p>
+<p>We have an update for your MasseurMatch profile.</p>
+<p><a href="https://www.masseurmatch.com/pro/dashboard">Open your dashboard</a></p>
+<p>Best,<br />MasseurMatch</p>`;
+
+const EMPTY_SNAPSHOT: Snapshot = {
+  recipients: [],
+  templates: [],
+  campaigns: [],
+  summary: { sent30d: 0, failed30d: 0, suppressed30d: 0, complaints30d: 0 },
+};
+
+async function api<T>(options: RequestInit = {}, query = ""): Promise<T> {
+  const response = await fetch(`/api/admin/emails${query}`, {
+    credentials: "include",
+    ...options,
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body.error || "Email Center request failed.");
+  return body as T;
+}
+
+function unique(values: Array<string | null>) {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value)))).sort();
+}
+
+export default function AdminEmailCenter() {
+  const [snapshot, setSnapshot] = useState<Snapshot>(EMPTY_SNAPSHOT);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [notice, setNotice] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const [campaignName, setCampaignName] = useState("");
+  const [subject, setSubject] = useState("");
+  const [bodyHtml, setBodyHtml] = useState(DEFAULT_HTML);
+  const [bodyText, setBodyText] = useState("");
+  const [sendCategory, setSendCategory] = useState<"marketing" | "transactional">("marketing");
+  const [fromAddress, setFromAddress] = useState("MasseurMatch Updates <updates@updates.masseurmatch.com>");
+  const [replyTo, setReplyTo] = useState("support@masseurmatch.com");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [templateId, setTemplateId] = useState("");
+  const [profileStatus, setProfileStatus] = useState("");
+  const [plan, setPlan] = useState("");
+  const [city, setCity] = useState("");
+  const [state, setState] = useState("");
+
+  const load = useCallback(async (search = "") => {
+    setLoading(true);
+    try {
+      const data = await api<{ ok: true } & Snapshot>({}, search ? `?q=${encodeURIComponent(search)}` : "");
+      setSnapshot({
+        recipients: data.recipients || [],
+        templates: data.templates || [],
+        campaigns: data.campaigns || [],
+        summary: data.summary || EMPTY_SNAPSHOT.summary,
+      });
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Unable to load Email Center." });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const recipients = useMemo(() => {
+    return snapshot.recipients.filter((recipient) => {
+      if (profileStatus && recipient.profileStatus !== profileStatus) return false;
+      if (plan && recipient.plan !== plan) return false;
+      if (city && recipient.city !== city) return false;
+      if (state && recipient.state !== state) return false;
+      return true;
+    });
+  }, [snapshot.recipients, profileStatus, plan, city, state]);
+
+  const selectedRecipients = useMemo(
+    () => snapshot.recipients.filter((recipient) => selected.includes(recipient.userId)),
+    [snapshot.recipients, selected],
+  );
+  const blockedSelected = selectedRecipients.filter((recipient) => recipient.suppressed || !recipient.marketingOptIn).length;
+  const statuses = unique(snapshot.recipients.map((recipient) => recipient.profileStatus));
+  const plans = unique(snapshot.recipients.map((recipient) => recipient.plan));
+  const cities = unique(snapshot.recipients.map((recipient) => recipient.city));
+  const states = unique(snapshot.recipients.map((recipient) => recipient.state));
+
+  const toggle = (userId: string) => {
+    setSelected((current) =>
+      current.includes(userId) ? current.filter((id) => id !== userId) : [...current, userId],
+    );
+  };
+
+  const selectVisible = () => {
+    setSelected((current) => Array.from(new Set([...current, ...recipients.map((recipient) => recipient.userId)])));
+  };
+
+  const applyTemplate = (id: string) => {
+    setTemplateId(id);
+    const template = snapshot.templates.find((item) => item.id === id);
+    if (!template) return;
+    setSubject(template.subject);
+    setBodyHtml(template.bodyHtml);
+    setBodyText(template.bodyText || "");
+    setSendCategory(template.sendCategory);
+    setFromAddress(template.fromAddress || fromAddress);
+    setReplyTo(template.replyTo || replyTo);
+  };
+
+  const saveTemplate = async () => {
+    setSaving(true);
+    setNotice(null);
+    try {
+      const data = await api<{ ok: true; templateId: string }>({
+        method: "POST",
+        body: JSON.stringify({
+          action: "save_template",
+          id: templateId || null,
+          name: campaignName || subject || "Email template",
+          description: "Saved from the Admin Email Center",
+          subject,
+          bodyHtml,
+          bodyText: bodyText || null,
+          sendCategory,
+          fromAddress,
+          replyTo,
+        }),
+      });
+      setTemplateId(data.templateId);
+      setNotice({ ok: true, text: "Template saved." });
+      await load(query);
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Template save failed." });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const createCampaign = async () => {
+    setSending(true);
+    setNotice(null);
+    try {
+      const data = await api<{ campaign: { total: number; queued: number; suppressed: number } }>({
+        method: "POST",
+        body: JSON.stringify({
+          action: "create_campaign",
+          name: campaignName,
+          subject,
+          bodyHtml,
+          bodyText: bodyText || null,
+          sendCategory,
+          fromAddress,
+          replyTo,
+          scheduledFor: scheduledFor ? new Date(scheduledFor).toISOString() : null,
+          templateId: templateId || null,
+          userIds: selected,
+          profileStatuses: profileStatus ? [profileStatus] : [],
+          plans: plan ? [plan] : [],
+          cities: city ? [city] : [],
+          states: state ? [state] : [],
+        }),
+      });
+      setNotice({
+        ok: true,
+        text: `Campaign created: ${data.campaign.queued} queued, ${data.campaign.suppressed} suppressed, ${data.campaign.total} matched.`,
+      });
+      setSelected([]);
+      await load(query);
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Campaign creation failed." });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const cancelCampaign = async (campaignId: string) => {
+    try {
+      const data = await api<{ cancelled: number }>({
+        method: "POST",
+        body: JSON.stringify({ action: "cancel_campaign", campaignId }),
+      });
+      setNotice({ ok: true, text: `Campaign cancelled. ${data.cancelled} queued messages were stopped.` });
+      await load(query);
+    } catch (error) {
+      setNotice({ ok: false, text: error instanceof Error ? error.message : "Campaign cancellation failed." });
+    }
+  };
+
+  const hasAudience = sendCategory === "transactional"
+    ? selected.length > 0
+    : selected.length > 0 || Boolean(profileStatus || plan || city || state);
+  const canSend = Boolean(campaignName.trim() && subject.trim() && bodyHtml.trim() && hasAudience && !sending);
+  const previewHtml = bodyHtml.replaceAll("{{name}}", "Bruno").replaceAll("{{city}}", "Dallas");
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Metric label="Sent · 30 days" value={snapshot.summary.sent30d} icon={CheckCircle2} />
+        <Metric label="Failed · 30 days" value={snapshot.summary.failed30d} icon={XCircle} />
+        <Metric label="Suppressed · 30 days" value={snapshot.summary.suppressed30d} icon={ShieldCheck} />
+        <Metric label="Complaints · 30 days" value={snapshot.summary.complaints30d} icon={AlertTriangle} />
+      </div>
+
+      {notice ? (
+        <div className={`rounded-2xl border p-4 text-sm ${notice.ok ? "border-emerald-200 bg-emerald-50 text-emerald-800" : "border-red-200 bg-red-50 text-red-800"}`}>
+          {notice.text}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 2xl:grid-cols-[390px_minmax(0,1fr)]">
+        <section className="overflow-hidden rounded-2xl border border-border bg-white shadow-sm">
+          <div className="border-b border-border p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="font-semibold text-slate-900">Audience</h2>
+                <p className="text-sm text-muted-foreground">{selected.length} explicitly selected</p>
+              </div>
+              <button type="button" onClick={selectVisible} className="text-sm font-semibold text-brand-secondary hover:underline">
+                Select visible
+              </button>
+            </div>
+            <div className="relative mt-4">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => event.key === "Enter" && void load(query)}
+                placeholder="Search people..."
+                className="w-full rounded-xl border border-slate-200 py-2.5 pl-9 pr-12 text-sm outline-none focus:border-brand-secondary"
+              />
+              <button type="button" onClick={() => void load(query)} className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg p-1.5 text-slate-500 hover:bg-slate-100">
+                <RefreshCw className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <Filter value={profileStatus} onChange={setProfileStatus} label="All statuses" values={statuses} />
+              <Filter value={plan} onChange={setPlan} label="All plans" values={plans} />
+              <Filter value={city} onChange={setCity} label="All cities" values={cities} />
+              <Filter value={state} onChange={setState} label="All states" values={states} />
+            </div>
+          </div>
+          <div className="max-h-[720px] overflow-y-auto p-2">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 p-10 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading audience</div>
+            ) : recipients.length === 0 ? (
+              <div className="p-10 text-center text-sm text-muted-foreground">No recipients match these filters.</div>
+            ) : recipients.map((recipient) => (
+              <label key={recipient.userId} className="flex cursor-pointer gap-3 rounded-xl p-3 hover:bg-slate-50">
+                <input type="checkbox" checked={selected.includes(recipient.userId)} onChange={() => toggle(recipient.userId)} className="mt-1 h-4 w-4 rounded border-slate-300" />
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-2">
+                    <span className="truncate text-sm font-semibold text-slate-900">{recipient.name}</span>
+                    {recipient.suppressed || !recipient.marketingOptIn ? <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" /> : null}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">{recipient.email}</span>
+                  <span className="block text-xs text-slate-400">{recipient.city || "No city"} · {recipient.profileStatus || "draft"} · {recipient.plan || "free"}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </section>
+
+        <div className="space-y-6">
+          <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+            <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="rounded-xl bg-brand-secondary/10 p-2.5 text-brand-secondary"><Mail className="h-5 w-5" /></div>
+                <div><h2 className="font-semibold text-slate-900">Campaign composer</h2><p className="text-sm text-muted-foreground">Queued through the compliant lifecycle delivery system.</p></div>
+              </div>
+              <select value={templateId} onChange={(event) => applyTemplate(event.target.value)} className="rounded-xl border border-slate-200 px-3 py-2 text-sm">
+                <option value="">Start without template</option>
+                {snapshot.templates.map((template) => <option key={template.id} value={template.id}>{template.name}</option>)}
+              </select>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field label="Campaign name"><input value={campaignName} onChange={(e) => setCampaignName(e.target.value)} placeholder="August profile update" className="input" /></Field>
+              <Field label="Category"><select value={sendCategory} onChange={(e) => setSendCategory(e.target.value as "marketing" | "transactional")} className="input"><option value="marketing">Marketing</option><option value="transactional">Transactional</option></select></Field>
+              <Field label="From"><input value={fromAddress} onChange={(e) => setFromAddress(e.target.value)} className="input" /></Field>
+              <Field label="Reply-to"><input value={replyTo} onChange={(e) => setReplyTo(e.target.value)} className="input" /></Field>
+            </div>
+            <Field label="Subject"><input value={subject} onChange={(e) => setSubject(e.target.value)} placeholder="A quick update for {{name}}" className="input" /></Field>
+            <Field label="HTML content"><textarea value={bodyHtml} onChange={(e) => setBodyHtml(e.target.value)} rows={13} className="input font-mono text-sm" /></Field>
+            <Field label="Plain-text fallback"><textarea value={bodyText} onChange={(e) => setBodyText(e.target.value)} rows={4} className="input" placeholder="Optional. The worker can derive a fallback when omitted." /></Field>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field label="Schedule"><input type="datetime-local" value={scheduledFor} onChange={(e) => setScheduledFor(e.target.value)} className="input" /></Field>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+                <p className="font-semibold text-slate-900">Audience summary</p>
+                <p>{selected.length} selected · {recipients.length} visible by filters</p>
+                {selected.length > 0 ? <p className="mt-1 text-slate-500">Explicit selections override audience filters when sent.</p> : null}
+                {blockedSelected > 0 ? <p className="mt-1 text-amber-700">{blockedSelected} selected contacts may be suppressed automatically.</p> : null}
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs text-muted-foreground">Variables: <code>{"{{name}}"}</code> and <code>{"{{city}}"}</code>. Marketing sends enforce opt-out, cooldown, suppression and unsubscribe rules.</p>
+              <div className="flex gap-2">
+                <button type="button" onClick={() => void saveTemplate()} disabled={saving || !subject || !bodyHtml} className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-700 disabled:opacity-50">
+                  {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />} Save template
+                </button>
+                <button type="button" onClick={() => void createCampaign()} disabled={!canSend} className="inline-flex items-center gap-2 rounded-xl bg-brand-secondary px-5 py-2.5 text-sm font-semibold text-white disabled:opacity-50">
+                  {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : scheduledFor ? <CalendarClock className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+                  {scheduledFor ? "Schedule campaign" : "Queue campaign"}
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+            <h2 className="mb-4 font-semibold text-slate-900">Preview</h2>
+            <div className="overflow-hidden rounded-xl border border-slate-200">
+              <div className="border-b border-slate-200 bg-slate-50 px-5 py-3 text-sm"><strong>Subject:</strong> {(subject || "No subject").replaceAll("{{name}}", "Bruno").replaceAll("{{city}}", "Dallas")}</div>
+              <iframe
+                title="Email HTML preview"
+                sandbox=""
+                srcDoc={previewHtml}
+                className="min-h-[360px] w-full bg-white"
+              />
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <section className="rounded-2xl border border-border bg-white p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-3"><FileText className="h-5 w-5 text-brand-secondary" /><div><h2 className="font-semibold text-slate-900">Campaign history</h2><p className="text-sm text-muted-foreground">Live queue totals from the lifecycle email system.</p></div></div>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[900px] text-left text-sm">
+            <thead className="border-b border-slate-200 text-xs uppercase text-slate-500"><tr><th className="px-3 py-3">Campaign</th><th className="px-3 py-3">Status</th><th className="px-3 py-3">Scheduled</th><th className="px-3 py-3">Total</th><th className="px-3 py-3">Queued</th><th className="px-3 py-3">Sent</th><th className="px-3 py-3">Suppressed</th><th className="px-3 py-3">Failed</th><th className="px-3 py-3">Action</th></tr></thead>
+            <tbody className="divide-y divide-slate-100">
+              {snapshot.campaigns.length === 0 ? <tr><td colSpan={9} className="px-3 py-10 text-center text-muted-foreground">No campaigns yet.</td></tr> : snapshot.campaigns.map((campaign) => (
+                <tr key={campaign.id}><td className="px-3 py-4"><p className="font-semibold text-slate-900">{campaign.name}</p><p className="max-w-xs truncate text-xs text-muted-foreground">{campaign.subject}</p></td><td className="px-3 py-4"><span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold capitalize">{campaign.status}</span></td><td className="px-3 py-4 text-slate-600">{new Date(campaign.scheduledFor).toLocaleString()}</td><td className="px-3 py-4">{campaign.total}</td><td className="px-3 py-4">{campaign.queued + campaign.processing}</td><td className="px-3 py-4 text-emerald-700">{campaign.sent}</td><td className="px-3 py-4 text-amber-700">{campaign.suppressed}</td><td className="px-3 py-4 text-red-700">{campaign.failed}</td><td className="px-3 py-4">{["scheduled", "processing"].includes(campaign.status) && campaign.queued > 0 ? <button type="button" onClick={() => void cancelCampaign(campaign.id)} className="text-xs font-semibold text-red-700 hover:underline">Cancel queued</button> : <span className="text-xs text-slate-400">—</span>}</td></tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <style jsx>{`
+        :global(.input) { width: 100%; border-radius: 0.75rem; border: 1px solid rgb(226 232 240); padding: 0.625rem 0.75rem; font-weight: 400; outline: none; }
+        :global(.input:focus) { border-color: var(--brand-secondary, #8b1e2d); }
+      `}</style>
+    </div>
+  );
+}
+
+function Metric({ label, value, icon: Icon }: { label: string; value: number; icon: typeof Mail }) {
+  return <div className="rounded-2xl border border-border bg-white p-5 shadow-sm"><div className="flex items-center justify-between"><div><p className="text-sm text-muted-foreground">{label}</p><p className="mt-1 text-2xl font-bold text-slate-900">{value}</p></div><div className="rounded-xl bg-slate-100 p-2.5 text-slate-600"><Icon className="h-5 w-5" /></div></div></div>;
+}
+
+function Filter({ value, onChange, label, values }: { value: string; onChange: (value: string) => void; label: string; values: string[] }) {
+  return <select value={value} onChange={(event) => onChange(event.target.value)} className="rounded-xl border border-slate-200 px-2.5 py-2 text-xs"><option value="">{label}</option>{values.map((item) => <option key={item} value={item}>{item}</option>)}</select>;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return <label className="mt-4 block space-y-1.5 text-sm font-medium text-slate-700"><span>{label}</span>{children}</label>;
+}

--- a/src/app/admin/emails/page.tsx
+++ b/src/app/admin/emails/page.tsx
@@ -1,0 +1,17 @@
+import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+import AdminEmailCenter from "./AdminEmailCenter";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default function AdminEmailsPage() {
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="Email Center"
+        description="Build compliant campaigns, save templates, schedule delivery, and monitor the Resend lifecycle queue."
+      />
+      <AdminEmailCenter />
+    </div>
+  );
+}

--- a/src/app/admin/migrations/page.tsx
+++ b/src/app/admin/migrations/page.tsx
@@ -59,9 +59,8 @@ export default function AdminMigrationsPage() {
       const migration = migrations.find((m) => m.id === migrationId);
       if (!migration) return;
 
-      const reviewsToApprove = migration.reviews
-        ?.filter((r) => approvalStatus[r.id] !== false)
-        .map((r) => ({
+      const reviewDecisions = migration.reviews
+        ?.map((r) => ({
           reviewId: r.id,
           approved: approvalStatus[r.id] !== false,
           notes: reviewNotes[r.id] || "",
@@ -72,7 +71,7 @@ export default function AdminMigrationsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           migrationId,
-          reviews: reviewsToApprove,
+          reviews: reviewDecisions,
         }),
       });
 
@@ -81,7 +80,7 @@ export default function AdminMigrationsPage() {
       }
 
       // Refresh migrations
-      fetchMigrations();
+      await fetchMigrations();
       setSelectedMigration(null);
       setReviewNotes({});
       setApprovalStatus({});
@@ -128,7 +127,7 @@ export default function AdminMigrationsPage() {
                     <p className="text-sm text-[#8E8E8E]">{migration.platform}</p>
                   </div>
                   {migration.is_verified ? (
-                    <Badge className="bg-green-100 text-green-800">Approved</Badge>
+                    <Badge className="bg-green-100 text-green-800">Reviewed</Badge>
                   ) : (
                     <Badge variant="outline" className="border-yellow-400 bg-yellow-50 text-yellow-800">
                       Pending

--- a/src/app/admin/people/PeopleCrm.tsx
+++ b/src/app/admin/people/PeopleCrm.tsx
@@ -1,7 +1,27 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Check, ExternalLink, ImageIcon, KeyRound, RefreshCw, Search, Star, Trash2, UserRound, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  AlertTriangle,
+  BadgeCheck,
+  Ban,
+  Check,
+  ChevronRight,
+  ExternalLink,
+  ImageIcon,
+  KeyRound,
+  MoreHorizontal,
+  RefreshCw,
+  Search,
+  Shield,
+  Star,
+  Trash2,
+  UserCheck,
+  UserRound,
+  Users,
+  X,
+} from "lucide-react";
 
 import { postJson } from "@/app/_lib/client-api";
 import { Button } from "@/components/ui/button";
@@ -9,127 +29,359 @@ import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
 import type { AdminPerson } from "./loadPeople";
 
+type StatusFilter = "all" | "approved" | "pending" | "suspended" | "banned";
+type PlanFilter = "all" | "free" | "standard" | "pro" | "elite";
+
+type AccountAction = "deactivate" | "reactivate" | "delete";
+
+const planOptions = ["free", "standard", "pro", "elite"] as const;
+
+function statusTone(status: string) {
+  if (status === "approved") return "bg-emerald-50 text-emerald-700 ring-emerald-200";
+  if (status.includes("pending")) return "bg-amber-50 text-amber-700 ring-amber-200";
+  if (status === "rejected") return "bg-rose-50 text-rose-700 ring-rose-200";
+  return "bg-slate-100 text-slate-700 ring-slate-200";
+}
+
+function planTone(plan: string | null) {
+  if (plan === "elite") return "bg-amber-100 text-amber-800";
+  if (plan === "pro") return "bg-indigo-100 text-indigo-800";
+  if (plan === "standard") return "bg-sky-100 text-sky-800";
+  return "bg-slate-100 text-slate-700";
+}
+
 export default function PeopleCrm({ people }: { people: AdminPerson[] }) {
+  const router = useRouter();
   const { toast } = useToast();
   const [search, setSearch] = useState("");
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [planFilter, setPlanFilter] = useState<PlanFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(people[0]?.profileId ?? null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [deleteConfirmation, setDeleteConfirmation] = useState("");
+  const [dangerReason, setDangerReason] = useState("");
+  const [reviewReason, setReviewReason] = useState("");
+  const [showDanger, setShowDanger] = useState(false);
+
+  const selected = people.find((person) => person.profileId === selectedId) ?? null;
+
+  const stats = useMemo(() => ({
+    total: people.length,
+    approved: people.filter((person) => person.profileStatus === "approved").length,
+    pending: people.filter((person) => person.profileStatus.includes("pending")).length,
+    restricted: people.filter((person) => person.isSuspended || person.isBanned).length,
+  }), [people]);
 
   const filtered = useMemo(() => {
     const query = search.trim().toLowerCase();
-    if (!query) return people;
-    return people.filter((person) =>
-      [person.name, person.email, person.city, person.role, person.profileStatus, person.subscriptionTier, person.userId]
-        .filter(Boolean)
-        .some((value) => String(value).toLowerCase().includes(query)),
+    return people.filter((person) => {
+      const matchesSearch = !query || [
+        person.name,
+        person.email,
+        person.city,
+        person.role,
+        person.profileStatus,
+        person.subscriptionTier,
+        person.userId,
+        person.profileId,
+      ].filter(Boolean).some((value) => String(value).toLowerCase().includes(query));
+
+      const matchesStatus = statusFilter === "all"
+        || (statusFilter === "suspended" && person.isSuspended)
+        || (statusFilter === "banned" && person.isBanned)
+        || (statusFilter === "pending" && person.profileStatus.includes("pending"))
+        || person.profileStatus === statusFilter;
+
+      const matchesPlan = planFilter === "all" || (person.subscriptionTier || "free") === planFilter;
+      return matchesSearch && matchesStatus && matchesPlan;
+    });
+  }, [people, search, statusFilter, planFilter]);
+
+  const run = async (key: string, endpoint: string, payload: Record<string, unknown>, success: string) => {
+    setBusyId(key);
+    try {
+      await postJson(endpoint, payload);
+      toast({ title: success });
+      router.refresh();
+      return true;
+    } catch (error) {
+      toast({
+        title: "Action failed",
+        description: error instanceof Error ? error.message : "Unknown error.",
+        variant: "destructive",
+      });
+      return false;
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const sendPasswordReset = (person: AdminPerson) => run(
+    person.userId,
+    "/api/admin/users/reset-password",
+    { userId: person.userId },
+    "Password reset email sent",
+  );
+
+  const updatePlan = (person: AdminPerson, tier: string) => run(
+    `plan-${person.profileId}`,
+    `/api/admin/profile/${person.profileId}/upgrade`,
+    { subscription_tier: tier },
+    `Plan changed to ${tier}`,
+  );
+
+  const updateProfile = async (
+    person: AdminPerson,
+    action: "approve" | "reject" | "verify_identity" | "feature" | "unfeature",
+  ) => {
+    const succeeded = await run(
+      `${action}-${person.profileId}`,
+      action === "feature" || action === "unfeature"
+        ? `/api/admin/profile/${person.profileId}/feature`
+        : `/api/admin/profile/${person.profileId}/${action}`,
+      action === "approve" || action === "reject" ? { reason: reviewReason.trim() || undefined } : {},
+      `Profile ${action.replace("_", " ")} completed`,
     );
-  }, [people, search]);
 
-  const sendPasswordReset = async (person: AdminPerson) => {
-    setBusyId(person.userId);
-    try {
-      await postJson("/api/admin/users/reset-password", { userId: person.userId });
-      toast({ title: "Password reset sent", description: `A secure reset email was sent to ${person.email || "the user"}.` });
-    } catch (error) {
-      toast({ title: "Could not send password reset", description: error instanceof Error ? error.message : "Unknown error.", variant: "destructive" });
-    } finally {
-      setBusyId(null);
+    if (succeeded && (action === "approve" || action === "reject")) {
+      setReviewReason("");
     }
   };
 
-  const runPhotoAction = async (photoId: string, action: "approve" | "reject" | "set_primary" | "delete" | "reprocess") => {
-    setBusyId(photoId);
-    try {
-      await postJson("/api/admin/photos/action", { photoId, action });
-      toast({ title: "Photo updated", description: `Action ${action.replace("_", " ")} completed.` });
-      window.location.reload();
-    } catch (error) {
-      toast({ title: "Could not update photo", description: error instanceof Error ? error.message : "Unknown error.", variant: "destructive" });
-    } finally {
-      setBusyId(null);
-    }
+  const accountAction = async (person: AdminPerson, action: AccountAction) => {
+    const succeeded = await run(
+      `${action}-${person.userId}`,
+      "/api/admin/people/account-action",
+      {
+        userId: person.userId,
+        profileId: person.profileId,
+        action,
+        confirmation: action === "delete" ? deleteConfirmation : undefined,
+        reason: dangerReason || undefined,
+      },
+      action === "delete" ? "Account permanently deleted" : `Account ${action}d`,
+    );
+    if (!succeeded) return;
+
+    if (action === "delete") setSelectedId(null);
+    setDeleteConfirmation("");
+    setDangerReason("");
+    setShowDanger(false);
   };
+
+  const photoAction = (photoId: string, action: "approve" | "reject" | "set_primary" | "delete" | "reprocess") => run(
+    `${action}-${photoId}`,
+    "/api/admin/photos/action",
+    { photoId, action },
+    `Photo ${action.replace("_", " ")} completed`,
+  );
 
   return (
-    <div className="space-y-5">
-      <div className="relative max-w-xl">
-        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-        <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search by name, email, city, status or ID..." className="pl-10" />
-      </div>
+    <div className="space-y-6">
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {[
+          { label: "Total people", value: stats.total, icon: Users },
+          { label: "Approved", value: stats.approved, icon: UserCheck },
+          { label: "Needs review", value: stats.pending, icon: Shield },
+          { label: "Restricted", value: stats.restricted, icon: Ban },
+        ].map(({ label, value, icon: Icon }) => (
+          <div key={label} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-slate-500">{label}</p>
+              <Icon className="h-4 w-4 text-slate-400" />
+            </div>
+            <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">{value}</p>
+          </div>
+        ))}
+      </section>
 
-      <div className="grid gap-4">
-        {filtered.map((person) => {
-          const expanded = expandedId === person.profileId;
-          const primaryPhoto = person.photos.find((photo) => photo.isPrimary) || person.photos[0];
-          return (
-            <article key={person.profileId} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-              <button type="button" onClick={() => setExpandedId(expanded ? null : person.profileId)} className="flex w-full items-center gap-4 p-5 text-left hover:bg-slate-50">
-                <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-slate-100">
-                  {primaryPhoto ? <img src={primaryPhoto.url} alt="" className="h-full w-full object-cover" /> : <UserRound className="h-6 w-6 text-slate-400" />}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="truncate font-semibold text-slate-900">{person.name}</h2>
-                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{person.role || "provider"}</span>
-                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">{person.profileStatus}</span>
-                  </div>
-                  <p className="mt-1 truncate text-sm text-slate-500">{person.email || "No email"} · {person.city || "No city"} · {person.photos.length} photo(s)</p>
-                </div>
-                <span className="text-xs font-medium text-slate-500">{expanded ? "Close" : "Open"}</span>
-              </button>
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-200 p-4">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-950">People</h2>
+              <p className="text-sm text-slate-500">Manage accounts, plans, profiles, access, verification and photos.</p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="relative min-w-[280px]">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                <Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search name, email, city or ID" className="pl-9" />
+              </div>
+              <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as StatusFilter)} className="h-10 rounded-md border border-slate-200 bg-white px-3 text-sm">
+                <option value="all">All statuses</option>
+                <option value="approved">Approved</option>
+                <option value="pending">Needs review</option>
+                <option value="suspended">Suspended</option>
+                <option value="banned">Banned</option>
+              </select>
+              <select value={planFilter} onChange={(event) => setPlanFilter(event.target.value as PlanFilter)} className="h-10 rounded-md border border-slate-200 bg-white px-3 text-sm">
+                <option value="all">All plans</option>
+                {planOptions.map((plan) => <option key={plan} value={plan}>{plan}</option>)}
+              </select>
+            </div>
+          </div>
+        </div>
 
-              {expanded ? (
-                <div className="border-t border-slate-100 p-5">
-                  <div className="grid gap-5 lg:grid-cols-[1fr_1.4fr]">
-                    <div className="space-y-4">
-                      <div className="rounded-xl bg-slate-50 p-4 text-sm">
-                        <p><strong>User ID:</strong> {person.userId}</p>
-                        <p className="mt-1"><strong>Profile ID:</strong> {person.profileId}</p>
-                        <p className="mt-1"><strong>Plan:</strong> {person.subscriptionTier || "free"}</p>
-                        <p className="mt-1"><strong>Verification:</strong> {person.verificationStatus || "unverified"}</p>
-                        <p className="mt-1"><strong>Featured:</strong> {person.isFeatured ? "Yes" : "No"}</p>
-                        <p className="mt-1"><strong>Suspended:</strong> {person.isSuspended ? "Yes" : "No"}</p>
-                        <p className="mt-1"><strong>Banned:</strong> {person.isBanned ? "Yes" : "No"}</p>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        <Button type="button" variant="outline" disabled={!person.email || busyId === person.userId} onClick={() => void sendPasswordReset(person)}>
-                          <KeyRound className="mr-2 h-4 w-4" />{busyId === person.userId ? "Sending..." : "Send password reset"}
-                        </Button>
-                        {person.slug ? <Button type="button" variant="outline" asChild><a href={`/therapists/${person.slug}`} target="_blank" rel="noreferrer"><ExternalLink className="mr-2 h-4 w-4" />View public profile</a></Button> : null}
-                      </div>
-                    </div>
-
-                    <div>
-                      <div className="mb-3 flex items-center gap-2"><ImageIcon className="h-4 w-4 text-slate-500" /><h3 className="font-semibold">Cloudinary gallery</h3></div>
-                      {person.photos.length ? (
-                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                          {person.photos.map((photo) => (
-                            <div key={photo.id} className="overflow-hidden rounded-xl border border-slate-200 bg-white">
-                              <div className="aspect-square bg-slate-100"><img src={photo.url} alt="" className="h-full w-full object-cover" /></div>
-                              <div className="space-y-2 p-3 text-xs text-slate-600">
-                                <div className="flex items-center justify-between gap-2"><span>{photo.moderationStatus}</span>{photo.isPrimary ? <span className="font-medium text-amber-700">Primary</span> : null}</div>
-                                {photo.moderationReason ? <p className="truncate">{photo.moderationReason}</p> : null}
-                                <div className="flex flex-wrap gap-1.5">
-                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "approve")}><Check className="h-3.5 w-3.5" /></Button>
-                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "reject")}><X className="h-3.5 w-3.5" /></Button>
-                                  <Button size="sm" variant="outline" disabled={busyId === photo.id || photo.isPrimary} onClick={() => void runPhotoAction(photo.id, "set_primary")}><Star className="h-3.5 w-3.5" /></Button>
-                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "reprocess")}><RefreshCw className="h-3.5 w-3.5" /></Button>
-                                  <Button size="sm" variant="outline" disabled={busyId === photo.id} onClick={() => void runPhotoAction(photo.id, "delete")}><Trash2 className="h-3.5 w-3.5" /></Button>
-                                </div>
-                              </div>
-                            </div>
-                          ))}
+        <div className="grid min-h-[680px] xl:grid-cols-[minmax(0,1.35fr)_minmax(420px,.85fr)]">
+          <div className="overflow-x-auto border-r border-slate-200">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 z-10 bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="px-4 py-3 font-semibold">Person</th>
+                  <th className="px-4 py-3 font-semibold">Status</th>
+                  <th className="px-4 py-3 font-semibold">Plan</th>
+                  <th className="px-4 py-3 font-semibold">Photos</th>
+                  <th className="px-4 py-3 font-semibold"><span className="sr-only">Open</span></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {filtered.map((person) => {
+                  const primary = person.photos.find((photo) => photo.isPrimary) || person.photos[0];
+                  const active = selectedId === person.profileId;
+                  return (
+                    <tr
+                      key={person.profileId}
+                      onClick={() => {
+                        setSelectedId(person.profileId);
+                        setReviewReason("");
+                      }}
+                      className={`cursor-pointer transition ${active ? "bg-slate-950 text-white" : "hover:bg-slate-50"}`}
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-3">
+                          <div className={`h-11 w-11 overflow-hidden rounded-xl ${active ? "bg-white/10" : "bg-slate-100"}`}>
+                            {primary ? <img src={primary.url} alt="" className="h-full w-full object-cover" /> : <UserRound className="m-2.5 h-6 w-6 text-slate-400" />}
+                          </div>
+                          <div className="min-w-0">
+                            <p className="truncate font-semibold">{person.name}</p>
+                            <p className={`truncate text-xs ${active ? "text-slate-300" : "text-slate-500"}`}>{person.email || "No email"}</p>
+                            <p className={`truncate text-xs ${active ? "text-slate-400" : "text-slate-400"}`}>{person.city || "No city"}</p>
+                          </div>
                         </div>
-                      ) : <p className="text-sm text-slate-500">No photos registered in profile_photos.</p>}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ring-1 ring-inset ${active ? "bg-white/10 text-white ring-white/20" : statusTone(person.profileStatus)}`}>{person.profileStatus}</span>
+                        {(person.isSuspended || person.isBanned) && <p className={`mt-1 text-xs ${active ? "text-rose-300" : "text-rose-600"}`}>{person.isBanned ? "Banned" : "Suspended"}</p>}
+                      </td>
+                      <td className="px-4 py-3"><span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${active ? "bg-white/10 text-white" : planTone(person.subscriptionTier)}`}>{person.subscriptionTier || "free"}</span></td>
+                      <td className="px-4 py-3">{person.photos.length}</td>
+                      <td className="px-4 py-3"><ChevronRight className="h-4 w-4" /></td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {filtered.length === 0 && <div className="p-10 text-center text-sm text-slate-500">No people match these filters.</div>}
+          </div>
+
+          <aside className="bg-slate-50/70 p-5">
+            {!selected ? (
+              <div className="flex h-full min-h-[500px] items-center justify-center text-center">
+                <div><UserRound className="mx-auto h-10 w-10 text-slate-300" /><p className="mt-3 font-medium text-slate-700">Select a person</p><p className="text-sm text-slate-500">Their account controls will appear here.</p></div>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                <div className="rounded-2xl bg-slate-950 p-5 text-white shadow-lg">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[.18em] text-slate-400">Account overview</p>
+                      <h2 className="mt-2 text-2xl font-semibold">{selected.name}</h2>
+                      <p className="mt-1 text-sm text-slate-300">{selected.email || "No email"}</p>
                     </div>
+                    <MoreHorizontal className="h-5 w-5 text-slate-400" />
+                  </div>
+                  <div className="mt-5 grid grid-cols-2 gap-3 text-sm">
+                    <div className="rounded-xl bg-white/5 p-3"><p className="text-xs text-slate-400">Profile status</p><p className="mt-1 font-medium">{selected.profileStatus}</p></div>
+                    <div className="rounded-xl bg-white/5 p-3"><p className="text-xs text-slate-400">Verification</p><p className="mt-1 font-medium">{selected.verificationStatus || "unverified"}</p></div>
                   </div>
                 </div>
-              ) : null}
-            </article>
-          );
-        })}
-      </div>
-      {filtered.length === 0 ? <p className="text-sm text-slate-500">No people found.</p> : null}
+
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="font-semibold text-slate-950">Quick actions</h3>
+                  <div className="mt-3 grid grid-cols-2 gap-2">
+                    <Button variant="outline" disabled={!selected.email || busyId === selected.userId} onClick={() => void sendPasswordReset(selected)}><KeyRound className="mr-2 h-4 w-4" />Reset password</Button>
+                    {selected.slug ? <Button variant="outline" asChild><a href={`/therapists/${selected.slug}`} target="_blank" rel="noreferrer"><ExternalLink className="mr-2 h-4 w-4" />Public profile</a></Button> : <Button variant="outline" disabled><ExternalLink className="mr-2 h-4 w-4" />No public page</Button>}
+                    <Button variant="outline" onClick={() => void updateProfile(selected, selected.isFeatured ? "unfeature" : "feature")}><Star className="mr-2 h-4 w-4" />{selected.isFeatured ? "Unfeature" : "Feature"}</Button>
+                    <Button variant="outline" onClick={() => void updateProfile(selected, "verify_identity")}><BadgeCheck className="mr-2 h-4 w-4" />Verify identity</Button>
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="font-semibold text-slate-950">Profile review</h3>
+                  <Input
+                    value={reviewReason}
+                    onChange={(event) => setReviewReason(event.target.value)}
+                    placeholder="Review note (required to reject)"
+                    className="mt-3"
+                  />
+                  <div className="mt-3 flex gap-2">
+                    <Button disabled={busyId !== null} className="flex-1 bg-emerald-600 hover:bg-emerald-700" onClick={() => void updateProfile(selected, "approve")}><Check className="mr-2 h-4 w-4" />Approve</Button>
+                    <Button disabled={busyId !== null || !reviewReason.trim()} className="flex-1" variant="destructive" onClick={() => void updateProfile(selected, "reject")}><X className="mr-2 h-4 w-4" />Reject</Button>
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="font-semibold text-slate-950">Subscription</h3>
+                  <p className="mt-1 text-sm text-slate-500">Change access immediately without searching for a hidden action menu.</p>
+                  <div className="mt-3 grid grid-cols-4 gap-2">
+                    {planOptions.map((plan) => (
+                      <button key={plan} type="button" onClick={() => void updatePlan(selected, plan)} className={`rounded-xl border px-2 py-3 text-xs font-semibold capitalize transition ${selected.subscriptionTier === plan || (!selected.subscriptionTier && plan === "free") ? "border-slate-950 bg-slate-950 text-white" : "border-slate-200 bg-white hover:border-slate-400"}`}>{plan}</button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <div className="flex items-center justify-between"><div><h3 className="font-semibold text-slate-950">Photos</h3><p className="text-sm text-slate-500">{selected.photos.length} uploaded</p></div><ImageIcon className="h-5 w-5 text-slate-400" /></div>
+                  <div className="mt-4 grid grid-cols-2 gap-3">
+                    {selected.photos.map((photo) => (
+                      <div key={photo.id} className="overflow-hidden rounded-xl border border-slate-200 bg-white">
+                        <div className="relative aspect-square bg-slate-100"><img src={photo.url} alt="" className="h-full w-full object-cover" />{photo.isPrimary && <span className="absolute left-2 top-2 rounded-full bg-slate-950 px-2 py-1 text-[10px] font-semibold text-white">Primary</span>}</div>
+                        <div className="p-2">
+                          <p className="truncate text-xs font-medium text-slate-700">{photo.moderationStatus}</p>
+                          <div className="mt-2 grid grid-cols-5 gap-1">
+                            <button aria-label="Approve photo" className="rounded-md border p-1.5 hover:bg-emerald-50" onClick={() => void photoAction(photo.id, "approve")}><Check className="h-3.5 w-3.5" /></button>
+                            <button aria-label="Reject photo" className="rounded-md border p-1.5 hover:bg-rose-50" onClick={() => void photoAction(photo.id, "reject")}><X className="h-3.5 w-3.5" /></button>
+                            <button aria-label="Set primary photo" disabled={photo.isPrimary} className="rounded-md border p-1.5 disabled:opacity-40" onClick={() => void photoAction(photo.id, "set_primary")}><Star className="h-3.5 w-3.5" /></button>
+                            <button aria-label="Reprocess photo" className="rounded-md border p-1.5" onClick={() => void photoAction(photo.id, "reprocess")}><RefreshCw className="h-3.5 w-3.5" /></button>
+                            <button aria-label="Delete photo" className="rounded-md border p-1.5 text-rose-600" onClick={() => void photoAction(photo.id, "delete")}><Trash2 className="h-3.5 w-3.5" /></button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {!selected.photos.length && <p className="mt-4 rounded-xl bg-slate-50 p-4 text-sm text-slate-500">No photos uploaded.</p>}
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 bg-white p-4 text-xs text-slate-500">
+                  <p><strong className="text-slate-700">User ID:</strong> {selected.userId}</p>
+                  <p className="mt-1"><strong className="text-slate-700">Profile ID:</strong> {selected.profileId}</p>
+                </div>
+
+                <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4">
+                  <button type="button" className="flex w-full items-center justify-between text-left" onClick={() => setShowDanger((value) => !value)}>
+                    <div><p className="font-semibold text-rose-900">Danger zone</p><p className="text-sm text-rose-700">Deactivate or permanently delete this account.</p></div><AlertTriangle className="h-5 w-5 text-rose-600" />
+                  </button>
+                  {showDanger && (
+                    <div className="mt-4 space-y-3 border-t border-rose-200 pt-4">
+                      <Input value={dangerReason} onChange={(event) => setDangerReason(event.target.value)} placeholder="Reason for this action" />
+                      <div className="grid grid-cols-2 gap-2">
+                        {selected.isSuspended || selected.isBanned ? (
+                          <Button variant="outline" className="border-emerald-300 text-emerald-700" onClick={() => void accountAction(selected, "reactivate")}><UserCheck className="mr-2 h-4 w-4" />Reactivate</Button>
+                        ) : (
+                          <Button variant="outline" className="border-amber-300 text-amber-700" onClick={() => void accountAction(selected, "deactivate")}><Ban className="mr-2 h-4 w-4" />Deactivate</Button>
+                        )}
+                        <Button variant="destructive" disabled={deleteConfirmation !== "DELETE"} onClick={() => void accountAction(selected, "delete")}><Trash2 className="mr-2 h-4 w-4" />Delete forever</Button>
+                      </div>
+                      <Input value={deleteConfirmation} onChange={(event) => setDeleteConfirmation(event.target.value)} placeholder="Type DELETE to enable permanent deletion" />
+                      <p className="text-xs text-rose-700">Permanent deletion removes the profile and authentication account. This cannot be undone.</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </aside>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/admin/tools/page.tsx
+++ b/src/app/admin/tools/page.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  BarChart3,
+  Beaker,
+  CalendarCheck,
+  CreditCard,
+  FileClock,
+  FileSearch,
+  FileText,
+  Flag,
+  ImageIcon,
+  LifeBuoy,
+  Mail,
+  MapPin,
+  MessageSquare,
+  Newspaper,
+  Search,
+  Settings,
+  ShieldAlert,
+  ShieldCheck,
+  Tag,
+  UserRoundCog,
+  Users,
+  Workflow,
+} from "lucide-react";
+
+import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+
+const sections = [
+  {
+    title: "People and profiles",
+    description: "Accounts, public profiles, moderation, verification and safety.",
+    items: [
+      { href: "/admin/people", label: "People CRM", description: "Manage accounts, plans, access, profiles and photos from one workspace.", icon: Users },
+      { href: "/admin/profile-cms", label: "Profile CMS", description: "Edit and batch-maintain provider profile data.", icon: UserRoundCog },
+      { href: "/admin/photos", label: "Photo Approvals", description: "Review uploads, moderation results and primary photos.", icon: ImageIcon },
+      { href: "/admin/moderation", label: "Profile Approvals", description: "Approve or reject profiles waiting for review.", icon: ShieldAlert },
+      { href: "/admin/verification", label: "Verification", description: "Operate identity and profile verification workflows.", icon: ShieldCheck },
+      { href: "/admin/profile-reports", label: "Profile Reports", description: "Investigate reports submitted about public profiles.", icon: Flag },
+      { href: "/admin/complaints", label: "Complaints", description: "Resolve client complaints and document administrative action.", icon: FileSearch },
+    ],
+  },
+  {
+    title: "Communication and service",
+    description: "Outbound messages, requests, support and import operations.",
+    items: [
+      { href: "/admin/emails", label: "Email Center", description: "Create compliant templates and queued campaigns with live delivery totals.", icon: Mail },
+      { href: "/admin/tickets", label: "Tickets", description: "Work operational and customer-service tickets.", icon: MessageSquare },
+      { href: "/admin/support", label: "Support", description: "Open the support operations workspace.", icon: LifeBuoy },
+      { href: "/admin/bookings", label: "Booking Approvals", description: "Review appointment inquiries that need action.", icon: CalendarCheck },
+      { href: "/admin/sms", label: "SMS Auto-Reply", description: "Monitor SMS conversations and unresolved follow-ups.", icon: MessageSquare },
+      { href: "/admin/migrations", label: "Profile Imports", description: "Review external profile imports and approve imported reviews.", icon: Workflow },
+    ],
+  },
+  {
+    title: "Growth and content",
+    description: "Publishing, discovery, search visibility and experimentation.",
+    items: [
+      { href: "/admin/blog", label: "Blog", description: "Create and manage editorial content.", icon: Newspaper },
+      { href: "/admin/cities", label: "Cities", description: "Manage city coverage and local landing pages.", icon: MapPin },
+      { href: "/admin/keywords", label: "Keywords", description: "Maintain service, specialty and SEO keyword surfaces.", icon: Tag },
+      { href: "/admin/seo", label: "SEO", description: "Review search visibility and indexing configuration.", icon: Search },
+      { href: "/admin/analytics", label: "Analytics", description: "Inspect provider, market and platform performance.", icon: BarChart3 },
+      { href: "/admin/ab-tests", label: "A/B Tests", description: "Review profile-field experiments and rollout controls.", icon: Beaker },
+    ],
+  },
+  {
+    title: "Business and system",
+    description: "Revenue, reporting, audit history, legal content and configuration.",
+    items: [
+      { href: "/admin/billing", label: "Billing", description: "Review subscriptions, plans and billing operations.", icon: CreditCard },
+      { href: "/admin/reports", label: "Reports", description: "View platform and operational reporting.", icon: BarChart3 },
+      { href: "/admin/audit-log", label: "Audit Log", description: "Trace profile and administrative changes.", icon: FileClock },
+      { href: "/admin/logs", label: "System Logs", description: "Inspect runtime and administrative activity logs.", icon: FileClock },
+      { href: "/admin/legal", label: "Legal", description: "Manage legal and policy content.", icon: FileText },
+      { href: "/admin/settings", label: "Settings", description: "Configure platform-level administrative settings.", icon: Settings },
+    ],
+  },
+];
+
+export default function AdminToolsPage() {
+  return (
+    <div className="space-y-8">
+      <AdminPageHeader
+        title="All Admin Tools"
+        description="A complete map of the active administrative workspaces in MasseurMatch."
+      />
+
+      {sections.map((section) => (
+        <section key={section.title} className="space-y-4">
+          <div>
+            <h2 className="font-display text-xl font-bold text-slate-950">{section.title}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{section.description}</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {section.items.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="group rounded-2xl border border-border bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-secondary/30 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-brand-secondary/10 text-brand-secondary">
+                    <item.icon className="h-5 w-5" />
+                  </span>
+                  <ArrowRight className="h-4 w-4 text-slate-300 transition group-hover:translate-x-1 group-hover:text-brand-secondary" />
+                </div>
+                <h3 className="mt-4 font-semibold text-slate-950">{item.label}</h3>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">{item.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/app/api/admin/emails/route.ts
+++ b/src/app/api/admin/emails/route.ts
@@ -1,0 +1,173 @@
+export const dynamic = "force-dynamic";
+
+import { z } from "zod";
+
+import { assertRateLimit } from "@/app/_lib/security";
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+
+const campaignSchema = z.object({
+  action: z.literal("create_campaign"),
+  name: z.string().trim().min(2).max(120),
+  subject: z.string().trim().min(1).max(180),
+  bodyHtml: z.string().min(1).max(150_000),
+  bodyText: z.string().max(80_000).optional().nullable(),
+  sendCategory: z.enum(["marketing", "transactional"]),
+  fromAddress: z.string().trim().max(200).optional().nullable(),
+  replyTo: z.string().trim().email().optional().nullable(),
+  scheduledFor: z.string().datetime().optional().nullable(),
+  templateId: z.string().uuid().optional().nullable(),
+  userIds: z.array(z.string().uuid()).max(500).default([]),
+  profileStatuses: z.array(z.string().trim().min(1)).max(20).default([]),
+  plans: z.array(z.string().trim().min(1)).max(20).default([]),
+  cities: z.array(z.string().trim().min(1)).max(100).default([]),
+  states: z.array(z.string().trim().min(1)).max(100).default([]),
+});
+
+const templateSchema = z.object({
+  action: z.literal("save_template"),
+  id: z.string().uuid().optional().nullable(),
+  name: z.string().trim().min(2).max(120),
+  description: z.string().trim().max(500).optional().nullable(),
+  subject: z.string().trim().min(1).max(180),
+  bodyHtml: z.string().min(1).max(150_000),
+  bodyText: z.string().max(80_000).optional().nullable(),
+  sendCategory: z.enum(["marketing", "transactional"]),
+  fromAddress: z.string().trim().max(200).optional().nullable(),
+  replyTo: z.string().trim().email().optional().nullable(),
+});
+
+const cancelSchema = z.object({
+  action: z.literal("cancel_campaign"),
+  campaignId: z.string().uuid(),
+});
+
+const postSchema = z.discriminatedUnion("action", [campaignSchema, templateSchema, cancelSchema]);
+
+const templateIdResultSchema = z.string().uuid();
+const cancelledResultSchema = z.coerce.number().int().nonnegative();
+const campaignResultSchema = z.object({
+  campaignId: z.string().uuid(),
+  total: z.coerce.number().int().nonnegative(),
+  queued: z.coerce.number().int().nonnegative(),
+  suppressed: z.coerce.number().int().nonnegative(),
+});
+
+type RpcClient = ReturnType<typeof createSupabaseAdminClient> & {
+  rpc: (name: string, params?: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }>;
+};
+
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    assertRateLimit(request, "admin-email-center-read", { limit: 90, windowMs: 60_000 });
+
+    const url = new URL(request.url);
+    const query = url.searchParams.get("q")?.trim() || null;
+    const adminClient = createSupabaseAdminClient() as RpcClient;
+    const { data, error } = await adminClient.rpc("admin_email_center_snapshot", {
+      p_query: query,
+      p_limit: 500,
+    });
+
+    if (error) throw new RouteError(500, error.message);
+    return json({ ok: true, ...(data as Record<string, unknown>) });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-email-center-write", { limit: 20, windowMs: 60_000 });
+    const body = await parseJsonBody(request, postSchema);
+    const adminClient = createSupabaseAdminClient() as RpcClient;
+
+    if (body.action === "save_template") {
+      const { data, error } = await adminClient.rpc("admin_email_save_template", {
+        p_admin_user_id: admin.userId,
+        p_id: body.id || null,
+        p_name: body.name,
+        p_description: body.description || null,
+        p_subject: body.subject,
+        p_body_html: body.bodyHtml,
+        p_body_text: body.bodyText || null,
+        p_send_category: body.sendCategory,
+        p_from_address: body.fromAddress || null,
+        p_reply_to: body.replyTo || null,
+      });
+      if (error) throw new RouteError(500, error.message);
+
+      const templateId = templateIdResultSchema.parse(data);
+
+      await recordAuditLog(admin.userId, "admin_email_template_saved", "email_template", templateId, {
+        name: body.name,
+        sendCategory: body.sendCategory,
+      });
+      return json({ ok: true, templateId });
+    }
+
+    if (body.action === "cancel_campaign") {
+      const { data, error } = await adminClient.rpc("admin_email_cancel_campaign", {
+        p_admin_user_id: admin.userId,
+        p_campaign_id: body.campaignId,
+      });
+      if (error) throw new RouteError(500, error.message);
+
+      const cancelled = cancelledResultSchema.parse(data);
+
+      await recordAuditLog(admin.userId, "admin_email_campaign_cancelled", "email_campaign", body.campaignId, {
+        cancelledQueuedMessages: cancelled,
+      });
+      return json({ ok: true, cancelled });
+    }
+
+    const selectedAudience =
+      body.userIds.length + body.profileStatuses.length + body.plans.length + body.cities.length + body.states.length;
+    if (selectedAudience === 0) {
+      throw new RouteError(400, "Choose recipients or at least one audience filter.");
+    }
+    if (body.sendCategory === "transactional" && body.userIds.length === 0) {
+      throw new RouteError(400, "Transactional campaigns require explicitly selected recipients.");
+    }
+
+    const scheduledFor = body.scheduledFor || new Date().toISOString();
+    const { data, error } = await adminClient.rpc("admin_email_create_campaign", {
+      p_admin_user_id: admin.userId,
+      p_name: body.name,
+      p_subject: body.subject,
+      p_body_html: body.bodyHtml,
+      p_body_text: body.bodyText || null,
+      p_send_category: body.sendCategory,
+      p_from_address: body.fromAddress || null,
+      p_reply_to: body.replyTo || null,
+      p_scheduled_for: scheduledFor,
+      p_template_id: body.templateId || null,
+      p_user_ids: body.userIds,
+      p_profile_statuses: body.profileStatuses,
+      p_plans: body.plans,
+      p_cities: body.cities,
+      p_states: body.states,
+    });
+    if (error) throw new RouteError(500, error.message);
+
+    const result = campaignResultSchema.parse(data);
+    await recordAuditLog(admin.userId, "admin_email_campaign_created", "email_campaign", result.campaignId, {
+      name: body.name,
+      sendCategory: body.sendCategory,
+      scheduledFor,
+      total: result.total,
+      queued: result.queued,
+      suppressed: result.suppressed,
+    });
+
+    return json({ ok: true, campaign: result });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/people/account-action/route.ts
+++ b/src/app/api/admin/people/account-action/route.ts
@@ -1,0 +1,109 @@
+export const dynamic = "force-dynamic";
+
+import { z } from "zod";
+
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+import { assertRateLimit } from "@/app/_lib/security";
+
+const schema = z.object({
+  userId: z.string().uuid(),
+  profileId: z.string().uuid(),
+  action: z.enum(["deactivate", "reactivate", "delete"]),
+  confirmation: z.string().optional(),
+  reason: z.string().max(500).optional(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-people-account-action", { limit: 20, windowMs: 60_000 });
+    const body = await parseJsonBody(request, schema);
+
+    if (body.userId === admin.userId) {
+      throw new RouteError(400, "You cannot deactivate or delete your own admin account.");
+    }
+
+    const supabase = createSupabaseAdminClient();
+    const { data: targetProfile, error: targetError } = await supabase
+      .from("profiles")
+      .select("id, user_id")
+      .eq("id", body.profileId)
+      .eq("user_id", body.userId)
+      .maybeSingle();
+
+    if (targetError) throw new RouteError(500, targetError.message);
+    if (!targetProfile) throw new RouteError(404, "The selected account and profile no longer match.");
+
+    if (body.action === "deactivate") {
+      const { error: authError } = await supabase.auth.admin.updateUserById(body.userId, {
+        ban_duration: "876000h",
+      });
+      if (authError) throw new RouteError(500, authError.message);
+
+      const { data: updatedProfile, error: profileError } = await supabase
+        .from("profiles")
+        .update({ is_active: false, is_suspended: true })
+        .eq("id", body.profileId)
+        .eq("user_id", body.userId)
+        .select("id")
+        .maybeSingle();
+
+      if (profileError || !updatedProfile) {
+        await supabase.auth.admin.updateUserById(body.userId, { ban_duration: "0s" });
+        throw new RouteError(500, profileError?.message || "The profile could not be deactivated.");
+      }
+
+      await recordAuditLog(admin.userId, "deactivate_account", "user", body.userId, {
+        profile_id: body.profileId,
+        reason: body.reason || null,
+      });
+      return json({ ok: true });
+    }
+
+    if (body.action === "reactivate") {
+      const { error: authError } = await supabase.auth.admin.updateUserById(body.userId, {
+        ban_duration: "0s",
+      });
+      if (authError) throw new RouteError(500, authError.message);
+
+      const { data: updatedProfile, error: profileError } = await supabase
+        .from("profiles")
+        .update({ is_active: true, is_suspended: false, is_banned: false })
+        .eq("id", body.profileId)
+        .eq("user_id", body.userId)
+        .select("id")
+        .maybeSingle();
+
+      if (profileError || !updatedProfile) {
+        await supabase.auth.admin.updateUserById(body.userId, { ban_duration: "876000h" });
+        throw new RouteError(500, profileError?.message || "The profile could not be reactivated.");
+      }
+
+      await recordAuditLog(admin.userId, "reactivate_account", "user", body.userId, {
+        profile_id: body.profileId,
+      });
+      return json({ ok: true });
+    }
+
+    if (body.confirmation !== "DELETE") {
+      throw new RouteError(400, "Type DELETE to permanently remove this account.");
+    }
+
+    const { error: authError } = await supabase.auth.admin.deleteUser(body.userId);
+    if (authError) throw new RouteError(500, authError.message);
+
+    await recordAuditLog(admin.userId, "delete_account", "user", body.userId, {
+      profile_id: body.profileId,
+      reason: body.reason || null,
+    });
+
+    return json({ ok: true });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/migrate/_lib/processor.ts
+++ b/src/app/api/migrate/_lib/processor.ts
@@ -1,4 +1,5 @@
 import { createSupabaseWebhookAdminClient } from "@/app/api/_lib/supabase-server";
+import { assertSafePublicUrl } from "@/app/api/migrate/_lib/source-url";
 
 interface ScrapedReview {
   reviewer_name: string | null;
@@ -18,36 +19,76 @@ interface PendingMigration {
 const FETCH_TIMEOUT_MS = 10_000;
 const MAX_HTML_BYTES = 3_000_000;
 const BATCH_LIMIT = 10;
+const MAX_REDIRECTS = 5;
 
-async function fetchHtml(url: string): Promise<string | null> {
+async function readHtmlWithLimit(body: ReadableStream<Uint8Array> | null): Promise<string | null> {
+  if (!body) return null;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let html = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+
+    if (totalBytes > MAX_HTML_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+
+    html += decoder.decode(value, { stream: true });
+  }
+
+  return html + decoder.decode();
+}
+
+async function fetchHtml(rawUrl: string): Promise<string | null> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
-    const res = await fetch(url, {
-      redirect: "follow",
-      signal: controller.signal,
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (compatible; MasseurMatchImporter/1.0; +https://masseurmatch.com)",
-        Accept: "text/html,application/xhtml+xml",
-      },
-    });
+    let currentUrl = rawUrl;
 
-    if (!res.ok) {
-      console.warn(`[migrate/processor] Fetch ${url} returned ${res.status}`);
-      return null;
+    for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount += 1) {
+      const safeUrl = await assertSafePublicUrl(currentUrl);
+      const res = await fetch(safeUrl, {
+        redirect: "manual",
+        signal: controller.signal,
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (compatible; MasseurMatchImporter/1.0; +https://masseurmatch.com)",
+          Accept: "text/html,application/xhtml+xml",
+        },
+      });
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get("location");
+        if (!location || redirectCount === MAX_REDIRECTS) return null;
+        if (res.body) await res.body.cancel();
+        currentUrl = new URL(location, safeUrl).toString();
+        continue;
+      }
+
+      if (!res.ok) {
+        console.warn(`[migrate/processor] Fetch ${safeUrl.toString()} returned ${res.status}`);
+        return null;
+      }
+
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("html") && !contentType.includes("xml")) return null;
+
+      const contentLength = Number(res.headers.get("content-length") || 0);
+      if (Number.isFinite(contentLength) && contentLength > MAX_HTML_BYTES) return null;
+
+      return await readHtmlWithLimit(res.body);
     }
 
-    const contentType = res.headers.get("content-type") ?? "";
-    if (!contentType.includes("html") && !contentType.includes("xml")) {
-      return null;
-    }
-
-    const text = await res.text();
-    return text.length > MAX_HTML_BYTES ? text.slice(0, MAX_HTML_BYTES) : text;
+    return null;
   } catch (err) {
-    console.warn(`[migrate/processor] Fetch failed for ${url}:`, err);
+    console.warn(`[migrate/processor] Fetch failed for ${rawUrl}:`, err);
     return null;
   } finally {
     clearTimeout(timeoutId);

--- a/src/app/api/migrate/_lib/source-url.ts
+++ b/src/app/api/migrate/_lib/source-url.ts
@@ -1,0 +1,106 @@
+import "server-only";
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+import { RouteError } from "@/app/api/_lib/http";
+
+function isPrivateIpv4(address: string): boolean {
+  const parts = address.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return true;
+  }
+
+  const [a, b, c] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0 && c === 0) ||
+    (a === 192 && b === 0 && c === 2) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+export function isPrivateNetworkAddress(address: string): boolean {
+  const normalized = address.replace(/^\[|\]$/g, "").toLowerCase();
+  const version = isIP(normalized);
+
+  if (version === 4) return isPrivateIpv4(normalized);
+  if (version !== 6) return true;
+
+  if (normalized === "::" || normalized === "::1") return true;
+  if (normalized.startsWith("::ffff:")) {
+    const mappedIpv4 = normalized.slice("::ffff:".length);
+    return isIP(mappedIpv4) !== 4 || isPrivateIpv4(mappedIpv4);
+  }
+
+  const firstHextet = Number.parseInt(normalized.split(":")[0] || "0", 16);
+  return (
+    (firstHextet & 0xfe00) === 0xfc00 ||
+    (firstHextet & 0xffc0) === 0xfe80 ||
+    (firstHextet & 0xff00) === 0xff00 ||
+    normalized.startsWith("2001:db8:")
+  );
+}
+
+export function parseSafePublicUrl(rawUrl: string): URL {
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new RouteError(400, "Enter a valid profile URL.");
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new RouteError(400, "Only HTTP and HTTPS profile links are supported.");
+  }
+
+  if (url.username || url.password) {
+    throw new RouteError(400, "Profile links cannot include embedded credentials.");
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const blockedHostname =
+    !hostname ||
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    (isIP(hostname) > 0 && isPrivateNetworkAddress(hostname));
+
+  if (blockedHostname) {
+    throw new RouteError(400, "That profile link cannot be accessed.");
+  }
+
+  url.hash = "";
+  return url;
+}
+
+export async function assertSafePublicUrl(rawUrl: string): Promise<URL> {
+  const url = parseSafePublicUrl(rawUrl);
+  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+
+  if (isIP(hostname) === 0) {
+    let addresses: Array<{ address: string }>;
+    try {
+      addresses = await lookup(hostname, { all: true, verbatim: true });
+    } catch {
+      throw new RouteError(400, "The profile link hostname could not be resolved.");
+    }
+
+    if (addresses.length === 0 || addresses.some(({ address }) => isPrivateNetworkAddress(address))) {
+      throw new RouteError(400, "That profile link cannot be accessed.");
+    }
+  }
+
+  return url;
+}

--- a/src/app/api/migrate/initiate/route.ts
+++ b/src/app/api/migrate/initiate/route.ts
@@ -1,136 +1,164 @@
+import React from "react";
 import { after } from "next/server";
+import { z } from "zod";
+
+import { assertRateLimit } from "@/app/_lib/security";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
+import { sendEmail } from "@/app/api/_lib/email";
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { requireRequestSession } from "@/app/api/_lib/session";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { processPendingMigrations } from "@/app/api/migrate/_lib/processor";
-import { sendEmail } from "@/app/api/_lib/email";
-import React from "react";
+import { assertSafePublicUrl } from "@/app/api/migrate/_lib/source-url";
+import { SITE_URL } from "@/lib/site";
 
-interface ProfileUrl {
-  platform: string;
-  url: string;
+const legacyPlatforms = ["rubmaps", "4corners", "nuru", "custom"] as const;
+type LegacyPlatform = (typeof legacyPlatforms)[number];
+
+const requestSchema = z.object({
+  profileUrls: z
+    .array(
+      z.object({
+        platform: z.enum(legacyPlatforms),
+        url: z.string().trim().url().max(2048),
+      }),
+    )
+    .min(1)
+    .max(5),
+  // Retained for compatibility with the signup client, but never trusted.
+  email: z.string().email().optional(),
+});
+
+const platformHosts: Record<Exclude<LegacyPlatform, "custom">, string[]> = {
+  rubmaps: ["rubmaps.com"],
+  "4corners": ["4corners.xxx"],
+  nuru: ["nurumap.com"],
+};
+
+function assertPlatformMatch(platform: LegacyPlatform, url: URL) {
+  if (platform === "custom") return;
+
+  const hostname = url.hostname.toLowerCase();
+  const matches = platformHosts[platform].some(
+    (allowedHost) => hostname === allowedHost || hostname.endsWith(`.${allowedHost}`),
+  );
+
+  if (!matches) {
+    throw new RouteError(400, "The selected directory does not match the profile link.");
+  }
 }
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
-    const { profileUrls, email } = body;
+    assertRateLimit(request, "profile-migration-initiate", { limit: 8, windowMs: 60_000 });
+    const session = await requireRequestSession(request);
+    const parsed = requestSchema.safeParse(await request.json().catch(() => null));
 
-    if (!Array.isArray(profileUrls) || profileUrls.length === 0) {
-      throw new RouteError(400, "At least one profile URL is required.");
-    }
-
-    if (!email || typeof email !== "string") {
-      throw new RouteError(400, "Email is required.");
+    if (!parsed.success) {
+      throw new RouteError(400, parsed.error.issues[0]?.message || "Add at least one valid profile link.");
     }
 
     const adminClient = createSupabaseAdminClient();
+    const { data: profile, error: profileError } = await adminClient
+      .from("profiles")
+      .select("id, email_address")
+      .eq("user_id", session.userId)
+      .maybeSingle();
 
-    // Store migration requests in database
-    const migrationData = profileUrls.map((pu: ProfileUrl) => ({
+    if (profileError) throw new RouteError(500, "Could not load your provider profile.");
+
+    const email = session.email || profile?.email_address;
+    if (!email) throw new RouteError(400, "Add an email address to your account before requesting an import.");
+
+    const normalized = await Promise.all(
+      parsed.data.profileUrls.map(async (entry) => {
+        const url = await assertSafePublicUrl(entry.url);
+        assertPlatformMatch(entry.platform, url);
+        return { platform: entry.platform, source_url: url.toString() };
+      }),
+    );
+    const uniqueEntries = Array.from(
+      new Map(normalized.map((entry) => [entry.source_url.toLowerCase(), entry])).values(),
+    );
+
+    const { data: existing, error: existingError } = await (adminClient as any)
+      .from("profile_migrations")
+      .select("source_url")
+      .eq("email", email)
+      .in("status", ["pending", "in_progress", "manual_review"]);
+
+    if (existingError) throw new RouteError(500, "Could not verify your existing import requests.");
+
+    const activeUrls = new Set(
+      (existing ?? []).map((entry: { source_url: string }) => entry.source_url.toLowerCase()),
+    );
+    const newEntries = uniqueEntries.filter((entry) => !activeUrls.has(entry.source_url.toLowerCase()));
+    if (newEntries.length === 0) {
+      throw new RouteError(409, "That profile link already has an active import request.");
+    }
+
+    const now = new Date().toISOString();
+    const migrationData = newEntries.map((entry) => ({
       email,
-      platform: pu.platform,
-      source_url: pu.url,
+      profile_id: profile?.id ?? null,
+      platform: entry.platform,
+      source_url: entry.source_url,
       status: "pending" as const,
-      created_at: new Date().toISOString(),
+      created_at: now,
     }));
 
-    const { error: insertError } = await ((adminClient as any)
+    const { error: insertError } = await (adminClient as any)
       .from("profile_migrations")
-      .insert(migrationData));
+      .insert(migrationData);
 
     if (insertError) {
       console.error("[api/migrate/initiate] Insert error:", insertError.message);
       throw new RouteError(500, "Could not save migration request.");
     }
 
-    // Send confirmation email
-    try {
-      await sendEmail({
-        to: email,
-        subject: "We're Importing Your Profile — Sit Back & Relax",
-        react: React.createElement("div", {
-          dangerouslySetInnerHTML: {
-            __html: `
-              <!DOCTYPE html>
-              <html>
-                <head>
-                  <style>
-                    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.6; color: #333; }
-                    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-                    .header { border-bottom: 3px solid #8B1E2D; padding-bottom: 20px; margin-bottom: 30px; }
-                    .header h1 { margin: 0; color: #111111; font-size: 24px; font-weight: bold; }
-                    .content { margin-bottom: 30px; }
-                    .content p { margin: 15px 0; }
-                    .step { background: #FAFAFA; border-left: 4px solid #8B1E2D; padding: 15px; margin: 15px 0; }
-                    .step h3 { margin-top: 0; color: #8B1E2D; }
-                    .cta-button { display: inline-block; background-color: #8B1E2D; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; margin: 20px 0; }
-                    .footer { border-top: 1px solid #E8E8E8; padding-top: 20px; font-size: 12px; color: #8E8E8E; }
-                  </style>
-                </head>
-                <body>
-                  <div class="container">
-                    <div class="header">
-                      <h1>Welcome to MasseurMatch</h1>
-                    </div>
-
-                    <div class="content">
-                      <p>Hi there,</p>
-                      <p>Great news! We've received your profile URLs and we're already working on importing your reviews, ratings, and service history to MasseurMatch.</p>
-
-                      <div class="step">
-                        <h3>📋 What's Happening</h3>
-                        <p>We're extracting your profiles from the directories you provided and consolidating everything into your new MasseurMatch listing. This includes:</p>
-                        <ul>
-                          <li>All client reviews and ratings</li>
-                          <li>Your service history</li>
-                          <li>Verified status and trust signals</li>
-                        </ul>
-                      </div>
-
-                      <div class="step">
-                        <h3>⏱️ Timeline</h3>
-                        <p>Migration typically takes 24–48 hours. We'll send you an email as soon as your profile is live on MasseurMatch, and you can start accepting bookings right away.</p>
-                      </div>
-
-                      <div class="step">
-                        <h3>🤝 Need Help?</h3>
-                        <p>If you have questions about the migration or need to add more profiles, just reply to this email or contact our support team at concierge@masseurmatch.com.</p>
-                      </div>
-
-                      <p>We're excited to have you on board!</p>
-                      <p><strong>The MasseurMatch Team</strong></p>
-                    </div>
-
-                    <div class="footer">
-                      <p>© 2025 MasseurMatch. All rights reserved.</p>
-                      <p>This is an automated message. Please do not reply directly to this email if you're having issues — contact us at concierge@masseurmatch.com instead.</p>
-                    </div>
-                  </div>
-                </body>
-              </html>
-            `,
-          },
-        }),
-      }).catch((err) => {
-        console.error("[api/migrate/initiate] Email send failed:", err);
-        // Don't throw — email failure shouldn't block the migration request
-      });
-    } catch (emailErr) {
-      console.error("[api/migrate/initiate] Email error:", emailErr);
-    }
-
-    // Kick off scraping as soon as the response is sent instead of waiting
-    // for the next cron sweep. The cron route remains the retry safety net.
     after(async () => {
-      try {
-        await processPendingMigrations();
-      } catch (err) {
-        console.error("[api/migrate/initiate] Background processing failed:", err);
-      }
+      const results = await Promise.allSettled([
+        processPendingMigrations(),
+        sendEmail({
+          to: email,
+          subject: "We're Importing Your Profile — Sit Back & Relax",
+          react: React.createElement(
+            "div",
+            null,
+            React.createElement("h1", null, "We received your profile links"),
+            React.createElement(
+              "p",
+              null,
+              "MasseurMatch is reviewing your external profiles and imported reviews. Most requests are completed within 24–48 hours.",
+            ),
+            React.createElement("p", null, "We'll email you when the review is complete."),
+          ),
+        }),
+        notifyAdmin({
+          subject: `New signup profile import from ${email}`,
+          heading: "Profile import requested during signup",
+          fields: [
+            { label: "Provider email", value: email },
+            { label: "Profile ID", value: profile?.id ?? null },
+            { label: "Requests", value: String(migrationData.length) },
+            { label: "Platforms", value: migrationData.map((entry) => entry.platform).join(", ") },
+          ],
+          message: migrationData.map((entry) => entry.source_url).join("\n"),
+          action: { label: "Review imports", url: `${SITE_URL}/admin/migrations` },
+          replyTo: email,
+        }),
+      ]);
+
+      results.forEach((result, index) => {
+        if (result.status === "rejected") {
+          console.error(`[api/migrate/initiate] Background task ${index + 1} failed:`, result.reason);
+        }
+      });
     });
 
     return json({
       ok: true,
+      submitted: migrationData.length,
       message: "Migration request received. You'll be notified when your profile is ready.",
     });
   } catch (error) {

--- a/src/app/api/migrate/review/route.ts
+++ b/src/app/api/migrate/review/route.ts
@@ -1,13 +1,36 @@
-import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
-import { createSupabaseAdminClient, requireAdminSession } from "@/app/api/_lib/supabase-server";
-import { sendEmail } from "@/app/api/_lib/email";
 import React from "react";
+import { z } from "zod";
 
-interface ReviewDecision {
-  reviewId: string;
-  approved: boolean;
-  notes?: string;
-}
+import { sendEmail } from "@/app/api/_lib/email";
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+import { SITE_URL } from "@/lib/site";
+
+const reviewDecisionSchema = z.object({
+  reviewId: z.string().uuid(),
+  approved: z.boolean(),
+  notes: z.string().trim().max(1_000).optional(),
+});
+
+const reviewRequestSchema = z
+  .object({
+    migrationId: z.string().uuid(),
+    reviews: z.array(reviewDecisionSchema).min(1).max(1_000),
+  })
+  .superRefine((value, context) => {
+    const uniqueIds = new Set(value.reviews.map((review) => review.reviewId));
+    if (uniqueIds.size !== value.reviews.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["reviews"],
+        message: "Each imported review can only be decided once.",
+      });
+    }
+  });
 
 // Admin listing for /admin/migrations: pending/processed migrations with
 // their imported reviews attached.
@@ -56,130 +79,111 @@ export async function PUT(request: Request) {
   try {
     const session = await requireAdminSession(request);
     const userId = session.userId;
-
-    const body = await request.json();
-    const { migrationId, reviews, notes } = body as {
-      migrationId: string;
-      reviews: ReviewDecision[];
-      notes?: string;
-    };
-
-    if (!migrationId || !Array.isArray(reviews)) {
-      throw new RouteError(400, "Migration ID and reviews array are required.");
-    }
+    const body = await parseJsonBody(request, reviewRequestSchema);
 
     const adminClient = createSupabaseAdminClient();
 
-    // Update each review's approval status
-    for (const decision of reviews) {
+    const { data: migration, error: migrationError } = await (adminClient as any)
+      .from("profile_migrations")
+      .select("id, email")
+      .eq("id", body.migrationId)
+      .maybeSingle();
+
+    if (migrationError) throw new RouteError(500, "Could not retrieve migration.");
+    if (!migration) throw new RouteError(404, "Migration not found.");
+
+    const reviewIds = body.reviews.map((review) => review.reviewId);
+    const { data: migrationReviews, error: reviewLookupError } = await (adminClient as any)
+      .from("imported_reviews")
+      .select("id")
+      .eq("migration_id", body.migrationId);
+
+    if (reviewLookupError) throw new RouteError(500, "Could not verify imported reviews.");
+
+    const migrationReviewIds = new Set(
+      (migrationReviews ?? []).map((review: { id: string }) => review.id),
+    );
+    if (
+      migrationReviewIds.size !== reviewIds.length ||
+      reviewIds.some((reviewId) => !migrationReviewIds.has(reviewId))
+    ) {
+      throw new RouteError(400, "Include one decision for every review in this migration.");
+    }
+
+    for (const decision of body.reviews) {
       const updateData: Record<string, unknown> = {
+        is_public: decision.approved,
+        public_label: "Imported review",
         reviewed_at: new Date().toISOString(),
         reviewed_by: userId,
+        review_notes: decision.notes || null,
       };
 
-      if (decision.approved) {
-        updateData.is_public = true;
-      }
-
-      if (decision.notes) {
-        updateData.review_notes = decision.notes;
-      }
-
-      const { error: updateError } = await ((adminClient as any)
+      const { data: updatedReview, error: updateError } = await (adminClient as any)
         .from("imported_reviews")
         .update(updateData)
-        .eq("id", decision.reviewId));
+        .eq("id", decision.reviewId)
+        .eq("migration_id", body.migrationId)
+        .select("id")
+        .maybeSingle();
 
-      if (updateError) {
-        console.error("[api/migrate/review] Update error:", updateError.message);
+      if (updateError || !updatedReview) {
+        console.error(
+          "[api/migrate/review] Update error:",
+          updateError?.message || "review row did not match the selected migration",
+        );
         throw new RouteError(500, "Could not update review status.");
       }
     }
 
-    // Mark migration as verified if all reviews approved
-    const approvedCount = reviews.filter((r) => r.approved).length;
-    const { data: migration, error: selectError } = await ((adminClient as any)
+    const approvedCount = body.reviews.filter((review) => review.approved).length;
+    const rejectedCount = body.reviews.length - approvedCount;
+    const verifiedAt = new Date().toISOString();
+    const { error: verificationError } = await (adminClient as any)
       .from("profile_migrations")
-      .select("*")
-      .eq("id", migrationId)
-      .single());
+      .update({ is_verified: true, verified_at: verifiedAt, verified_by: userId })
+      .eq("id", body.migrationId);
 
-    if (selectError) {
-      console.error("[api/migrate/review] Select error:", selectError.message);
-      throw new RouteError(500, "Could not retrieve migration.");
-    }
+    if (verificationError) throw new RouteError(500, "Could not finalize migration review.");
 
-    if (migration && approvedCount > 0) {
-      const { error: migrationError } = await ((adminClient as any)
-        .from("profile_migrations")
-        .update({
-          is_verified: true,
-          verified_at: new Date().toISOString(),
-          verified_by: userId,
-        })
-        .eq("id", migrationId));
+    await recordAuditLog(userId, "profile_import_reviewed", "profile_migration", body.migrationId, {
+      approved_reviews: approvedCount,
+      rejected_reviews: rejectedCount,
+    });
 
-      if (!migrationError && migration.email) {
-        // Send notification to therapist
-        try {
-          await sendEmail({
-            to: migration.email,
-            subject: "Your Profile Migration is Complete — Reviews Now Live!",
-            react: React.createElement("div", {
-              dangerouslySetInnerHTML: {
-                __html: `
-                  <!DOCTYPE html>
-                  <html>
-                    <head>
-                      <style>
-                        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.6; color: #333; }
-                        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-                        .header { border-bottom: 3px solid #8B1E2D; padding-bottom: 20px; margin-bottom: 30px; }
-                        .header h1 { margin: 0; color: #111111; font-size: 24px; font-weight: bold; }
-                        .content { margin-bottom: 30px; }
-                        .stat-box { background: #F8EDEE; border-left: 4px solid #8B1E2D; padding: 20px; margin: 20px 0; text-align: center; }
-                        .stat-box .number { color: #8B1E2D; font-size: 32px; font-weight: bold; }
-                        .cta-button { display: inline-block; background-color: #8B1E2D; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold; margin: 20px 0; }
-                        .footer { border-top: 1px solid #E8E8E8; padding-top: 20px; font-size: 12px; color: #8E8E8E; }
-                      </style>
-                    </head>
-                    <body>
-                      <div class="container">
-                        <div class="header">
-                          <h1>🎉 Your Reviews Are Now Live!</h1>
-                        </div>
-                        <div class="content">
-                          <p>Great news! Your profile migration has been approved and your reviews are now appearing on your MasseurMatch profile.</p>
-                          <div class="stat-box">
-                            <div class="number">${approvedCount}</div>
-                            <div style="color: #6F6F6F; font-size: 14px; margin-top: 5px;">Reviews Published</div>
-                          </div>
-                          <p>Your reviews are now searchable on MasseurMatch and will help new clients find you. Your profile is live and accepting bookings.</p>
-                          <p><a href="https://masseurmatch.com/dashboard" class="cta-button">View Your Profile</a></p>
-                          <p>Questions? Contact concierge@masseurmatch.com</p>
-                          <p><strong>The MasseurMatch Team</strong></p>
-                        </div>
-                        <div class="footer">
-                          <p>© 2025 MasseurMatch. All rights reserved.</p>
-                        </div>
-                      </div>
-                    </body>
-                  </html>
-                `,
-              },
-            }),
-          }).catch((err) => {
-            console.error("[api/migrate/review] Email send failed:", err);
-          });
-        } catch (emailErr) {
-          console.error("[api/migrate/review] Email error:", emailErr);
-        }
-      }
+    if (migration.email) {
+      await sendEmail({
+        to: migration.email,
+        subject: approvedCount > 0
+          ? "Your imported reviews are now live"
+          : "Your profile import review is complete",
+        react: React.createElement(
+          "div",
+          null,
+          React.createElement("h1", null, "Your profile import review is complete"),
+          React.createElement(
+            "p",
+            null,
+            approvedCount > 0
+              ? `${approvedCount} imported ${approvedCount === 1 ? "review is" : "reviews are"} now published on your profile.`
+              : "None of the submitted reviews met the requirements for publication.",
+          ),
+          React.createElement(
+            "p",
+            null,
+            React.createElement("a", { href: `${SITE_URL}/pro/dashboard` }, "View your profile"),
+          ),
+        ),
+      }).catch((error) => {
+        console.error("[api/migrate/review] Email send failed:", error);
+      });
     }
 
     return json({
       ok: true,
-      message: `${approvedCount} reviews approved and published.`,
+      approved: approvedCount,
+      rejected: rejectedCount,
+      message: `${approvedCount} approved, ${rejectedCount} rejected.`,
     });
   } catch (error) {
     return errorResponse(error);

--- a/src/app/api/migrate/validate-url/route.ts
+++ b/src/app/api/migrate/validate-url/route.ts
@@ -1,85 +1,48 @@
-import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { z } from "zod";
 
-const PLATFORM_VALIDATORS: Record<string, (url: string) => boolean> = {
-  rubmaps: (url) => {
-    try {
-      const u = new URL(url);
-      return u.hostname.includes("rubmaps.com") && u.pathname.includes("/provider");
-    } catch {
-      return false;
-    }
-  },
-  "4corners": (url) => {
-    try {
-      const u = new URL(url);
-      return u.hostname.includes("4corners") && u.pathname.length > 1;
-    } catch {
-      return false;
-    }
-  },
-  nuru: (url) => {
-    try {
-      const u = new URL(url);
-      return u.hostname.includes("nurumap") && u.pathname.includes("/provider");
-    } catch {
-      return false;
-    }
-  },
-  custom: (url) => {
-    try {
-      const u = new URL(url);
-      return u.protocol.startsWith("http");
-    } catch {
-      return false;
-    }
-  },
-};
+import { assertRateLimit } from "@/app/_lib/security";
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { requireRequestSession } from "@/app/api/_lib/session";
+import { assertSafePublicUrl } from "@/app/api/migrate/_lib/source-url";
+
+const platforms = ["rubmaps", "4corners", "nuru", "custom"] as const;
+const schema = z.object({
+  url: z.string().trim().url().max(2048),
+  platform: z.enum(platforms),
+});
+
+function matchesHost(hostname: string, allowedHost: string) {
+  return hostname === allowedHost || hostname.endsWith(`.${allowedHost}`);
+}
+
+function assertPlatformUrl(platform: (typeof platforms)[number], url: URL) {
+  const hostname = url.hostname.toLowerCase();
+  const path = url.pathname.toLowerCase();
+  const valid =
+    platform === "custom" ||
+    (platform === "rubmaps" && matchesHost(hostname, "rubmaps.com") && path.includes("/provider")) ||
+    (platform === "4corners" && matchesHost(hostname, "4corners.xxx") && path.length > 1) ||
+    (platform === "nuru" && matchesHost(hostname, "nurumap.com") && path.includes("/provider"));
+
+  if (!valid) {
+    throw new RouteError(400, `Invalid ${platform} URL format. Please check and try again.`);
+  }
+}
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
-    const { url, platform } = body;
+    assertRateLimit(request, "profile-migration-validate-url", { limit: 20, windowMs: 60_000 });
+    await requireRequestSession(request);
 
-    if (!url || typeof url !== "string") {
-      throw new RouteError(400, "URL is required.");
+    const parsed = schema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      throw new RouteError(400, parsed.error.issues[0]?.message || "Enter a valid profile URL.");
     }
 
-    if (!platform || typeof platform !== "string") {
-      throw new RouteError(400, "Platform is required.");
-    }
+    const url = await assertSafePublicUrl(parsed.data.url);
+    assertPlatformUrl(parsed.data.platform, url);
 
-    if (!PLATFORM_VALIDATORS[platform]) {
-      throw new RouteError(400, "Unsupported platform.");
-    }
-
-    const isValid = PLATFORM_VALIDATORS[platform](url);
-    if (!isValid) {
-      throw new RouteError(400, `Invalid ${platform} URL format. Please check and try again.`);
-    }
-
-    // Optional: Make a HEAD request to verify the URL is reachable
-    try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-      const headRes = await fetch(url, {
-        method: "HEAD",
-        redirect: "follow",
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!headRes.ok && headRes.status !== 404) {
-        throw new RouteError(400, "Could not reach the URL. Please check it and try again.");
-      }
-    } catch (fetchErr) {
-      // If HEAD fails, that's okay — the URL might have CORS restrictions
-      // but we still accept it for backend validation
-      if (fetchErr instanceof RouteError) throw fetchErr;
-    }
-
-    return json({ ok: true, valid: true });
+    return json({ ok: true, valid: true, url: url.toString() });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/api/pro/profile-import/route.ts
+++ b/src/app/api/pro/profile-import/route.ts
@@ -2,10 +2,13 @@ import { after } from "next/server";
 import { z } from "zod";
 
 import { assertRateLimit } from "@/app/_lib/security";
+import { SITE_URL } from "@/lib/site";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { requireRequestSession } from "@/app/api/_lib/session";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { processPendingMigrations } from "@/app/api/migrate/_lib/processor";
+import { assertSafePublicUrl } from "@/app/api/migrate/_lib/source-url";
 
 const supportedPlatforms = [
   "rentmasseur",
@@ -50,56 +53,6 @@ const PLATFORM_HOST_MATCHERS: Record<Exclude<SupportedPlatform, "custom">, strin
   travelgay: ["travelgay.com"],
   hiswellness: ["hiswellness.co", "hiswellness.com"],
 };
-
-function isPrivateIpv4(hostname: string) {
-  const parts = hostname.split(".").map((part) => Number(part));
-  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-
-  const [a, b] = parts;
-  return (
-    a === 10 ||
-    a === 127 ||
-    a === 0 ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
-  );
-}
-
-function parseSafePublicUrl(rawUrl: string) {
-  let url: URL;
-
-  try {
-    url = new URL(rawUrl);
-  } catch {
-    throw new RouteError(400, "Enter a valid profile URL.");
-  }
-
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new RouteError(400, "Only HTTP and HTTPS profile links are supported.");
-  }
-
-  if (url.username || url.password) {
-    throw new RouteError(400, "Profile links cannot include embedded credentials.");
-  }
-
-  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  const blockedHost =
-    hostname === "localhost" ||
-    hostname === "::1" ||
-    hostname.endsWith(".local") ||
-    hostname.endsWith(".internal") ||
-    isPrivateIpv4(hostname);
-
-  if (!hostname || blockedHost) {
-    throw new RouteError(400, "That profile link cannot be accessed.");
-  }
-
-  url.hash = "";
-  return url;
-}
 
 function assertPlatformMatch(platform: SupportedPlatform, url: URL) {
   if (platform === "custom") return;
@@ -177,14 +130,16 @@ export async function POST(request: Request) {
       throw new RouteError(400, "Add an email address to your account before requesting an import.");
     }
 
-    const normalized: NormalizedEntry[] = parsed.data.profileUrls.map((entry) => {
-      const url = parseSafePublicUrl(entry.url);
-      assertPlatformMatch(entry.platform, url);
-      return {
-        platform: entry.platform,
-        source_url: url.toString(),
-      };
-    });
+    const normalized: NormalizedEntry[] = await Promise.all(
+      parsed.data.profileUrls.map(async (entry) => {
+        const url = await assertSafePublicUrl(entry.url);
+        assertPlatformMatch(entry.platform, url);
+        return {
+          platform: entry.platform,
+          source_url: url.toString(),
+        };
+      }),
+    );
 
     const uniqueByUrl: NormalizedEntry[] = Array.from(
       new Map<string, NormalizedEntry>(
@@ -230,11 +185,29 @@ export async function POST(request: Request) {
     }
 
     after(async () => {
-      try {
-        await processPendingMigrations();
-      } catch (error) {
-        console.error("[api/pro/profile-import] Background processing failed:", error);
-      }
+      const results = await Promise.allSettled([
+        processPendingMigrations(),
+        notifyAdmin({
+          subject: `New profile import request from ${email}`,
+          heading: "Profile import requested",
+          intro: "A provider submitted external profile links for review import.",
+          fields: [
+            { label: "Provider email", value: email },
+            { label: "Profile ID", value: profile.id },
+            { label: "Requests", value: String(rows.length) },
+            { label: "Platforms", value: rows.map((row) => row.platform).join(", ") },
+          ],
+          message: rows.map((row) => row.source_url).join("\n"),
+          action: { label: "Review imports", url: `${SITE_URL}/admin/migrations` },
+          replyTo: email,
+        }),
+      ]);
+
+      results.forEach((result, index) => {
+        if (result.status === "rejected") {
+          console.error(`[api/pro/profile-import] Background task ${index + 1} failed:`, result.reason);
+        }
+      });
     });
 
     return json({

--- a/src/app/signup/migration/page.tsx
+++ b/src/app/signup/migration/page.tsx
@@ -52,7 +52,7 @@ export default function SignupMigrationPage() {
 
       if (!res.ok) {
         const err = await res.json();
-        setValidationError(err.message || "Could not validate URL. Please check and try again.");
+        setValidationError(err.error || err.message || "Could not validate URL. Please check and try again.");
         setIsValidating(false);
         return false;
       }
@@ -112,7 +112,8 @@ export default function SignupMigrationPage() {
         });
 
         if (!res.ok) {
-          setValidationError("Failed to initiate migration. Please try again.");
+          const body = await res.json().catch(() => ({}));
+          setValidationError(body.error || body.message || "Failed to initiate migration. Please try again.");
           setIsSubmitting(false);
           return;
         }

--- a/src/app/therapists/[slug]/_components/vox/VoxProfile.tsx
+++ b/src/app/therapists/[slug]/_components/vox/VoxProfile.tsx
@@ -42,7 +42,13 @@ import { ReportProfileDialog } from "@/components/profile/ReportProfileDialog";
 import { trackConversion } from "@/lib/seo-tracking-config";
 
 type RelatedProfile = { name: string; slug: string; city: string; profilePhotoUrl?: string };
-type Review = { quote: string; author: string; date?: string };
+type Review = {
+  quote: string;
+  author: string;
+  date?: string;
+  rating?: number;
+  sourceLabel?: string;
+};
 
 const SERVICE_ICONS: Array<{ test: RegExp; Icon: typeof Sparkles }> = [
   { test: /deep|sport|recovery|trigger|therap/i, Icon: Activity },
@@ -82,7 +88,7 @@ export function VoxProfile({
   availableNow: boolean;
   lgbtqAffirming: boolean;
   knottyPrompt: string;
-  // Optional showcase-only social proof. Real directory profiles never pass these.
+  // Public reviews are pre-filtered on the server; source platforms stay private.
   reviews?: Review[];
   rating?: number;
   reviewCount?: number;
@@ -113,6 +119,7 @@ export function VoxProfile({
 
   const quickNavItems = [
     profile.galleryImages.length > 1 && { label: "Gallery", href: "#gallery" },
+    reviews.length > 0 && { label: "Reviews", href: "#reviews" },
     allServices.length > 0 && { label: "Services", href: "#services" },
     (profile.pricing.length > 0 || hasRate(profile.incallPrice)) && { label: "Rates", href: "#rates" },
     { label: "Availability", href: "#availability" },
@@ -327,29 +334,39 @@ export function VoxProfile({
           </Section>
         )}
 
-        {/* ── Reviews (showcase only — never shown for real directory profiles) */}
+        {/* ── Public imported reviews ─────────────────────────────────────── */}
         {reviews.length > 0 && (
-          <Section id="reviews" eyebrow="Testimonials" title="Client reviews">
+          <Section id="reviews" eyebrow="Approved history" title="Imported reviews">
             <div className="grid gap-4 md:grid-cols-3">
-              {reviews.slice(0, 6).map((review, index) => (
-                <figure
-                  key={index}
-                  className="flex h-full flex-col rounded-2xl border border-[#E8E8E8] bg-white p-6 shadow-sm"
-                >
-                  <span className="mb-3 flex items-center gap-0.5 text-[#8B1E2D]">
-                    {[0, 1, 2, 3, 4].map((i) => (
-                      <Star key={i} className="h-4 w-4 fill-current" strokeWidth={0} />
-                    ))}
-                  </span>
-                  <blockquote className="flex-1 text-[15px] leading-7 text-[#3f3a33]">
-                    &ldquo;{review.quote}&rdquo;
-                  </blockquote>
-                  <figcaption className="mt-4 text-sm font-semibold text-[#111111]">
-                    {review.author}
-                    {review.date ? <span className="ml-2 font-normal text-[#6F6050]">{review.date}</span> : null}
-                  </figcaption>
-                </figure>
-              ))}
+              {reviews.slice(0, 6).map((review, index) => {
+                const filledStars = Math.max(0, Math.min(5, Math.round(review.rating ?? 5)));
+                return (
+                  <figure
+                    key={`${review.author}-${review.date || index}`}
+                    className="flex h-full flex-col rounded-2xl border border-[#E8E8E8] bg-white p-6 shadow-sm"
+                  >
+                    <span className="mb-3 flex items-center gap-0.5" aria-label={`${filledStars} out of 5 stars`}>
+                      {[0, 1, 2, 3, 4].map((star) => (
+                        <Star
+                          key={star}
+                          className={`h-4 w-4 ${star < filledStars ? "fill-[#8B1E2D] text-[#8B1E2D]" : "text-slate-300"}`}
+                          strokeWidth={star < filledStars ? 0 : 1.75}
+                        />
+                      ))}
+                    </span>
+                    <blockquote className="flex-1 text-[15px] leading-7 text-[#3f3a33]">
+                      &ldquo;{review.quote}&rdquo;
+                    </blockquote>
+                    <figcaption className="mt-4 text-sm font-semibold text-[#111111]">
+                      {review.author}
+                      {review.date ? <span className="ml-2 font-normal text-[#6F6050]">{review.date}</span> : null}
+                      <span className="mt-1 block text-xs font-normal uppercase tracking-wide text-[#8E8E8E]">
+                        {review.sourceLabel || "Imported review"}
+                      </span>
+                    </figcaption>
+                  </figure>
+                );
+              })}
             </div>
           </Section>
         )}

--- a/src/app/therapists/[slug]/page.tsx
+++ b/src/app/therapists/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { JsonLd } from "@/app/_components/JsonLd";
 import {
   getCities,
   getProfilePhotos,
+  getPublicImportedReviews,
   getPublicTherapistBySlug,
   getPublicTherapists,
 } from "@/app/_lib/directory";
@@ -16,10 +17,23 @@ import { VoxProfile } from "@/app/therapists/[slug]/_components/vox/VoxProfile";
 import { DemoProfileBanner } from "@/app/_components/demo-profile-banner";
 import { ProfileViewTracker } from "@/app/therapists/[slug]/_components/ProfileViewTracker";
 import { ProfilePageTracker } from "@/app/therapists/[slug]/_components/ProfilePageTracker";
+import { SITE_URL } from "@/lib/site";
 
 type Params = { slug: string };
 
 export const revalidate = 60;
+
+function formatReviewDate(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
 
 export async function generateStaticParams() {
   // Public profiles are generated on demand to avoid build-time database dependency.
@@ -40,12 +54,11 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
   }
 
   const profile = buildProfileViewModel(dbProfile);
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://masseurmatch.com";
 
   return buildProfilePageMetadata(
     dbProfile,
     resolvedParams.slug,
-    siteUrl,
+    SITE_URL,
     profile.seoTitle,
     profile.seoDescription,
     profile.ogImage,
@@ -58,9 +71,10 @@ export default async function TherapistPage({ params }: { params: Promise<Params
 
   if (!dbProfile) notFound();
 
-  const [photos, relatedResult] = await Promise.all([
+  const [photos, relatedResult, importedReviews] = await Promise.all([
     getProfilePhotos(dbProfile.id),
     getPublicTherapists({ city: dbProfile.city || undefined, page: 1, pageSize: 6 }),
+    getPublicImportedReviews(dbProfile.id),
   ]);
   const profile = buildProfileViewModel(dbProfile, photos);
   const matchedCity = getCities().find((city) => city.name.toLowerCase() === profile.city.toLowerCase());
@@ -87,6 +101,23 @@ export default async function TherapistPage({ params }: { params: Promise<Params
     .slice(0, 6);
 
   const knottyPrompt = `Tell me about ${profile.name}, a massage therapist in ${profile.city}. What services and availability do they offer?`;
+  const reviews = importedReviews.map((review) => ({
+    quote: review.review_text,
+    author: review.reviewer_name || "Imported reviewer",
+    date: formatReviewDate(review.review_date),
+    rating: review.rating ?? undefined,
+    sourceLabel: review.public_label || "Imported review",
+  }));
+  const importedRatings = importedReviews
+    .map((review) => review.rating)
+    .filter((rating): rating is number => typeof rating === "number" && Number.isFinite(rating));
+  const importedAverage = importedRatings.length > 0
+    ? importedRatings.reduce((total, rating) => total + rating, 0) / importedRatings.length
+    : undefined;
+  const rating = typeof dbProfile.average_rating === "number" && dbProfile.average_rating > 0
+    ? dbProfile.average_rating
+    : importedAverage;
+  const reviewCount = Math.max(dbProfile.review_count ?? 0, reviews.length);
 
   return (
     <>
@@ -105,6 +136,9 @@ export default async function TherapistPage({ params }: { params: Promise<Params
         businessHours={dbProfile.business_hours}
         training={Array.isArray(dbProfile.training) ? dbProfile.training : []}
         education={Array.isArray(dbProfile.education) ? dbProfile.education : []}
+        reviews={reviews}
+        rating={rating}
+        reviewCount={reviewCount}
       />
     </>
   );

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1077,10 +1077,13 @@ export type Database = {
           created_at: string | null
           id: string
           imported_at: string | null
+          is_public: boolean | null
           profile_id: string | null
+          public_label: string | null
           rating: number | null
           review_date: string | null
           review_text: string | null
+          reviewer_anonymized: boolean | null
           reviewer_name: string | null
           source_platform: string | null
           source_url: string | null
@@ -1089,10 +1092,13 @@ export type Database = {
           created_at?: string | null
           id?: string
           imported_at?: string | null
+          is_public?: boolean | null
           profile_id?: string | null
+          public_label?: string | null
           rating?: number | null
           review_date?: string | null
           review_text?: string | null
+          reviewer_anonymized?: boolean | null
           reviewer_name?: string | null
           source_platform?: string | null
           source_url?: string | null
@@ -1101,10 +1107,13 @@ export type Database = {
           created_at?: string | null
           id?: string
           imported_at?: string | null
+          is_public?: boolean | null
           profile_id?: string | null
+          public_label?: string | null
           rating?: number | null
           review_date?: string | null
           review_text?: string | null
+          reviewer_anonymized?: boolean | null
           reviewer_name?: string | null
           source_platform?: string | null
           source_url?: string | null
@@ -4387,6 +4396,20 @@ export type Database = {
       }
     }
     Views: {
+      public_imported_reviews: {
+        Row: {
+          created_at: string | null
+          id: string | null
+          imported_at: string | null
+          profile_id: string | null
+          public_label: string | null
+          rating: number | null
+          review_date: string | null
+          review_text: string | null
+          reviewer_name: string | null
+        }
+        Relationships: []
+      }
       public_therapist_profiles: {
         Row: {
           availability_note: string | null

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -560,12 +560,41 @@ create table if not exists public.imported_reviews (
 
 alter table public.imported_reviews
   add column if not exists migration_id uuid,
+  add column if not exists imported_at timestamptz default now(),
   add column if not exists reviewer_anonymized boolean default false,
   add column if not exists is_public boolean default false,
+  add column if not exists public_label text not null default 'Imported review',
   add column if not exists reviewed_by uuid,
   add column if not exists reviewed_at timestamp,
   add column if not exists review_notes text,
   add column if not exists updated_at timestamp default now();
+
+create index if not exists idx_imported_reviews_public_profile_date
+  on public.imported_reviews (profile_id, review_date desc)
+  where is_public = true;
+
+create or replace view public.public_imported_reviews
+with (security_invoker = true) as
+select
+  ir.id,
+  ir.profile_id,
+  case
+    when coalesce(ir.reviewer_anonymized, false) then null
+    else ir.reviewer_name
+  end as reviewer_name,
+  ir.rating,
+  ir.review_text,
+  ir.review_date,
+  ir.public_label,
+  ir.imported_at,
+  ir.created_at
+from public.imported_reviews ir
+where ir.is_public = true;
+
+revoke all on public.public_imported_reviews from public, anon, authenticated;
+grant select on public.public_imported_reviews to service_role;
+drop policy if exists "Public can view approved imported reviews" on public.imported_reviews;
+revoke select on public.imported_reviews from anon;
 
 -- Profile migration pipeline (/api/migrate): one row per requested import of
 -- an external profile into MasseurMatch. Mirrors the table already live in

--- a/supabase/functions/_shared/resend-tags.ts
+++ b/supabase/functions/_shared/resend-tags.ts
@@ -1,0 +1,19 @@
+const MAX_TAG_LENGTH = 256;
+
+/**
+ * Resend tag values only accept ASCII letters, digits, underscores and dashes.
+ * Normalize every queue-sourced value at the delivery boundary so legacy rows
+ * cannot make an otherwise valid email fail.
+ */
+export function sanitizeResendTag(value: string | null | undefined, fallback: string): string {
+  const asciiValue = Array.from((value ?? "").normalize("NFKD"))
+    .filter((character) => character.codePointAt(0)! <= 0x7f)
+    .join("");
+  const normalized = asciiValue
+    .replace(/[^A-Za-z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, MAX_TAG_LENGTH);
+
+  return normalized || fallback;
+}

--- a/supabase/functions/process-lifecycle-email-queue/index.ts
+++ b/supabase/functions/process-lifecycle-email-queue/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2.57.2";
 import { checkRateLimit, rateLimitResponse, getClientKey } from "../_shared/rate-limit.ts";
+import { sanitizeResendTag } from "../_shared/resend-tags.ts";
 
 type QueueRow = {
   id: string;
@@ -218,10 +219,10 @@ serve(async (req) => {
             reply_to: row.reply_to || undefined,
             headers,
             tags: [
-              { name: "campaign", value: row.campaign_key || "none" },
-              { name: "flow", value: row.flow_key || "none" },
-              { name: "segment", value: row.segment || "none" },
-              { name: "template", value: row.template_key || "custom" },
+              { name: "campaign", value: sanitizeResendTag(row.campaign_key, "none") },
+              { name: "flow", value: sanitizeResendTag(row.flow_key, "none") },
+              { name: "segment", value: sanitizeResendTag(row.segment, "none") },
+              { name: "template", value: sanitizeResendTag(row.template_key, "custom") },
             ],
           }),
         });

--- a/supabase/migrations/20260801214441_finalize_profile_import_workflow.sql
+++ b/supabase/migrations/20260801214441_finalize_profile_import_workflow.sql
@@ -1,11 +1,16 @@
 alter table public.imported_reviews
+  add column if not exists imported_at timestamptz default now(),
   add column if not exists public_label text not null default 'Imported review';
 
-create or replace view public.public_imported_reviews as
+create or replace view public.public_imported_reviews
+with (security_invoker = true) as
 select
   ir.id,
   ir.profile_id,
-  ir.reviewer_name,
+  case
+    when coalesce(ir.reviewer_anonymized, false) then null
+    else ir.reviewer_name
+  end as reviewer_name,
   ir.rating,
   ir.review_text,
   ir.review_date,
@@ -14,6 +19,9 @@ select
   ir.created_at
 from public.imported_reviews ir
 where ir.is_public = true;
+
+revoke all on public.public_imported_reviews from public, anon, authenticated;
+grant select on public.public_imported_reviews to service_role;
 
 create or replace function public.sync_profile_import_ticket_status()
 returns trigger

--- a/supabase/migrations/20260804084500_admin_email_center_v2.sql
+++ b/supabase/migrations/20260804084500_admin_email_center_v2.sql
@@ -1,0 +1,400 @@
+-- Admin Email Center v2
+-- Durable campaigns/templates layered on the existing lifecycle queue.
+
+create table if not exists public.admin_email_templates (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  subject text not null,
+  body_html text not null,
+  body_text text,
+  send_category text not null default 'marketing' check (send_category in ('marketing', 'transactional')),
+  from_address text,
+  reply_to text,
+  is_active boolean not null default true,
+  created_by uuid references auth.users(id) on delete set null,
+  updated_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.admin_email_campaigns (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  subject text not null,
+  body_html text not null,
+  body_text text,
+  send_category text not null check (send_category in ('marketing', 'transactional')),
+  from_address text,
+  reply_to text,
+  audience jsonb not null default '{}'::jsonb,
+  scheduled_for timestamptz not null default now(),
+  status text not null default 'draft' check (status in ('draft', 'scheduled', 'processing', 'completed', 'cancelled')),
+  template_id uuid references public.admin_email_templates(id) on delete set null,
+  created_by uuid references auth.users(id) on delete set null,
+  cancelled_by uuid references auth.users(id) on delete set null,
+  cancelled_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_admin_email_campaigns_created_at
+  on public.admin_email_campaigns(created_at desc);
+create index if not exists idx_admin_email_templates_updated_at
+  on public.admin_email_templates(updated_at desc);
+
+alter table public.admin_email_templates enable row level security;
+alter table public.admin_email_campaigns enable row level security;
+-- No direct client policies. All access is through admin-gated server routes.
+
+create or replace function public.admin_email_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_admin_email_templates_updated_at on public.admin_email_templates;
+create trigger trg_admin_email_templates_updated_at
+before update on public.admin_email_templates
+for each row execute function public.admin_email_touch_updated_at();
+
+drop trigger if exists trg_admin_email_campaigns_updated_at on public.admin_email_campaigns;
+create trigger trg_admin_email_campaigns_updated_at
+before update on public.admin_email_campaigns
+for each row execute function public.admin_email_touch_updated_at();
+
+create or replace function public.admin_email_center_snapshot(
+  p_query text default null,
+  p_limit integer default 250
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_query text := lower(trim(coalesce(p_query, '')));
+  v_limit integer := greatest(1, least(coalesce(p_limit, 250), 500));
+  v_result jsonb;
+begin
+  select jsonb_build_object(
+    'recipients', coalesce((
+      select jsonb_agg(row_to_json(r) order by r.updated_at desc)
+      from (
+        select
+          p.user_id as "userId",
+          p.id as "profileId",
+          coalesce(nullif(p.display_name, ''), nullif(p.full_name, ''), 'Provider') as name,
+          coalesce(u.email, p.email_address, p.email) as email,
+          p.city,
+          p.state,
+          p.profile_status as "profileStatus",
+          coalesce(p.subscription_tier, p._tier, 'free') as plan,
+          coalesce(mp.marketing_opt_in, true) as "marketingOptIn",
+          exists (
+            select 1 from public.email_suppressions es
+            where lower(es.email) = lower(coalesce(u.email, p.email_address, p.email, ''))
+              and es.is_active = true
+          ) as suppressed,
+          p.updated_at
+        from public.profiles p
+        left join auth.users u on u.id = p.user_id
+        left join public.marketing_preferences mp on mp.user_id = p.user_id
+        where p.user_id is not null
+          and coalesce(u.email, p.email_address, p.email) is not null
+          and (
+            v_query = '' or
+            lower(coalesce(p.display_name, '') || ' ' || coalesce(p.full_name, '') || ' ' ||
+              coalesce(u.email, p.email_address, p.email, '') || ' ' || coalesce(p.city, '') || ' ' ||
+              coalesce(p.state, '') || ' ' || coalesce(p.profile_status, '') || ' ' ||
+              coalesce(p.subscription_tier, p._tier, 'free')) like '%' || v_query || '%'
+          )
+        order by p.updated_at desc
+        limit v_limit
+      ) r
+    ), '[]'::jsonb),
+    'templates', coalesce((
+      select jsonb_agg(row_to_json(t) order by t.updated_at desc)
+      from (
+        select id, name, description, subject, body_html as "bodyHtml", body_text as "bodyText",
+          send_category as "sendCategory", from_address as "fromAddress", reply_to as "replyTo",
+          is_active as "isActive", created_at as "createdAt", updated_at as "updatedAt"
+        from public.admin_email_templates
+        where is_active = true
+        order by updated_at desc
+        limit 100
+      ) t
+    ), '[]'::jsonb),
+    'campaigns', coalesce((
+      select jsonb_agg(row_to_json(c) order by c.created_at desc)
+      from (
+        select
+          campaign.id,
+          campaign.name,
+          campaign.subject,
+          campaign.send_category as "sendCategory",
+          campaign.scheduled_for as "scheduledFor",
+          campaign.status,
+          campaign.created_at as "createdAt",
+          count(q.id)::int as total,
+          count(q.id) filter (where q.status = 'queued')::int as queued,
+          count(q.id) filter (where q.status = 'processing')::int as processing,
+          count(q.id) filter (where q.status = 'sent')::int as sent,
+          count(q.id) filter (where q.status = 'suppressed')::int as suppressed,
+          count(q.id) filter (where q.status = 'failed')::int as failed
+        from public.admin_email_campaigns campaign
+        left join public.lifecycle_email_queue q
+          on q.payload ->> 'campaign_id' = campaign.id::text
+        group by campaign.id
+        order by campaign.created_at desc
+        limit 50
+      ) c
+    ), '[]'::jsonb),
+    'summary', jsonb_build_object(
+      'sent30d', (select count(*) from public.lifecycle_email_log where status = 'sent' and created_at >= now() - interval '30 days'),
+      'failed30d', (select count(*) from public.lifecycle_email_log where status = 'failed' and created_at >= now() - interval '30 days'),
+      'suppressed30d', (select count(*) from public.lifecycle_email_log where status = 'suppressed' and created_at >= now() - interval '30 days'),
+      'complaints30d', (select count(*) from public.email_provider_events where event_type = 'complained' and created_at >= now() - interval '30 days')
+    )
+  ) into v_result;
+
+  return v_result;
+end;
+$$;
+
+create or replace function public.admin_email_save_template(
+  p_admin_user_id uuid,
+  p_id uuid,
+  p_name text,
+  p_description text,
+  p_subject text,
+  p_body_html text,
+  p_body_text text,
+  p_send_category text,
+  p_from_address text,
+  p_reply_to text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  if trim(coalesce(p_name, '')) = '' or trim(coalesce(p_subject, '')) = '' or trim(coalesce(p_body_html, '')) = '' then
+    raise exception 'Template name, subject and HTML body are required';
+  end if;
+  if p_send_category not in ('marketing', 'transactional') then
+    raise exception 'Invalid send category';
+  end if;
+
+  insert into public.admin_email_templates (
+    id, name, description, subject, body_html, body_text, send_category,
+    from_address, reply_to, created_by, updated_by
+  ) values (
+    coalesce(p_id, gen_random_uuid()), trim(p_name), nullif(trim(coalesce(p_description, '')), ''),
+    trim(p_subject), p_body_html, nullif(p_body_text, ''), p_send_category,
+    nullif(trim(coalesce(p_from_address, '')), ''), nullif(trim(coalesce(p_reply_to, '')), ''),
+    p_admin_user_id, p_admin_user_id
+  )
+  on conflict (id) do update set
+    name = excluded.name,
+    description = excluded.description,
+    subject = excluded.subject,
+    body_html = excluded.body_html,
+    body_text = excluded.body_text,
+    send_category = excluded.send_category,
+    from_address = excluded.from_address,
+    reply_to = excluded.reply_to,
+    updated_by = excluded.updated_by,
+    is_active = true
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+create or replace function public.admin_email_create_campaign(
+  p_admin_user_id uuid,
+  p_name text,
+  p_subject text,
+  p_body_html text,
+  p_body_text text,
+  p_send_category text,
+  p_from_address text,
+  p_reply_to text,
+  p_scheduled_for timestamptz,
+  p_template_id uuid,
+  p_user_ids uuid[],
+  p_profile_statuses text[],
+  p_plans text[],
+  p_cities text[],
+  p_states text[]
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_campaign_id uuid;
+  v_row record;
+  v_queue record;
+  v_total integer := 0;
+  v_queued integer := 0;
+  v_suppressed integer := 0;
+  v_scheduled_for timestamptz := coalesce(p_scheduled_for, now());
+begin
+  if trim(coalesce(p_name, '')) = '' or trim(coalesce(p_subject, '')) = '' or trim(coalesce(p_body_html, '')) = '' then
+    raise exception 'Campaign name, subject and HTML body are required';
+  end if;
+  if p_send_category not in ('marketing', 'transactional') then
+    raise exception 'Invalid send category';
+  end if;
+
+  insert into public.admin_email_campaigns (
+    name, subject, body_html, body_text, send_category, from_address, reply_to,
+    audience, scheduled_for, status, template_id, created_by
+  ) values (
+    trim(p_name), trim(p_subject), p_body_html, nullif(p_body_text, ''), p_send_category,
+    nullif(trim(coalesce(p_from_address, '')), ''), nullif(trim(coalesce(p_reply_to, '')), ''),
+    jsonb_build_object(
+      'userIds', coalesce(to_jsonb(p_user_ids), '[]'::jsonb),
+      'profileStatuses', coalesce(to_jsonb(p_profile_statuses), '[]'::jsonb),
+      'plans', coalesce(to_jsonb(p_plans), '[]'::jsonb),
+      'cities', coalesce(to_jsonb(p_cities), '[]'::jsonb),
+      'states', coalesce(to_jsonb(p_states), '[]'::jsonb)
+    ),
+    v_scheduled_for,
+    case when v_scheduled_for > now() then 'scheduled' else 'processing' end,
+    p_template_id,
+    p_admin_user_id
+  ) returning id into v_campaign_id;
+
+  for v_row in
+    select distinct on (p.user_id)
+      p.user_id,
+      coalesce(u.email, p.email_address, p.email) as email,
+      coalesce(nullif(p.display_name, ''), nullif(p.full_name, ''), 'there') as recipient_name,
+      p.city,
+      p.state,
+      p.profile_status,
+      coalesce(p.subscription_tier, p._tier, 'free') as plan
+    from public.profiles p
+    left join auth.users u on u.id = p.user_id
+    where p.user_id is not null
+      and coalesce(u.email, p.email_address, p.email) is not null
+      and (
+        (
+          coalesce(array_length(p_user_ids, 1), 0) > 0
+          and p.user_id = any(p_user_ids)
+        )
+        or (
+          coalesce(array_length(p_user_ids, 1), 0) = 0
+          and (coalesce(array_length(p_profile_statuses, 1), 0) = 0 or p.profile_status = any(p_profile_statuses))
+          and (coalesce(array_length(p_plans, 1), 0) = 0 or coalesce(p.subscription_tier, p._tier, 'free') = any(p_plans))
+          and (coalesce(array_length(p_cities, 1), 0) = 0 or p.city = any(p_cities))
+          and (coalesce(array_length(p_states, 1), 0) = 0 or p.state = any(p_states))
+        )
+      )
+    order by p.user_id, p.updated_at desc
+    limit 500
+  loop
+    v_total := v_total + 1;
+
+    select * into v_queue
+    from public.queue_lifecycle_email(
+      v_row.user_id,
+      v_row.email,
+      v_row.recipient_name,
+      'admin_email_center',
+      'admin-' || v_campaign_id::text,
+      'admin_email_center',
+      coalesce(p_template_id::text, 'custom'),
+      p_send_category,
+      replace(replace(p_subject, '{{name}}', v_row.recipient_name), '{{city}}', coalesce(v_row.city, '')),
+      replace(replace(p_body_html, '{{name}}', v_row.recipient_name), '{{city}}', coalesce(v_row.city, '')),
+      case when p_body_text is null then null else replace(replace(p_body_text, '{{name}}', v_row.recipient_name), '{{city}}', coalesce(v_row.city, '')) end,
+      p_from_address,
+      p_reply_to,
+      jsonb_build_object(
+        'source', 'admin_email_center',
+        'campaign_id', v_campaign_id,
+        'profile_status', v_row.profile_status,
+        'plan', v_row.plan,
+        'city', v_row.city,
+        'state', v_row.state
+      ),
+      v_scheduled_for,
+      'admin-email:' || v_campaign_id::text || ':' || v_row.user_id::text
+    ) limit 1;
+
+    if v_queue.status = 'queued' then
+      v_queued := v_queued + 1;
+    else
+      v_suppressed := v_suppressed + 1;
+    end if;
+  end loop;
+
+  if v_total = 0 then
+    delete from public.admin_email_campaigns where id = v_campaign_id;
+    raise exception 'No eligible recipients matched the selected audience';
+  end if;
+
+  update public.admin_email_campaigns
+  set status = case
+    when v_queued = 0 then 'completed'
+    when v_scheduled_for > now() then 'scheduled'
+    else 'processing'
+  end
+  where id = v_campaign_id;
+
+  return jsonb_build_object(
+    'campaignId', v_campaign_id,
+    'total', v_total,
+    'queued', v_queued,
+    'suppressed', v_suppressed
+  );
+end;
+$$;
+
+create or replace function public.admin_email_cancel_campaign(
+  p_admin_user_id uuid,
+  p_campaign_id uuid
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_cancelled integer;
+begin
+  update public.lifecycle_email_queue
+  set status = 'skipped', suppression_reason = 'campaign_cancelled'
+  where payload ->> 'campaign_id' = p_campaign_id::text
+    and status = 'queued';
+  get diagnostics v_cancelled = row_count;
+
+  update public.admin_email_campaigns
+  set status = 'cancelled', cancelled_by = p_admin_user_id, cancelled_at = now()
+  where id = p_campaign_id;
+
+  return v_cancelled;
+end;
+$$;
+
+revoke all on function public.admin_email_center_snapshot(text, integer) from public, anon, authenticated;
+revoke all on function public.admin_email_save_template(uuid, uuid, text, text, text, text, text, text, text, text) from public, anon, authenticated;
+revoke all on function public.admin_email_create_campaign(uuid, text, text, text, text, text, text, text, timestamptz, uuid, uuid[], text[], text[], text[], text[]) from public, anon, authenticated;
+revoke all on function public.admin_email_cancel_campaign(uuid, uuid) from public, anon, authenticated;
+
+grant execute on function public.admin_email_center_snapshot(text, integer) to service_role;
+grant execute on function public.admin_email_save_template(uuid, uuid, text, text, text, text, text, text, text, text) to service_role;
+grant execute on function public.admin_email_create_campaign(uuid, text, text, text, text, text, text, text, timestamptz, uuid, uuid[], text[], text[], text[], text[]) to service_role;
+grant execute on function public.admin_email_cancel_campaign(uuid, uuid) to service_role;

--- a/supabase/migrations/20260804151505_repair_imported_reviews_and_admin_email_campaigns.sql
+++ b/supabase/migrations/20260804151505_repair_imported_reviews_and_admin_email_campaigns.sql
@@ -1,0 +1,153 @@
+-- Repair production environments where the import workflow migration was
+-- recorded before imported_reviews.imported_at existed.
+alter table public.imported_reviews
+  add column if not exists imported_at timestamptz default now(),
+  add column if not exists public_label text not null default 'Imported review';
+
+alter table public.imported_reviews
+  alter column imported_at set default now();
+
+update public.imported_reviews
+set imported_at = coalesce(created_at, now())
+where imported_at is null;
+
+create index if not exists idx_imported_reviews_public_profile_date
+  on public.imported_reviews (profile_id, review_date desc)
+  where is_public = true;
+
+create or replace view public.public_imported_reviews
+with (security_invoker = true) as
+select
+  ir.id,
+  ir.profile_id,
+  case
+    when coalesce(ir.reviewer_anonymized, false) then null
+    else ir.reviewer_name
+  end as reviewer_name,
+  ir.rating,
+  ir.review_text,
+  ir.review_date,
+  ir.public_label,
+  ir.imported_at,
+  ir.created_at
+from public.imported_reviews ir
+where ir.is_public = true;
+
+-- Public profile pages read this projection on the server with the service
+-- role. Anonymous access to the base table would expose source URLs and raw
+-- reviewer names, so remove that legacy policy and grant only the safe view.
+drop policy if exists "Public can view approved imported reviews" on public.imported_reviews;
+revoke select on public.imported_reviews from anon;
+revoke all on public.public_imported_reviews from public, anon, authenticated;
+grant select on public.public_imported_reviews to service_role;
+
+-- Campaign rows are summaries of lifecycle queue rows. Keep the summary in
+-- sync whenever the worker claims, retries, sends, suppresses or fails a row.
+create index if not exists idx_lifecycle_email_queue_admin_campaign
+  on public.lifecycle_email_queue ((payload ->> 'campaign_id'))
+  where payload ? 'campaign_id';
+
+create or replace function public.sync_admin_email_campaign_status()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_campaign_id uuid;
+begin
+  if coalesce(new.payload ->> 'campaign_id', '')
+    !~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89aAbB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+  then
+    return new;
+  end if;
+
+  v_campaign_id := (new.payload ->> 'campaign_id')::uuid;
+
+  update public.admin_email_campaigns campaign
+  set status = (
+        select case
+          when count(*) filter (where queue.status = 'processing') > 0 then 'processing'
+          when count(*) filter (where queue.status = 'queued') > 0 then
+            case
+              when min(queue.scheduled_for) filter (where queue.status = 'queued') > now() then 'scheduled'
+              else 'processing'
+            end
+          else 'completed'
+        end
+        from public.lifecycle_email_queue queue
+        where queue.payload ->> 'campaign_id' = v_campaign_id::text
+      ),
+      updated_at = now()
+  where campaign.id = v_campaign_id
+    and campaign.status <> 'cancelled';
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_sync_admin_email_campaign_status on public.lifecycle_email_queue;
+create trigger trg_sync_admin_email_campaign_status
+after insert or update of status, scheduled_for on public.lifecycle_email_queue
+for each row execute function public.sync_admin_email_campaign_status();
+
+revoke all on function public.sync_admin_email_campaign_status() from public, anon, authenticated;
+
+-- Reconcile rows created before the trigger existed.
+update public.admin_email_campaigns campaign
+set status = case
+      when exists (
+        select 1
+        from public.lifecycle_email_queue queue
+        where queue.payload ->> 'campaign_id' = campaign.id::text
+          and queue.status = 'processing'
+      ) then 'processing'
+      when exists (
+        select 1
+        from public.lifecycle_email_queue queue
+        where queue.payload ->> 'campaign_id' = campaign.id::text
+          and queue.status = 'queued'
+      ) then case
+        when exists (
+          select 1
+          from public.lifecycle_email_queue queue
+          where queue.payload ->> 'campaign_id' = campaign.id::text
+            and queue.status = 'queued'
+            and queue.scheduled_for <= now()
+        ) then 'processing'
+        else 'scheduled'
+      end
+      else 'completed'
+    end,
+    updated_at = now()
+where campaign.status <> 'cancelled';
+
+-- Trigger functions are internal implementation details, not public RPCs.
+-- Remove inherited EXECUTE grants and pin their search paths.
+alter function public.set_updated_at() set search_path = '';
+alter function public.admin_email_touch_updated_at() set search_path = '';
+alter function public.create_profile_import_ticket() set search_path = '';
+alter function public.refresh_imported_review_profile_stats() set search_path = '';
+alter function public.support_ticket_touch_parent() set search_path = '';
+alter function public.sync_profile_import_ticket_status() set search_path = '';
+alter function public.sync_profile_verified_photos() set search_path = '';
+
+revoke execute on function public.create_profile_import_ticket() from public, anon, authenticated;
+revoke execute on function public.admin_email_touch_updated_at() from public, anon, authenticated;
+revoke execute on function public.refresh_imported_review_profile_stats() from public, anon, authenticated;
+revoke execute on function public.support_ticket_touch_parent() from public, anon, authenticated;
+revoke execute on function public.sync_profile_import_ticket_status() from public, anon, authenticated;
+revoke execute on function public.sync_profile_verified_photos() from public, anon, authenticated;
+
+-- Reassert the service-role-only contract for Stripe webhook RPCs. These
+-- functions also contain an in-function service-role guard, so this is a
+-- second independent boundary.
+revoke execute on function public.process_stripe_payment_intent_succeeded(text, uuid) from public, anon, authenticated;
+revoke execute on function public.process_stripe_payment_intent_failed(text) from public, anon, authenticated;
+revoke execute on function public.process_stripe_identity_verified(text, uuid) from public, anon, authenticated;
+revoke execute on function public.process_stripe_identity_requires_input(text, text) from public, anon, authenticated;
+
+grant execute on function public.process_stripe_payment_intent_succeeded(text, uuid) to service_role;
+grant execute on function public.process_stripe_payment_intent_failed(text) to service_role;
+grant execute on function public.process_stripe_identity_verified(text, uuid) to service_role;
+grant execute on function public.process_stripe_identity_requires_input(text, text) to service_role;

--- a/tests/unit/index-eligibility.test.ts
+++ b/tests/unit/index-eligibility.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getProfileIndexRobots } from "@/lib/index-eligibility";
+
+describe("getProfileIndexRobots", () => {
+  it("indexes verified public profiles", () => {
+    expect(getProfileIndexRobots({ verification_status: "verified", city: "Dallas" } as never)).toBe(
+      "index, follow",
+    );
+  });
+
+  it("keeps unverified profiles out of the sitemap-compatible directive", () => {
+    expect(getProfileIndexRobots({ verification_status: "pending", city: "Dallas" } as never)).toBe(
+      "noindex, follow",
+    );
+  });
+});

--- a/tests/unit/page-metadata.test.ts
+++ b/tests/unit/page-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createPageMetadata } from "@/app/_lib/seo";
+import { getProfileCanonicalUrl } from "@/app/_lib/profile-metadata";
 import { SITE_URL } from "@/lib/site";
 
 describe("createPageMetadata", () => {
@@ -54,5 +55,19 @@ describe("createPageMetadata", () => {
     });
 
     expect(metadata.title).toBe("Dallas Male Massage Therapists | MasseurMatch");
+  });
+});
+
+describe("getProfileCanonicalUrl", () => {
+  it("never creates a double slash when the configured origin has a trailing slash", () => {
+    expect(getProfileCanonicalUrl("bruno-santos", "https://www.masseurmatch.com/")).toBe(
+      "https://www.masseurmatch.com/therapists/bruno-santos",
+    );
+  });
+
+  it("normalizes accidental slashes around the route parameter", () => {
+    expect(getProfileCanonicalUrl("/bruno-santos/", "https://www.masseurmatch.com///")).toBe(
+      "https://www.masseurmatch.com/therapists/bruno-santos",
+    );
   });
 });

--- a/tests/unit/resend-tags.test.ts
+++ b/tests/unit/resend-tags.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeResendTag } from "../../supabase/functions/_shared/resend-tags";
+
+describe("sanitizeResendTag", () => {
+  it("normalizes spaces and punctuation from lifecycle segments", () => {
+    expect(sanitizeResendTag("Therapist - Profile Incomplete", "none")).toBe(
+      "Therapist_-_Profile_Incomplete",
+    );
+  });
+
+  it("uses a safe fallback for empty or non-ASCII-only values", () => {
+    expect(sanitizeResendTag("✨", "none")).toBe("none");
+    expect(sanitizeResendTag(null, "custom")).toBe("custom");
+  });
+
+  it("caps values at the provider limit", () => {
+    expect(sanitizeResendTag("a".repeat(300), "none")).toHaveLength(256);
+  });
+});

--- a/tests/unit/source-url.test.ts
+++ b/tests/unit/source-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPrivateNetworkAddress,
+  parseSafePublicUrl,
+} from "@/app/api/migrate/_lib/source-url";
+
+describe("profile import source URL security", () => {
+  it("accepts normal public HTTP and HTTPS URLs", () => {
+    expect(parseSafePublicUrl("https://example.com/profile#reviews").toString()).toBe(
+      "https://example.com/profile",
+    );
+    expect(parseSafePublicUrl("http://example.com/profile").protocol).toBe("http:");
+  });
+
+  it("rejects credentials and local hostnames", () => {
+    expect(() => parseSafePublicUrl("https://user:pass@example.com/profile")).toThrow();
+    expect(() => parseSafePublicUrl("http://localhost:5432/")).toThrow();
+    expect(() => parseSafePublicUrl("http://service.internal/")).toThrow();
+  });
+
+  it("recognizes private and metadata-service IP ranges", () => {
+    for (const address of ["127.0.0.1", "10.0.0.1", "169.254.169.254", "192.168.1.4", "::1", "fd00::1"]) {
+      expect(isPrivateNetworkAddress(address), address).toBe(true);
+    }
+    expect(isPrivateNetworkAddress("8.8.8.8")).toBe(false);
+    expect(isPrivateNetworkAddress("2606:4700:4700::1111")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- integrates and repairs the pending People CRM and Admin Email Center work from #643 and #644
- restores the unmerged All Admin Tools and approved imported-review flows
- fixes campaign recipient selection, template duplication, queue status reconciliation, Resend-safe tags, and sandboxed email previews
- fixes account deactivate/reactivate/delete consistency and profile rejection handling
- hardens profile-import URLs against SSRF, validates redirects and response size, and adds admin notifications
- fixes public imported-review moderation/privacy, sitemap eligibility, and profile canonical URLs
- adds the database repair migration and hardens trigger/RPC privileges
- updates the DB contract validator to recognize secure views

## Validation

- `pnpm run release:check`
- 183 unit tests passed
- 8 API smoke checks passed
- lint and TypeScript passed
- DB contract and release audit passed
- Next.js production build passed (280 static pages)

Supersedes #643 and #644.

Closes #624