### PR TITLE
fix(auth): correct mm_session leftovers in cookie policy and E2E assertions

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -5,6 +5,9 @@ import { createServerSupabase } from "@/lib/supabase/server";
 
 function isAuthCookie(name: string) {
   return (
+    // Legacy: this build authenticates purely with Supabase SSR cookies and
+    // never issues mm_session. Kept so a browser still holding one from an
+    // older deploy has it cleared on logout.
     name === "mm_session" ||
     name.startsWith("sb-") ||
     name.includes("-auth-token") ||

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -25,7 +25,7 @@ const COOKIE_TYPES = [
     required: true,
     description:
       "Required for the platform to function. These cookies manage your session, authenticate your account, and prevent cross-site request forgery. You cannot opt out of essential cookies.",
-    examples: ["mm_session (authentication)", "csrf_token (security)"],
+    examples: ["sb-<project>-auth-token (authentication)", "csrf_token (security)"],
   },
   {
     id: "preference",

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -1,6 +1,17 @@
 -- MasseurMatch Production Schema Lock (idempotent)
 -- This file is the production database contract used by go-live validation.
 -- It must stay additive-only: no destructive drops, no renames, no data loss.
+--
+-- SCOPE: tables, columns, constraints, indexes and RLS only. Application RPCs
+-- (sync_stripe_subscription, process_stripe_*, qualify_paid_referral,
+-- revoke_referral_reward, admin_email_*, get_nearby_therapists, and the rest)
+-- are NOT defined here — their bodies live in supabase/migrations/ so there is
+-- a single source of truth for each. A database provisioned from this file
+-- alone therefore has the right shape but none of the functions, which fails
+-- at runtime rather than at deploy time (a Stripe webhook that never syncs a
+-- tier, an admin panel that never loads). When standing up a new environment,
+-- apply the migrations as well. scripts/validate-db-contract.mjs enforces that
+-- every RPC the app calls is defined somewhere under supabase/.
 
 create extension if not exists pgcrypto;
 create extension if not exists citext;

--- a/tests/auth/comprehensive-security.spec.ts
+++ b/tests/auth/comprehensive-security.spec.ts
@@ -141,9 +141,10 @@ test.describe.serial("Auth Security", () => {
 
       await page.waitForURL(/\/(pro|onboard|dashboard)/, { timeout: 15000 });
 
-      // Check session cookie exists
+      // Check session cookie exists. Authentication is Supabase SSR, so the
+      // session lives in sb-<project>-auth-token cookies, not mm_session.
       const cookies = await context.cookies();
-      const sessionCookie = cookies.find((c) => c.name === "mm_session");
+      const sessionCookie = cookies.find((c) => c.name.startsWith("sb-"));
 
       expect(sessionCookie).toBeDefined();
       expect(sessionCookie?.httpOnly).toBe(true);
@@ -343,10 +344,12 @@ test.describe.serial("Auth Security", () => {
       // Should redirect to login
       await expect(page).toHaveURL(/\/(login|register)/);
 
-      // Session cookie should be cleared
+      // Session cookie should be cleared. Logout expires the Supabase SSR
+      // cookies, so the browser either drops them outright or keeps an empty
+      // value — both count as cleared.
       const cookies = await context.cookies();
-      const sessionCookie = cookies.find((c) => c.name === "mm_session");
-      expect(sessionCookie?.value).toBe("");
+      const sessionCookie = cookies.find((c) => c.name.startsWith("sb-"));
+      expect(sessionCookie?.value ?? "").toBe("");
 
       await deleteUserByEmail(testUser);
     });

--- a/tests/auth/flows.spec.ts
+++ b/tests/auth/flows.spec.ts
@@ -158,7 +158,11 @@ test.describe.serial("Auth launch flow", () => {
     expect(rolesError).toBeNull();
     expect(roles?.some((entry) => entry.role === "provider")).toBeTruthy();
 
-    const sessionCookie = (await context.cookies()).find((cookie) => cookie.name === "mm_session");
+    // Authentication is Supabase SSR: the session lives in sb-<project>-auth-token
+    // cookies. There is no mm_session cookie in this build.
+    const sessionCookie = (await context.cookies()).find((cookie) =>
+      cookie.name.startsWith("sb-"),
+    );
     expect(sessionCookie?.value).toBeTruthy();
   });
 


### PR DESCRIPTION
Follow-up to #673. That PR recorded `mm_session` as an open item; this cleans up what it left behind. The app authenticates purely with Supabase SSR cookies (`sb-*`) and never issues an `mm_session` cookie, but several places still referenced one — and two of them were not cosmetic.

## Files changed

| File | Change |
|---|---|
| `src/app/cookie-policy/page.tsx` | essential-cookie list no longer names a cookie the site never sets |
| `tests/auth/flows.spec.ts` | session assertion retargeted at the real `sb-*` cookie |
| `tests/auth/comprehensive-security.spec.ts` | two assertions retargeted (session exists; cleared on logout) |
| `src/app/api/auth/logout/route.ts` | comment only — the sweep entry stays, documented as legacy |
| `supabase/PRODUCTION_SCHEMA_LOCK.sql` | header note documenting the file's scope |

## What was fixed

**1. The cookie policy named a cookie the site does not set.**

`/cookie-policy` listed `mm_session (authentication)` under Essential Cookies. No such cookie is issued anywhere in the codebase. A published cookie policy describing a non-existent cookie is an accuracy problem in user-facing legal copy, not a tidiness issue. It now names the Supabase auth cookie.

**2. Three E2E assertions were latent failures.**

`flows.spec.ts` and `comprehensive-security.spec.ts` asserted that an `mm_session` cookie exists after login, is `httpOnly` / `sameSite=Lax`, and is cleared on logout. All three would fail if executed, because the cookie is never issued:

- `expect(sessionCookie?.value).toBeTruthy()` → `undefined`
- `expect(sessionCookie).toBeDefined()` → `undefined`
- `expect(sessionCookie?.value).toBe("")` → `undefined !== ""`

They pass today only because both suites call `test.skip(... || (!!process.env.CI && !process.env.ENABLE_AUTH_E2E))`, and no workflow sets `ENABLE_AUTH_E2E`. The assertions are retargeted at the real `sb-*` cookies so the coverage is restored rather than deleted. The logout case accepts an absent **or** empty cookie, since an expired cookie may be dropped by the browser outright rather than retained with an empty value.

**3. The logout sweep entry is deliberate and was kept.**

`isAuthCookie` matching `mm_session` initially looked dead, but it is not: a browser still holding an `mm_session` from an older deploy should have it cleared on logout. It only needed a comment saying so, so it is not mistaken for a live cookie again.

**4. Schema lock scope documented.**

`PRODUCTION_SCHEMA_LOCK.sql` defines tables, columns, constraints, indexes and RLS — not function bodies. All 14 application RPCs live in `supabase/migrations/`. A database provisioned from the lock alone has the right shape but no functions, which fails at runtime rather than at deploy time. The header now says this explicitly and points at the migrations. Deliberately **not** copying the function bodies into the lock: that would create two sources of truth that drift, to protect only a case the header can warn about instead.

## Validation results

Full chain run locally, exit 0:

| Command | Result |
|---|---|
| `pnpm lint` | 0 errors |
| `pnpm typecheck` | pass |
| `pnpm test` | 201 unit + 8 API smoke |
| `pnpm validate:db-contract` | OK |
| `pnpm release:audit` | OK |
| `playwright test --list` on both edited specs | 14 tests enumerate cleanly in 2 files |

The two edited E2E specs are listed rather than executed, because they require Supabase service-role credentials and an explicit `ENABLE_AUTH_E2E=1` opt-in. See the coverage note below.

## Manual smoke test checklist

- [ ] `/cookie-policy` renders and the Essential Cookies row reads `sb-<project>-auth-token (authentication)`.
- [ ] Log in, then log out; confirm the `sb-*` cookies are gone from devtools.
- [ ] Optional, in an isolated Supabase project only: run with `ENABLE_AUTH_E2E=1` and confirm the session/logout assertions now pass. Do **not** run this against production data — see below.

## Risk notes

**Low blast radius.** One user-facing string, one comment, one SQL comment, and three test assertions. No runtime logic changed; no route, cookie, or auth behaviour is altered by this diff.

**The authenticated-session E2E suite is dark in CI, and this PR does not change that.** Both auth specs skip unless `ENABLE_AUTH_E2E=1`, which no workflow sets. That covers password validation, session security, brute-force lockout, password recovery, OAuth security, security headers, XSS prevention, and logout. The skip is deliberate — its comment explains that CI exposes `SUPABASE_SERVICE_ROLE_KEY`, so running full-registration tests would hit the live database without test-environment isolation. That is a sound reason not to simply flip the flag on. The cost is that these three broken assertions sat unnoticed and the next breakage will too. Standing up an isolated Supabase test project is the real fix and is out of scope here.

**Not changed, needs a decision: `MM_SESSION_SECRET`.** It is enforced as a required key by `scripts/release-audit.mjs` and asserted by `/api/health`, but nothing under `src/` consumes it — the signing implementation it existed for is gone, and `tests/unit/session-signing.test.ts` exercises helper functions defined inside the test file rather than production code. Every new environment must therefore set a 32-character secret that signs nothing, or fail the release audit. Removing it is probably correct, but it changes what the go-live gate enforces, so it is left alone pending an explicit call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkBvCd9BAkNn8DXd2WSbnt)_