### PR TITLE
security: remove legacy public profile photo policies

### DIFF
--- a/supabase/migrations/20260804224000_remove_legacy_profile_photo_public_access.sql
+++ b/supabase/migrations/20260804224000_remove_legacy_profile_photo_public_access.sql
@@ -1,0 +1,19 @@
+-- Remove legacy permissive profile photo policies that bypass moderation.
+-- The canonical policies are:
+--   profile_photos_public_read_approved
+--   profile_photos_owner_select
+--   profile_photos_owner_insert
+--   profile_photos_owner_update
+--   profile_photos_owner_delete
+
+begin;
+
+drop policy if exists "Users can view profile photos" on public.profile_photos;
+drop policy if exists "Users can insert their own profile photos" on public.profile_photos;
+drop policy if exists "Users can update their own profile photos" on public.profile_photos;
+drop policy if exists "Users can delete their own profile photos" on public.profile_photos;
+drop policy if exists "Users can insert their own profile photos (authenticated)" on public.profile_photos;
+drop policy if exists "Users can update their own profile photos (authenticated)" on public.profile_photos;
+drop policy if exists "Users can delete their own profile photos (authenticated)" on public.profile_photos;
+
+commit;


### PR DESCRIPTION
Removes obsolete profile_photos RLS policies that still allowed unrestricted public SELECT access and duplicated owner write access.

Production migration has already been applied successfully.

Validated after apply:
• only approved photos are publicly readable
• authenticated owners retain select, insert, update, and delete access
• pending photos with public URLs: 0
• approved photos preserved: 9
• pending photo moderation queue: 0