### PR TITLE
Fix identity lookup for fallback therapist profiles

### DIFF
--- a/src/app/_lib/identity-verification.ts
+++ b/src/app/_lib/identity-verification.ts
@@ -11,6 +11,8 @@ export type CanonicalIdentityStatus =
   | "canceled"
   | "verified";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function normalizeIdentityStatus(value: unknown): CanonicalIdentityStatus {
   const status = typeof value === "string" ? value.trim().toLowerCase() : "";
 
@@ -58,7 +60,7 @@ export async function getCanonicalIdentityStatusForUser(
 export async function getCanonicalIdentityStatusForProfile(
   profileId: string | null | undefined,
 ): Promise<CanonicalIdentityStatus> {
-  if (!profileId) return "not_started";
+  if (!profileId || !UUID_RE.test(profileId)) return "not_started";
 
   try {
     const admin = createSupabaseAdminClient();


### PR DESCRIPTION
## Summary

Prevents identity verification owner lookups from querying `profiles.id` with synthetic fallback IDs such as `fallback-ethan-cole`, `fallback-kevin-os`, and `fallback-bruno-santos`.

## Change

- Adds UUID validation in `getCanonicalIdentityStatusForProfile`.
- Returns `not_started` immediately for non-UUID profile IDs.
- Avoids Postgres/Supabase UUID errors and removes recurring production log noise while preserving successful therapist page responses.

## Production symptom fixed

`[identity-verification] Failed to resolve profile owner.` on fallback therapist pages returning HTTP 200.