### PR TITLE
Fix TypeScript deployment error in referrals route

### DIFF
--- a/src/app/api/pro/referrals/route.ts
+++ b/src/app/api/pro/referrals/route.ts
@@ -17,8 +17,8 @@ const rpc = async <T>(
 };
 
 type ReferralDashboardPayload = {
-  summary?: Record<string, unknown>;
-  referrals?: Array<Record<string, unknown>>;
+  summary?: Record<string, unknown> | null;
+  referrals?: Array<Record<string, unknown> | null> | null;
 };
 
 export async function GET(request: Request) {


### PR DESCRIPTION
## Summary

Resolves TypeScript type error that was blocking CI/CD deployment:

```
error TS2322: Type 'Json[] | undefined' is not assignable to type 'Record<string, unknown>[] | undefined'.
  Type 'Json[]' is not assignable to type 'Record<string, unknown>[]'.
    Type 'Json' is not assignable to type 'Record<string, unknown>'.
      Type 'null' is not assignable to type 'Record<string, unknown>'.
```

## Root Cause

The `ReferralDashboardPayload` type didn't account for Supabase's JSON type which can contain `null` values. Arrays from RPC calls can contain nulls, which aren't assignable to `Record<string, unknown>`.

## Changes

Updated type definitions to correctly reflect Supabase RPC return values:
- `summary?: Record<string, unknown>` → `summary?: Record<string, unknown> | null`
- `referrals?: Array<Record<string, unknown>>` → `referrals?: Array<Record<string, unknown> | null> | null`

## Verification

✅ TypeScript type checking passes  
✅ No new linting errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK3QtxuXbWHYjAS7aFJTgQ)_