### PR TITLE
Fix public blog publishing, city listing, and Email Center audience loading

### DIFF
--- a/src/app/_lib/public-admin-blog.ts
+++ b/src/app/_lib/public-admin-blog.ts
@@ -1,0 +1,82 @@
+import "server-only";
+
+import { readContentStore, type StoredBlogPost } from "@/app/api/_lib/content-store";
+import type { BlogPost, BlogSection } from "@/app/_lib/blog-data";
+
+const EDITORIAL_AUTHOR = {
+  name: "MasseurMatch Editorial",
+  title: "Wellness & Inclusivity Editor",
+  bio: "The MasseurMatch editorial team produces evidence-based wellness content for LGBTQ+-inclusive audiences.",
+};
+
+export type PublicAdminBlogListItem = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  category: string;
+  date: string;
+  readTime: string;
+};
+
+export async function getPublicAdminBlogPosts(): Promise<StoredBlogPost[]> {
+  const store = await readContentStore();
+  return [...store.blogPosts].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+}
+
+export async function getPublicAdminBlogPost(slug: string): Promise<BlogPost | null> {
+  const posts = await getPublicAdminBlogPosts();
+  const post = posts.find((candidate) => candidate.slug === slug);
+  return post ? mapStoredPost(post) : null;
+}
+
+export function toPublicAdminBlogListItem(post: StoredBlogPost): PublicAdminBlogListItem {
+  return {
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    category: "MasseurMatch News",
+    date: formatDate(post.publishedAt),
+    readTime: `${estimateReadTime(post)} min read`,
+  };
+}
+
+function mapStoredPost(post: StoredBlogPost): BlogPost {
+  return {
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    content: post.blocks.map(mapBlock),
+    category: "MasseurMatch News",
+    tags: ["MasseurMatch", "wellness"],
+    author: {
+      ...EDITORIAL_AUTHOR,
+      name: post.author || EDITORIAL_AUTHOR.name,
+    },
+    publishedAt: normalizeDate(post.publishedAt),
+    updatedAt: post.updatedAt || normalizeDate(post.publishedAt),
+    readTimeMinutes: estimateReadTime(post),
+  };
+}
+
+function mapBlock(block: StoredBlogPost["blocks"][number]): BlogSection {
+  if (block.type === "heading") return { type: "h2", content: block.text };
+  if (block.type === "list") return { type: "ul", content: block.items };
+  return { type: "paragraph", content: block.text };
+}
+
+function estimateReadTime(post: StoredBlogPost): number {
+  const text = post.blocks
+    .map((block) => block.type === "list" ? block.items.join(" ") : block.text)
+    .join(" ");
+  return Math.max(1, Math.ceil(text.split(/\s+/).filter(Boolean).length / 200));
+}
+
+function normalizeDate(value: string): string {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T12:00:00Z` : value;
+}
+
+function formatDate(value: string): string {
+  const date = new Date(normalizeDate(value));
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}

--- a/src/app/api/admin/blog/route.ts
+++ b/src/app/api/admin/blog/route.ts
@@ -10,20 +10,12 @@ import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/h
 import { requireAdminSession, recordAuditLog } from "@/app/api/_lib/supabase-server";
 import { slugify } from "@/app/api/_lib/text";
 import type { BlogBlock } from "@/app/blog/posts";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 const blogBlockSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("paragraph"),
-    text: z.string().min(1),
-  }),
-  z.object({
-    type: z.literal("heading"),
-    text: z.string().min(1),
-  }),
-  z.object({
-    type: z.literal("list"),
-    items: z.array(z.string().min(1)).min(1),
-  }),
+  z.object({ type: z.literal("paragraph"), text: z.string().min(1) }),
+  z.object({ type: z.literal("heading"), text: z.string().min(1) }),
+  z.object({ type: z.literal("list"), items: z.array(z.string().min(1)).min(1) }),
 ]);
 
 const blogSchema = z.object({
@@ -35,9 +27,7 @@ const blogSchema = z.object({
   blocks: z.array(blogBlockSchema).min(1),
 });
 
-const deleteBlogSchema = z.object({
-  slug: z.string().min(1),
-});
+const deleteBlogSchema = z.object({ slug: z.string().min(1) });
 
 type BlogInput = {
   slug?: string;
@@ -48,13 +38,48 @@ type BlogInput = {
   blocks: BlogBlock[];
 };
 
+type LooseAdmin = { from: (table: string) => any };
+
+function publicContent(post: StoredBlogPost) {
+  return post.blocks.map((block) => {
+    if (block.type === "heading") return { type: "h2", content: block.text };
+    if (block.type === "list") return { type: "ul", content: block.items };
+    return { type: "paragraph", content: block.text };
+  });
+}
+
+async function syncPublicPost(post: StoredBlogPost) {
+  const admin = createAdminClient() as unknown as LooseAdmin;
+  const { error } = await admin.from("blog_posts").upsert(
+    {
+      slug: post.slug,
+      title: post.title,
+      excerpt: post.excerpt,
+      seo_description: post.excerpt,
+      content: JSON.stringify(publicContent(post)),
+      tags: ["MasseurMatch", "wellness"],
+      published_at: `${post.publishedAt}T12:00:00Z`,
+      updated_at: post.updatedAt,
+    },
+    { onConflict: "slug" },
+  );
+
+  if (error) {
+    throw new RouteError(500, `Post saved in admin store but public publishing failed: ${error.message}`);
+  }
+}
+
+async function removePublicPost(slug: string) {
+  const admin = createAdminClient() as unknown as LooseAdmin;
+  const { error } = await admin.from("blog_posts").delete().eq("slug", slug);
+  if (error) throw new RouteError(500, `Admin post deleted but public removal failed: ${error.message}`);
+}
+
 async function saveBlogPost(input: BlogInput): Promise<StoredBlogPost> {
   const store = await readContentStore();
   const slug = slugify(input.slug || input.title);
 
-  if (!slug) {
-    throw new RouteError(400, "A valid slug or title is required.");
-  }
+  if (!slug) throw new RouteError(400, "A valid slug or title is required.");
 
   const post: StoredBlogPost = {
     slug,
@@ -69,11 +94,8 @@ async function saveBlogPost(input: BlogInput): Promise<StoredBlogPost> {
   const nextPosts = store.blogPosts.filter((candidate) => candidate.slug !== slug);
   nextPosts.unshift(post);
 
-  await writeContentStore({
-    ...store,
-    blogPosts: nextPosts,
-  });
-
+  await writeContentStore({ ...store, blogPosts: nextPosts });
+  await syncPublicPost(post);
   return post;
 }
 
@@ -81,18 +103,11 @@ async function deleteBlogPost(slug: string) {
   const store = await readContentStore();
   const nextPosts = store.blogPosts.filter((candidate) => candidate.slug !== slug);
 
-  if (nextPosts.length === store.blogPosts.length) {
-    throw new RouteError(404, "Blog post not found.");
-  }
+  if (nextPosts.length === store.blogPosts.length) throw new RouteError(404, "Blog post not found.");
 
-  await writeContentStore({
-    ...store,
-    blogPosts: nextPosts,
-  });
-
-  return {
-    slug,
-  };
+  await writeContentStore({ ...store, blogPosts: nextPosts });
+  await removePublicPost(slug);
+  return { slug };
 }
 
 export async function POST(request: Request) {
@@ -101,14 +116,8 @@ export async function POST(request: Request) {
     const body = (await parseJsonBody(request, blogSchema)) as BlogInput;
     const post = await saveBlogPost(body);
 
-    await recordAuditLog(admin.userId, "save_blog_post", "blog", post.slug, {
-      title: post.title,
-    });
-
-    return json({
-      ok: true,
-      post,
-    });
+    await recordAuditLog(admin.userId, "save_blog_post", "blog", post.slug, { title: post.title });
+    return json({ ok: true, post });
   } catch (error) {
     return errorResponse(error);
   }
@@ -121,11 +130,7 @@ export async function DELETE(request: Request) {
     const result = await deleteBlogPost(body.slug);
 
     await recordAuditLog(admin.userId, "delete_blog_post", "blog", result.slug);
-
-    return json({
-      ok: true,
-      ...result,
-    });
+    return json({ ok: true, ...result });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/api/admin/cities/route.ts
+++ b/src/app/api/admin/cities/route.ts
@@ -38,12 +38,18 @@ async function saveCity(input: z.infer<typeof citySchema>): Promise<StoredCity> 
   const nextCities = store.cities.filter((candidate) => candidate.slug !== slug);
   nextCities.unshift(city);
 
-  await writeContentStore({
-    ...store,
-    cities: nextCities,
-  });
-
+  await writeContentStore({ ...store, cities: nextCities });
   return city;
+}
+
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    const store = await readContentStore();
+    return json({ ok: true, cities: store.cities });
+  } catch (error) {
+    return errorResponse(error);
+  }
 }
 
 export async function POST(request: Request) {
@@ -63,10 +69,7 @@ export async function POST(request: Request) {
       console.error("[api/admin/cities] Revalidation failed:", error);
     });
 
-    return json({
-      ok: true,
-      city,
-    });
+    return json({ ok: true, city });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/blog/_components/AdminPublishedPosts.tsx
+++ b/src/app/blog/_components/AdminPublishedPosts.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+import type { PublicAdminBlogListItem } from "@/app/_lib/public-admin-blog";
+
+export function AdminPublishedPosts({ posts }: { posts: PublicAdminBlogListItem[] }) {
+  if (posts.length === 0) return null;
+
+  const [featured, ...rest] = posts;
+
+  return (
+    <section style={{ maxWidth: 1100, margin: "0 auto", padding: "64px 24px 0" }}>
+      <div style={{ marginBottom: 28 }}>
+        <p style={{ fontFamily: "system-ui, sans-serif", fontSize: 11, letterSpacing: "0.18em", textTransform: "uppercase", color: "#8B1E2D", marginBottom: 8 }}>
+          Latest from MasseurMatch
+        </p>
+        <h2 style={{ fontSize: "clamp(26px, 4vw, 40px)", fontWeight: 400, margin: 0 }}>Published Articles</h2>
+      </div>
+
+      {featured ? (
+        <article style={{ background: "#111111", color: "#FFFFFF", padding: "40px", marginBottom: 2 }}>
+          <p style={{ fontFamily: "system-ui, sans-serif", fontSize: 11, color: "#8B1E2D", textTransform: "uppercase", letterSpacing: "0.14em" }}>{featured.category}</p>
+          <Link href={`/blog/${featured.slug}`} style={{ color: "inherit", textDecoration: "none" }}>
+            <h3 style={{ fontSize: "clamp(24px, 3vw, 34px)", fontWeight: 400, lineHeight: 1.2, margin: "14px 0" }}>{featured.title}</h3>
+          </Link>
+          <p style={{ fontFamily: "system-ui, sans-serif", lineHeight: 1.7, color: "rgba(255,255,255,.68)", maxWidth: 720 }}>{featured.excerpt}</p>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "center", marginTop: 24, fontFamily: "system-ui, sans-serif", fontSize: 12 }}>
+            <span style={{ color: "rgba(255,255,255,.5)" }}>{featured.date} | {featured.readTime}</span>
+            <Link href={`/blog/${featured.slug}`} style={{ color: "#FFFFFF", display: "inline-flex", alignItems: "center", gap: 6, textDecoration: "none" }}>
+              Read article <ArrowRight size={14} />
+            </Link>
+          </div>
+        </article>
+      ) : null}
+
+      {rest.length > 0 ? (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 2 }}>
+          {rest.map((post) => (
+            <article key={post.slug} style={{ border: "1px solid rgba(17,17,17,.08)", padding: 28 }}>
+              <p style={{ fontFamily: "system-ui, sans-serif", fontSize: 10, color: "#8B1E2D", textTransform: "uppercase", letterSpacing: "0.14em" }}>{post.category}</p>
+              <Link href={`/blog/${post.slug}`} style={{ color: "inherit", textDecoration: "none" }}>
+                <h3 style={{ fontSize: 20, fontWeight: 400, lineHeight: 1.3, margin: "12px 0" }}>{post.title}</h3>
+              </Link>
+              <p style={{ fontFamily: "system-ui, sans-serif", fontSize: 14, lineHeight: 1.65, color: "#6B7280" }}>{post.excerpt}</p>
+              <p style={{ fontFamily: "system-ui, sans-serif", fontSize: 11, color: "#9CA3AF", marginTop: 18 }}>{post.date} | {post.readTime}</p>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,11 @@
-﻿import type { Metadata } from "next";
+import type { Metadata } from "next";
 import Script from "next/script";
 import { BlogContent } from "./_components/BlogContent";
 import { NewsletterSignup } from "./_components/NewsletterSignup";
+import { AdminPublishedPosts } from "./_components/AdminPublishedPosts";
+import { getPublicAdminBlogPosts, toPublicAdminBlogListItem } from "@/app/_lib/public-admin-blog";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Blog | Massage Therapy Tips, Wellness & LGBTQ+ Resources - MasseurMatch",
@@ -32,7 +36,10 @@ const jsonLd = {
   },
 };
 
-export default function BlogPage() {
+export default async function BlogPage() {
+  const storedPosts = await getPublicAdminBlogPosts();
+  const publishedPosts = storedPosts.map(toPublicAdminBlogListItem);
+
   return (
     <>
       <Script
@@ -90,13 +97,12 @@ export default function BlogPage() {
               lineHeight: 1.7,
             }}
           >
-            Wellness insight, LGBTQ+ health resources, and industry expertise -
-            curated for clients and therapists alike.
+            Wellness insight, LGBTQ+ health resources, and industry expertise - curated for clients and therapists alike.
           </p>
         </section>
 
+        <AdminPublishedPosts posts={publishedPosts} />
         <BlogContent />
-
         <NewsletterSignup />
       </div>
     </>

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -464,10 +464,10 @@ create table if not exists public.blog_posts (
   slug text unique,
   title text,
   excerpt text,
-  body text,
+  seo_description text,
+  content text,
   tags text[] default '{}',
   published_at timestamptz,
-  seo_description text,
   created_at timestamptz default timezone('utc', now()),
   updated_at timestamptz default timezone('utc', now())
 );
@@ -1518,9 +1518,6 @@ alter table public.audit_log
   add column if not exists reason text,
   add column if not exists target_profile_id uuid,
   add column if not exists target_user_id uuid;
-
-alter table public.blog_posts
-  add column if not exists body text;
 
 alter table public.conversations
   add column if not exists participant_a_id uuid references auth.users(id) on delete cascade,

--- a/supabase/migrations/20260806101500_fix_email_snapshot_and_publish_admin_blog.sql
+++ b/supabase/migrations/20260806101500_fix_email_snapshot_and_publish_admin_blog.sql
@@ -1,0 +1,69 @@
+-- Repair the Email Center snapshot aliases used by the outer json aggregations.
+-- The subqueries expose camelCase aliases, so ordering by snake_case names fails.
+do $$
+declare
+  function_definition text;
+begin
+  select pg_get_functiondef(
+    'public.admin_email_center_snapshot(text,integer)'::regprocedure
+  ) into function_definition;
+
+  function_definition := replace(
+    function_definition,
+    'order by t.updated_at desc',
+    'order by t."updatedAt" desc'
+  );
+  function_definition := replace(
+    function_definition,
+    'order by c.created_at desc',
+    'order by c."createdAt" desc'
+  );
+
+  execute function_definition;
+end;
+$$;
+
+-- Publish posts that already exist in the durable admin_content singleton.
+-- Future saves are synchronized by /api/admin/blog.
+insert into public.blog_posts (
+  slug,
+  title,
+  excerpt,
+  seo_description,
+  content,
+  tags,
+  published_at,
+  updated_at
+)
+select
+  post ->> 'slug',
+  post ->> 'title',
+  post ->> 'excerpt',
+  post ->> 'excerpt',
+  coalesce((
+    select jsonb_agg(
+      case block ->> 'type'
+        when 'heading' then jsonb_build_object('type', 'h2', 'content', block ->> 'text')
+        when 'list' then jsonb_build_object('type', 'ul', 'content', coalesce(block -> 'items', '[]'::jsonb))
+        else jsonb_build_object('type', 'paragraph', 'content', block ->> 'text')
+      end
+    )
+    from jsonb_array_elements(coalesce(post -> 'blocks', '[]'::jsonb)) block
+  ), '[]'::jsonb)::text,
+  array['MasseurMatch', 'wellness']::text[],
+  coalesce((post ->> 'publishedAt')::date::timestamptz, now()),
+  coalesce((post ->> 'updatedAt')::timestamptz, now())
+from public.admin_content content_store
+cross join lateral jsonb_array_elements(coalesce(content_store.blog_posts, '[]'::jsonb)) post
+where content_store.id = 'singleton'
+  and nullif(post ->> 'slug', '') is not null
+  and nullif(post ->> 'title', '') is not null
+  and nullif(post ->> 'excerpt', '') is not null
+on conflict (slug) do update set
+  title = excluded.title,
+  excerpt = excluded.excerpt,
+  seo_description = excluded.seo_description,
+  content = excluded.content,
+  tags = excluded.tags,
+  published_at = excluded.published_at,
+  updated_at = excluded.updated_at;


### PR DESCRIPTION
## Summary

Fixes three confirmed admin and public content failures found during read-only QA.

### Blog publishing

- Connects `/blog` to the same durable `admin_content` store used by the admin Blog manager.
- Publishes future admin-created posts into `public.blog_posts`, which is already used by `/blog/[slug]`.
- Adds a migration backfill so existing posts such as `qa-diagnostic-test-post` become publicly resolvable after deployment.
- Keeps the existing editorial content as fallback content.

### Cities

- Adds authenticated `GET /api/admin/cities` support so saved cities can be listed instead of returning HTTP 405.

### Email Center

- Adds a production migration that repairs invalid outer ordering references in `admin_email_center_snapshot`:
  - `t.updated_at` to `t."updatedAt"`
  - `c.created_at` to `c."createdAt"`
- Restores audience, template, and campaign snapshot loading without exposing raw database errors.

## Safety

- No test blog post or city was deleted.
- No campaign was created or sent.
- No live account, profile, or audience data was modified.

## Required verification

- Run lint, typecheck, tests, database migration validation, and build.
- Confirm `/blog` shows stored CMS posts.
- Confirm `/blog/qa-diagnostic-test-post` resolves after migration.
- Confirm `GET /api/admin/cities` returns the stored city list.
- Confirm Email Center loads recipients without a 500 response.
