### PR TITLE
Fix profile CMS save contract

### DIFF
--- a/src/app/pro/profile/cms/ProProfileCmsPageClient.tsx
+++ b/src/app/pro/profile/cms/ProProfileCmsPageClient.tsx
@@ -245,9 +245,20 @@ export default function ProProfileCmsPageClient() {
     setErrors({});
 
     try {
-      const response = await postJson<ProfileResponse>("/api/pro/profile/cms-update", form);
+      let updatedProfile = profile;
+      const changedFields = Object.entries(form).filter(
+        ([key, value]) => profile && JSON.stringify(profile[key]) !== JSON.stringify(value)
+      );
 
-      setProfile(response.profile);
+      for (const [fieldName, value] of changedFields) {
+        const response = await postJson<ProfileResponse>("/api/pro/profile/cms-update", {
+          field_name: fieldName,
+          value,
+        });
+        updatedProfile = response.profile;
+      }
+
+      setProfile(updatedProfile);
       toast({
         title: "Profile saved",
         description: "Your CMS profile has been updated successfully.",


### PR DESCRIPTION
## Summary

Ports the only exclusive fix from the stale `claude/server-500-error-4vefhs` branch without bringing its obsolete dependency changes.

The profile CMS currently posts the entire form to `/api/pro/profile/cms-update`, while the API expects individual `{ field_name, value }` updates. This change detects modified fields and submits them one at a time, then refreshes local profile state.

## Safety

- No dependency changes
- No database changes
- No unrelated stale branch code
- File was verified unchanged on main since the stale branch merge base

## Validation

Require full CI, release checks, preview deployment, E2E and accessibility checks before merge.