### PR TITLE
fix: harden Supabase security advisor findings

### DIFF
--- a/supabase/migrations/20260807030000_fix_security_advisors.sql
+++ b/supabase/migrations/20260807030000_fix_security_advisors.sql
@@ -1,0 +1,27 @@
+-- Harden Supabase security advisor findings without changing app behavior.
+--
+-- 1. admin_email_templates / admin_email_campaigns are server-only tables.
+--    service_role is the only role with direct table privileges and bypasses RLS,
+--    so permissive USING (true) policies are unnecessary.
+-- 2. set_updated_at must pin search_path to prevent caller-controlled object resolution.
+--
+-- Deliberately not changing public.is_admin() here. Multiple production RLS policies
+-- depend on it and a previous EXECUTE revoke broke anonymous public profile reads.
+
+begin;
+
+drop policy if exists admin_email_templates_all on public.admin_email_templates;
+drop policy if exists admin_email_campaigns_all on public.admin_email_campaigns;
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+set search_path = pg_catalog, public
+as $$
+begin
+  new.updated_at = pg_catalog.timezone('utc', now());
+  return new;
+end;
+$$;
+
+commit;


### PR DESCRIPTION
## Summary

Adds a focused security migration for the current Supabase Security Advisor warnings.

## Changes

- Drops permissive `USING (true)` RLS policies from `admin_email_templates` and `admin_email_campaigns`.
- Keeps those tables server-only. Current production grants show `service_role` as the direct table role, and the admin email RPCs are executable only by `service_role`.
- Pins `public.set_updated_at()` to `search_path = pg_catalog, public`.

## Deliberately not changed

`public.is_admin()` remains `SECURITY DEFINER` and executable by `anon` / `authenticated` because multiple production RLS policies depend on it. A prior revoke broke anonymous public profile reads, and the repository contains a dedicated migration documenting that regression.

The remaining Auth warnings for leaked password protection and MFA require Supabase Auth dashboard configuration rather than SQL.

## Validation performed

- Queried live production policies and function grants.
- Confirmed both email table policies are currently `FOR ALL TO public USING (true)`.
- Confirmed admin email RPCs are not executable by `anon` or `authenticated` and are executable by `service_role`.
- Confirmed `is_admin()` is referenced by multiple production RLS policies.

## Risk

Low for the included migration. No application route behavior should change because server access uses `service_role`, which bypasses RLS. `is_admin()` is intentionally left unchanged pending a dedicated RLS refactor.