### PR TITLE
ci(vercel): deploy previews only for pull requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,16 @@ Example: `fetchCanonical` (follows Vercel's same-path cross-origin redirects tra
 - Before pushing, run: `npx tsc --noEmit`, `npx eslint <changed files>`,
   `pnpm run build`, and verify `pnpm-lock.yaml` is updated.
 - Do not open PRs unless explicitly asked.
+
+## Deployments
+
+Vercel does not build every commit. `vercel.json` delegates the decision to
+`scripts/vercel-ignore-build.mjs` (`ignoreCommand`), which builds production
+(`main`) and pull-request previews, and **skips pushes to a branch that has no
+pull request open**. Skipped builds appear as *Skipped*, never as *Error*.
+
+The reason is that deployment records are immutable: a work-in-progress commit
+that fails to compile leaves a permanent red row in the Deployments list even
+after the next commit fixes it. Open a pull request — a draft is enough — as
+soon as you want a preview URL or CI coverage; both are keyed to the pull
+request, not to the branch.

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,51 @@
+/**
+ * Vercel "Ignored Build Step" — decides whether a commit deserves a deployment.
+ *
+ * Wired up through `ignoreCommand` in vercel.json. Vercel inverts the exit code:
+ *   exit 1 → continue building
+ *   exit 0 → skip the build (shows as "Skipped", never as "Error")
+ *
+ * Why this exists: every push to a feature branch used to trigger its own
+ * preview build, so a broken work-in-progress commit stayed red in the
+ * Deployments list forever — even after the very next commit fixed it. Those
+ * records are immutable, so the only cure is to not build throwaway commits.
+ *
+ * What still builds:
+ *   - production (the `main` branch), always;
+ *   - preview commits that belong to an open pull request, because CI resolves
+ *     that preview URL and runs the Playwright E2E and accessibility suites
+ *     against it (see the `preview-url` job in .github/workflows/ci.yml).
+ *
+ * What gets skipped: pushes to a branch with no pull request open yet. Nothing
+ * is lost by skipping those — .github/workflows/ci.yml is also scoped to pull
+ * requests and main, so a branch without a pull request is private scratch
+ * space. Opening the pull request (a draft counts) turns both on: CI runs
+ * typecheck, lint, unit tests, the DB contract and a production build, and
+ * Vercel publishes the preview those Playwright suites target.
+ */
+
+const PRODUCTION_BRANCH = "main";
+
+const environment = process.env.VERCEL_ENV?.trim() ?? "";
+const branch = process.env.VERCEL_GIT_COMMIT_REF?.trim() ?? "";
+const pullRequestId = process.env.VERCEL_GIT_PULL_REQUEST_ID?.trim() ?? "";
+
+function build(reason) {
+  console.log(`Building: ${reason}.`);
+  process.exit(1);
+}
+
+function skip(reason) {
+  console.log(`Skipping build: ${reason}.`);
+  process.exit(0);
+}
+
+if (environment === "production" || branch === PRODUCTION_BRANCH) {
+  build(`production deployment from ${branch || PRODUCTION_BRANCH}`);
+}
+
+if (pullRequestId) {
+  build(`preview for pull request #${pullRequestId} on ${branch || "unknown branch"}`);
+}
+
+skip(`${branch || "this branch"} has no open pull request, so no preview is needed yet`);

--- a/vercel.json
+++ b/vercel.json
@@ -2,16 +2,11 @@
   "installCommand": "corepack enable && corepack prepare pnpm@10.32.1 --activate && pnpm install --no-frozen-lockfile",
   "buildCommand": "corepack enable && corepack prepare pnpm@10.32.1 --activate && pnpm run build",
   "framework": "nextjs",
+  "ignoreCommand": "node scripts/vercel-ignore-build.mjs",
   "crons": [
     {
       "path": "/api/migrate/process",
       "schedule": "0 6 * * *"
     }
-  ],
-  "git": {
-    "deploymentEnabled": {
-      "main": true,
-      "*": false
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Why

The Deployments list is a wall of red. Almost all of it is history that cannot be repaired — deployment records are immutable, so a build that failed in June stays red forever, and clicking *Redeploy* on an old deployment rebuilds that old commit and fails again.

The part that *is* fixable is the flow that keeps producing new red rows: **every push to a feature branch triggered its own preview build.** A work-in-progress commit that does not compile gets its own permanent red row even when the very next commit fixes it. That is exactly where the two most recent red previews came from — `ca4051c` and `c70c7ee` on `fix/referral-antifraud-20260808`, both superseded minutes later by commits that are now green on `main`.

`vercel.json` already tried to express the right policy:

```json
"git": { "deploymentEnabled": { "main": true, "*": false } }
```

It never took effect. The `*` glob does not match branch names containing a slash, and essentially every branch in this repo is slashed (`fix/…`, `feature/…`, `claude/…`), so previews kept deploying while the config claimed they were off.

## What changed

Replaced the ineffective glob with Vercel's supported *Ignored Build Step*, keyed off environment variables Vercel actually populates:

| Scenario | Result |
| --- | --- |
| Production (`main`) | **Build** |
| Preview, commit belongs to an open pull request | **Build** |
| Preview, branch has no pull request yet | **Skip** |

A skipped build is reported by Vercel as *Skipped*, not *Error* — so work-in-progress commits stop generating red rows entirely.

Preview deployments for pull requests are kept **deliberately**: the `preview-url` job in `.github/workflows/ci.yml` resolves that preview URL and runs the Playwright E2E and accessibility suites against it. Disabling previews outright would have left those suites silently falling through to their `PLAYWRIGHT_BASE_URL` fallback.

This pairs cleanly with the existing CI triggers (`pull_request` + `push` to `main`): a branch without a pull request is private scratch space with no CI and no deploy, and opening a pull request — a draft is enough — turns both on at once.

## Files

- `scripts/vercel-ignore-build.mjs` — new; the decision logic, with the exit-code contract documented (`exit 1` → build, `exit 0` → skip).
- `vercel.json` — wire up `ignoreCommand`, drop the `git.deploymentEnabled` block that never worked.

## Verification

The decision script was exercised across all five scenarios, including the slashed-branch case the old glob missed:

```
production / main                       -> BUILD (exit 1)
preview / branch WITH open PR           -> BUILD (exit 1)
main pushed but VERCEL_ENV unset        -> BUILD (exit 1)   safety net
preview / slashed branch, NO PR         -> SKIP  (exit 0)
preview / flat branch, NO PR            -> SKIP  (exit 0)
```

Full gate re-run on this branch:

| Check | Result |
| --- | --- |
| `pnpm typecheck` | exit 0, no errors |
| `pnpm lint` | clean |
| `pnpm test:unit` | 18 files, 194 tests passing |
| `pnpm validate:db-contract` | DB contract OK |
| `pnpm run build` | full production build succeeds |

## Note on the reported typecheck failure

The `src/app/api/admin/verification/route.ts` `TS2345` errors were from an older run and are already fixed on `main`. The reported signature was `<T extends { user_id: string }>` at line 95; current code reads `<T extends { user_id: string | null }>` at line 91, fixed by `35ac5c4` and `1fc9cd7`. `pnpm typecheck` exits 0 on `main` today.

This pull request is itself the first test of the new policy — it should produce exactly one preview deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr9DuKEBZ1VEnRVTYRLHMq)_