### PR TITLE
FINAL GO LIVE: production schema, auth, CI, Stripe, and legacy cleanup

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -50,5 +50,10 @@ jobs:
         run: pnpm validate:db-contract
       - name: Release audit
         run: pnpm release:audit
+      # Aggregate gate. The discrete steps above exist so a failure points at the
+      # exact gate; this step additionally verifies the aggregate script itself
+      # stays wired to the same set of checks.
+      - name: Release check (aggregate gate)
+        run: pnpm release:check
       - name: Production build
         run: pnpm build

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -2,7 +2,81 @@
 
 This checklist defines the minimum release gates required before sending MasseurMatch to production.
 
-> **Final go-live closure pass (2026-07-25):** full repository gate (section 1) passes end to end.
+> **Final go-live closure pass (2026-08-09):** full repository gate (section 1) passes end to end.
+>
+> The repository entered this pass already green on every gate, so this pass is
+> narrow by design: it closes two real defects and one blind spot in the gate
+> itself rather than restating checks that already hold.
+>
+> Changes in this pass (2026-08-09):
+> - `scripts/validate-db-contract.mjs`: the contract gate validated tables and
+>   columns but never functions, so a `.rpc()` call with no matching SQL
+>   definition passed every gate and failed only at runtime (a Stripe webhook
+>   that never syncs a tier, an admin panel that never loads). The validator now
+>   collects every RPC the app invokes — both the direct call form and the
+>   `as unknown as` cast form used where the generated Supabase types do not
+>   know the function — and fails when any of them has no
+>   `create [or replace] function` anywhere under `supabase/`. All 14 RPCs
+>   currently referenced resolve; the check was verified against a deliberately
+>   broken reference before being committed.
+> - `src/app/auth/callback/route.ts` + new `src/app/auth/callback/destination.ts`:
+>   fixed the Google sign-in destination. The social buttons on the "Sign up"
+>   tab always attach `next=/pro/onboard`, and the callback honoured `next`
+>   verbatim for any account that already had a profile — so an existing
+>   provider who signed in with Google from that tab was sent back into the plan
+>   picker instead of their dashboard. New accounts now enter onboarding at
+>   `/pro/onboard` (the same entry point the password signup form uses, so
+>   social and password signups converge); returning users get `next`, except
+>   when `next` is the onboarding entry, which resolves to `/pro/dashboard`.
+>   The routing rules moved into a dependency-free module so they are unit
+>   tested (`tests/unit/auth-callback-destination.test.ts`, 7 cases, including
+>   open-redirect rejection).
+> - `.github/workflows/release-checks.yml`: added the `pnpm release:check`
+>   aggregate step between `release:audit` and `build`. See the risk note below.
+> - `src/components/ui/therapist-card-tilt.tsx`: translated the remaining
+>   Portuguese in the usage example (`"Deep Tissue · Relaxamento"` /
+>   `"São Paulo, SP"`) to the English US sample already used by the design-system
+>   page. `tests/api/profiles-listing.spec.ts`: the anonymous-rejection case now
+>   filters on an encoded US city instead of `São Paulo`.
+> - Re-verified as already correct, unchanged: no legacy artifacts
+>   (`vite.config.ts`, `index.html`, `package-lock.json`, `public/robots.txt`
+>   absent); `packageManager` is `pnpm@10.32.1`; `.gitattributes` is exactly
+>   `* text=auto eol=lf`; `.vscode/extensions.json` recommends only the three
+>   required extensions; Tailwind content paths contain no `src/mm` or
+>   `src/pages` globs; `profiles_profile_status_check` already excludes
+>   `submitted` and no `profile_status: "submitted"` remains in source
+>   (`submitted` is retained only on `profile_reviews.status`, where the review
+>   workflow needs it); no public phone OTP UI (only email OTP and Stripe
+>   Identity — phone stays a profile field); Stripe checkout sends
+>   `metadata.user_id` on both the session and the subscription; the webhook
+>   verifies signatures, is idempotent via `stripe_events`, and syncs tier,
+>   `_tier`, `photo_limit`, `visibility_level`, customer/subscription IDs and
+>   `current_period_end`, downgrading to `free` on
+>   `customer.subscription.deleted`; `release:audit` fails when
+>   `STRIPE_PRICE_STANDARD|PRO|ELITE` are unset while `STRIPE_SECRET_KEY` is set.
+> - Risk note — `pnpm release:check` in CI: this step re-runs lint, typecheck,
+>   test, validate:sitemap, validate:db-contract, release:audit **and build**,
+>   all of which already ran as discrete steps, and is followed by another
+>   `pnpm build`. It adds no new signal and roughly doubles CI wall time. It is
+>   included because the release specification enumerates it; deleting the step
+>   is a safe one-line revert if throughput matters more than the aggregate
+>   script staying exercised.
+> - Open item — `mm_session`: the specification asks the OAuth callback to
+>   "sync mm_session". No such cookie is issued anywhere in the codebase; the
+>   app is fully on Supabase SSR cookies (`sb-*`), and `mm_session` survives
+>   only as a name in the logout sweep and the cookie-policy copy. The callback
+>   does establish the session (`exchangeCodeForSession` writes the auth cookies
+>   onto the response) and does sync the profile/role rows via
+>   `ensureUserProfileAndRole`. Re-introducing a bespoke session cookie would be
+>   a second, parallel auth system, so it was deliberately not done. Removing
+>   the two dead `mm_session` references is left as separate cleanup.
+> - Validation results (2026-08-09): `pnpm install --frozen-lockfile`, lockfile
+>   diff clean, `pnpm lint` (0 errors), `pnpm typecheck`, `pnpm test`
+>   (201 unit + 8 API smoke), `pnpm validate:sitemap`,
+>   `pnpm validate:db-contract`, `pnpm release:audit`, `pnpm release:check`, and
+>   `pnpm build` all pass.
+>
+> Previous closure (2026-07-25): full repository gate (section 1) passes end to end.
 >
 > Changes in this pass (2026-07-25):
 > - `.github/workflows/release-checks.yml`: the single `pnpm release:check` step was split

--- a/scripts/validate-db-contract.mjs
+++ b/scripts/validate-db-contract.mjs
@@ -10,6 +10,10 @@ const SCHEMA_EXTENSION_PATHS = [
   path.join(ROOT, "supabase/migrations/20260806230000_demand_radar_pipeline.sql"),
 ];
 const SCAN_DIRS = ["src", "scripts", "tests", "supabase"];
+// Every .sql file that can define a database function. Unlike the table/column
+// contract (which the schema lock owns outright), function bodies live in the
+// migration history, so the RPC check reads the whole SQL corpus.
+const SQL_DEFINITION_DIRS = ["supabase"];
 
 const REQUIRED_TABLES = [
   "users",
@@ -396,6 +400,57 @@ function scanReferences() {
   return references;
 }
 
+/**
+ * Collects every Postgres function name defined anywhere in the SQL corpus.
+ * Matches `create [or replace] function [public.]name(` in either case.
+ */
+function collectDefinedFunctions() {
+  const defined = new Set();
+  const functionRegex = new RegExp(
+    `create\\s+(?:or\\s+replace\\s+)?function\\s+(?:${IDENT_TOKEN}\\s*\\.\\s*)?(${IDENT_TOKEN})\\s*\\(`,
+    "gi",
+  );
+
+  for (const file of SQL_DEFINITION_DIRS.flatMap(walkFiles)) {
+    if (!file.endsWith(".sql")) continue;
+    const normalized = normalizeSql(fs.readFileSync(file, "utf8"));
+    let match;
+    while ((match = functionRegex.exec(normalized))) {
+      defined.add(unquoteIdentifier(match[1]).toLowerCase());
+    }
+  }
+
+  return defined;
+}
+
+/**
+ * Collects every RPC name the application invokes. Covers the direct call form
+ * and the cast form used where the generated Supabase types do not yet know the
+ * function, i.e. the rpc member cast through an inline signature before being
+ * applied to the function name.
+ */
+function scanRpcReferences() {
+  const references = new Map();
+  const direct = /\.rpc\(\s*["'`]([a-zA-Z_][a-zA-Z0-9_]*)["'`]/g;
+  const cast = /\.rpc\s+as\s+unknown\s+as[\s\S]{0,500}?\)\(\s*["'`]([a-zA-Z_][a-zA-Z0-9_]*)["'`]/g;
+
+  for (const file of SCAN_DIRS.flatMap(walkFiles)) {
+    if (file.endsWith(".sql")) continue;
+    const source = fs.readFileSync(file, "utf8");
+    for (const regex of [direct, cast]) {
+      regex.lastIndex = 0;
+      let match;
+      while ((match = regex.exec(source))) {
+        const name = match[1].toLowerCase();
+        if (!references.has(name)) references.set(name, new Set());
+        references.get(name).add(path.relative(ROOT, file));
+      }
+    }
+  }
+
+  return references;
+}
+
 function schemaContainsAllowedValues(sql, constraintName, values) {
   const normalized = normalizeSql(sql);
   const index = normalized.indexOf(constraintName.toLowerCase());
@@ -445,6 +500,17 @@ for (const [table, columns] of scanned) {
   for (const [column, files] of columns) {
     if (!contract.get(table)?.has(column)) errors.push(`Referenced column missing from schema lock: ${table}.${column} (${[...files].slice(0, 3).join(", ")})`);
   }
+}
+
+// Every RPC the application calls must be defined by some migration. A missing
+// definition is invisible at build/type time and only surfaces as a runtime 500
+// (a Stripe webhook that never syncs a tier, an admin panel that never loads).
+const definedFunctions = collectDefinedFunctions();
+for (const [rpcName, files] of scanRpcReferences()) {
+  if (definedFunctions.has(rpcName)) continue;
+  errors.push(
+    `Referenced RPC missing from SQL definitions: ${rpcName} (${[...files].slice(0, 3).join(", ")})`,
+  );
 }
 
 if (errors.length) {

--- a/src/app/auth/callback/destination.ts
+++ b/src/app/auth/callback/destination.ts
@@ -1,0 +1,45 @@
+/**
+ * Post-authentication routing for the OAuth / email-link callback.
+ *
+ * Kept in its own module (no Supabase or Next.js imports) so the routing rules
+ * are unit-testable without booting the route handler's dependency graph.
+ */
+
+/**
+ * Canonical onboarding entry point. Middleware maps it to the current first
+ * step of the signup wizard, so callers never hardcode that step.
+ */
+export const ONBOARDING_ENTRY = "/pro/onboard";
+
+export const DASHBOARD = "/pro/dashboard";
+
+/**
+ * Restricts a caller-supplied `next` to a same-origin absolute path.
+ * Protocol-relative values (`//evil.com`) are rejected as open redirects.
+ */
+export function sanitizeRedirect(next: string | null): string {
+  if (!next) return DASHBOARD;
+  if (!next.startsWith("/") || next.startsWith("//")) return DASHBOARD;
+  return next;
+}
+
+/**
+ * Chooses where an authenticated user lands.
+ *
+ * New accounts enter onboarding at {@link ONBOARDING_ENTRY}, the same entry
+ * point the password signup form uses, so social and password signups converge.
+ *
+ * Returning users go where they asked — except when that is the onboarding
+ * entry. The social buttons on the "Sign up" tab always attach
+ * `next=/pro/onboard`, so an existing provider who signs in with Google from
+ * that tab would otherwise be dropped back into the plan picker instead of
+ * their dashboard.
+ */
+export function resolveAuthDestination(options: {
+  profileCreated: boolean;
+  next: string;
+}): string {
+  if (options.profileCreated) return ONBOARDING_ENTRY;
+  if (options.next === ONBOARDING_ENTRY) return DASHBOARD;
+  return options.next;
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -2,17 +2,11 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import type { EmailOtpType, User } from "@supabase/supabase-js";
 import { assertRateLimit } from "@/app/_lib/security";
+import { resolveAuthDestination, sanitizeRedirect } from "@/app/auth/callback/destination";
 import { ensureUserProfileAndRole } from "@/app/api/_lib/supabase-server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isExpectedInvalidSessionError } from "@/lib/supabase/auth-errors";
 import { createServerSupabase } from "@/lib/supabase/server";
-
-function sanitizeRedirect(next: string | null): string {
-  const fallback = "/pro/dashboard";
-  if (!next) return fallback;
-  if (!next.startsWith("/") || next.startsWith("//")) return fallback;
-  return next;
-}
 
 function failedAuthRedirect(origin: string, type: EmailOtpType | null) {
   if (type === "recovery") {
@@ -116,9 +110,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // New accounts continue the signup wizard; returning users go where they
-  // asked (default: their dashboard).
-  const destination = profileCreated ? "/signup/plan" : next;
+  const destination = resolveAuthDestination({ profileCreated, next });
   return NextResponse.redirect(`${origin}${destination}`);
 }
 

--- a/src/components/ui/therapist-card-tilt.tsx
+++ b/src/components/ui/therapist-card-tilt.tsx
@@ -14,13 +14,13 @@ import { cn } from "@/lib/utils";
  *
  * Usage:
  *   <TherapistCardTilt
- *     name="Sofia Almeida"
- *     specialty="Deep Tissue · Relaxamento"
- *     location="São Paulo, SP"
+ *     name="James Carter"
+ *     specialty="Deep Tissue · Swedish"
+ *     location="Los Angeles, CA"
  *     rating={4.9}
  *     reviewCount={128}
  *     pricePerHour={180}
- *     avatarUrl="/images/sofia.jpg"
+ *     avatarUrl="/images/james-carter.jpg"
  *     verified
  *   />
  */

--- a/tests/api/profiles-listing.spec.ts
+++ b/tests/api/profiles-listing.spec.ts
@@ -14,7 +14,9 @@ test.describe('GET /api/pro/profiles', () => {
   });
 
   test('rejects anonymous requests with query params (city)', async ({ request }) => {
-    const res = await request.get('/api/pro/profiles?city=São Paulo');
+    const res = await request.get(
+      `/api/pro/profiles?city=${encodeURIComponent('Los Angeles')}`,
+    );
     expect(res.status()).toBe(401);
     const data = await res.json();
     expect(data.profiles).toBeUndefined();

--- a/tests/unit/auth-callback-destination.test.ts
+++ b/tests/unit/auth-callback-destination.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DASHBOARD,
+  ONBOARDING_ENTRY,
+  resolveAuthDestination,
+  sanitizeRedirect,
+} from "@/app/auth/callback/destination";
+
+describe("sanitizeRedirect", () => {
+  it("falls back to the dashboard when no target is supplied", () => {
+    expect(sanitizeRedirect(null)).toBe(DASHBOARD);
+    expect(sanitizeRedirect("")).toBe(DASHBOARD);
+  });
+
+  it("rejects absolute and protocol-relative URLs (open redirect)", () => {
+    expect(sanitizeRedirect("//evil.example.com")).toBe(DASHBOARD);
+    expect(sanitizeRedirect("https://evil.example.com")).toBe(DASHBOARD);
+    expect(sanitizeRedirect("pro/dashboard")).toBe(DASHBOARD);
+  });
+
+  it("keeps same-origin absolute paths", () => {
+    expect(sanitizeRedirect("/pro/billing")).toBe("/pro/billing");
+    expect(sanitizeRedirect(ONBOARDING_ENTRY)).toBe(ONBOARDING_ENTRY);
+  });
+});
+
+describe("resolveAuthDestination", () => {
+  it("sends brand new accounts into onboarding", () => {
+    expect(resolveAuthDestination({ profileCreated: true, next: DASHBOARD })).toBe(
+      ONBOARDING_ENTRY,
+    );
+  });
+
+  it("sends new accounts into onboarding even when next is elsewhere", () => {
+    expect(resolveAuthDestination({ profileCreated: true, next: "/pro/billing" })).toBe(
+      ONBOARDING_ENTRY,
+    );
+  });
+
+  it("honours the requested destination for returning users", () => {
+    expect(resolveAuthDestination({ profileCreated: false, next: "/pro/billing" })).toBe(
+      "/pro/billing",
+    );
+  });
+
+  // The social buttons on the "Sign up" tab always attach next=/pro/onboard.
+  // An existing provider signing in with Google from that tab must reach their
+  // dashboard, not be dropped back into the plan picker.
+  it("redirects returning users away from the onboarding entry", () => {
+    expect(
+      resolveAuthDestination({ profileCreated: false, next: ONBOARDING_ENTRY }),
+    ).toBe(DASHBOARD);
+  });
+});


### PR DESCRIPTION
Final production go-live audit pass. The repository entered this pass already green on every gate in the release checklist, so this PR is deliberately narrow: it closes two real defects and one blind spot in the gate itself, rather than restating checks that already hold.

## Files changed

| File | Change |
|---|---|
| `src/app/auth/callback/destination.ts` | **new** — dependency-free post-auth routing rules |
| `src/app/auth/callback/route.ts` | uses the new module; inline `sanitizeRedirect` and destination logic removed |
| `tests/unit/auth-callback-destination.test.ts` | **new** — 7 cases covering routing + open-redirect rejection |
| `scripts/validate-db-contract.mjs` | RPC coverage check added to the contract gate |
| `.github/workflows/release-checks.yml` | `pnpm release:check` aggregate step added |
| `src/components/ui/therapist-card-tilt.tsx` | Portuguese usage example translated |
| `tests/api/profiles-listing.spec.ts` | city filter case no longer uses a Portuguese city name |
| `docs/GO_LIVE_CHECKLIST.md` | 2026-08-09 closure entry |

## What was removed

- Duplicated redirect logic from `src/app/auth/callback/route.ts` (moved, not deleted — the route now imports it).
- Portuguese strings in source: `"Deep Tissue · Relaxamento"` / `"São Paulo, SP"` in the therapist card usage example, and `city=São Paulo` in the profiles-listing API test.

Nothing else was removed. The legacy artifacts named in the release spec (`vite.config.ts`, `index.html`, `package-lock.json`, `public/robots.txt`) were already absent, and the Tailwind config already carried no `src/mm` or `src/pages` globs.

## What was fixed

**1. Google sign-in sent existing providers into the plan picker.**

`SocialButtons` on the "Sign up" tab always attaches `next=/pro/onboard`, and the callback honoured `next` verbatim for any account that already had a profile. An existing provider who signed in with Google from that tab was routed to `/pro/onboard` → 308 → `/signup/plan` instead of their dashboard.

New accounts now enter onboarding at `/pro/onboard` — the same entry point the password signup form already uses, so social and password signups converge. Returning users get `next`, except when `next` is the onboarding entry, which resolves to `/pro/dashboard`. The rules live in a module with no Supabase or Next.js imports so they are unit-testable without booting the route's dependency graph.

**2. The DB contract gate was blind to database functions.**

`validate-db-contract.mjs` validated tables and columns but never functions. A `.rpc()` call with no matching SQL definition passed every gate — lint, typecheck, build included — and failed only at runtime: a Stripe webhook that never syncs a tier, an admin panel that never loads.

The validator now collects every RPC the application invokes, covering both the direct call form and the `as unknown as` cast form used where the generated Supabase types do not know the function, and fails when any has no `create [or replace] function` anywhere under `supabase/`. All 14 current references resolve. The check was verified by temporarily breaking a reference and confirming a non-zero exit — not just by observing it pass.

**3. CI** — `pnpm release:check` added between `release:audit` and `build`, completing the enumerated command sequence.

## Schema file to run

`supabase/PRODUCTION_SCHEMA_LOCK.sql` — **unchanged in this PR**. No schema change was required: `profiles_profile_status_check` already excludes `submitted`, and `submitted` is correctly retained only on `profile_reviews.status`, where the review workflow needs it. Re-apply the lock in the Supabase SQL editor only if production has not yet received the 2026-07-09 convergence section.

Note that the lock defines tables and columns, not function bodies; RPC definitions live in `supabase/migrations/`. The new gate validates against the whole SQL corpus accordingly.

## Validation results

Full chain run locally, exit 0:

| Command | Result |
|---|---|
| `pnpm install --frozen-lockfile` | pass |
| `git diff --exit-code package.json pnpm-lock.yaml` | clean |
| `pnpm lint` | 0 errors |
| `pnpm typecheck` | pass |
| `pnpm test` | 201 unit (19 files) + 8 API smoke |
| `pnpm validate:sitemap` | 70 canonical URLs, all HTTP 200 and indexable |
| `pnpm validate:db-contract` | OK (now including RPC coverage) |
| `pnpm release:audit` | OK |
| `pnpm release:check` | pass |
| `pnpm build` | pass |

Unit test count rose from 194 to 201 via the 7 new routing tests.

## Manual smoke test checklist

- [ ] **New Google signup** — Sign up tab → Google → lands in onboarding, profile and provider role rows created.
- [ ] **Existing provider, Google from the Sign up tab** — reaches `/pro/dashboard`, **not** the plan picker. This is the regression this PR fixes; test it from the Sign up tab specifically, since the Sign in tab was never affected.
- [ ] **Existing provider, Google from the Sign in tab** — still reaches `/pro/dashboard`.
- [ ] **Deep link preserved** — sign in with `?redirect=/pro/billing` → lands on `/pro/billing`.
- [ ] **Open redirect rejected** — `/auth/callback?next=//evil.example.com` → `/pro/dashboard`.
- [ ] **Password signup** — unchanged path, still lands in onboarding.
- [ ] **Password recovery** — email link → `/reset-password`, never the dashboard.
- [ ] **Stripe checkout → webhook** — subscribe on a test plan, confirm `subscription_tier`, `_tier`, `photo_limit`, `visibility_level`, `stripe_customer_id`, `stripe_subscription_id`, `current_period_end` all populate.
- [ ] **Stripe cancellation** — `customer.subscription.deleted` downgrades the profile to `free`.

## Risk notes

**`pnpm release:check` in CI adds cost without signal.** It re-runs lint, typecheck, test, validate:sitemap, validate:db-contract, release:audit **and build** — all of which already ran as discrete steps — and is followed by another `pnpm build`. It roughly doubles CI wall time. It also partially reverses the 2026-07-25 decision to split the aggregate into discrete steps so failures point at the exact failing gate; the discrete steps are retained and still run first, so that diagnostic property is preserved. Included because the release specification enumerates it. Deleting the step is a safe one-line revert.

**`mm_session` was deliberately not implemented.** The specification asks the OAuth callback to "sync `mm_session`". No such cookie is issued anywhere in the codebase — the app runs entirely on Supabase SSR cookies (`sb-*`), and `mm_session` survives only as a name in the logout cookie sweep and in the cookie-policy copy. The callback does establish the session (`exchangeCodeForSession` writes the auth cookies onto the response) and does sync the profile/role rows via `ensureUserProfileAndRole`. Re-introducing a bespoke session cookie would stand up a second, parallel auth system, which the release rules prohibit. Recorded as an open item in the checklist; removing the two dead references is separate cleanup.

**`/pro/onboard` is a permanent (308) redirect.** New accounts are routed through it, and browsers cache 308s indefinitely. This is pre-existing behaviour — the password signup form already routed there — and this PR only makes the social path consistent with it. Worth revisiting if onboarding ever moves back to `/pro/onboard`, since cached redirects would break those users. Not changed here, as it is beyond a stability patch.

**Low blast radius otherwise.** The routing change affects only the destination chosen after a successful authentication; token exchange, cookie handling, profile creation, and the welcome-email path are untouched. The validator change is CI-only and cannot affect runtime behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkBvCd9BAkNn8DXd2WSbnt)_