### PR TITLE
Add complete email unsubscribe page

### DIFF
--- a/src/app/api/_lib/unsubscribe-token.ts
+++ b/src/app/api/_lib/unsubscribe-token.ts
@@ -1,0 +1,31 @@
+import { SignJWT } from 'jose';
+
+const JWT_SECRET = new TextEncoder().encode(
+  process.env.UNSUBSCRIBE_JWT_SECRET || process.env.JWT_SECRET || 'unsubscribe-secret-key'
+);
+
+export async function generateUnsubscribeToken(
+  userId: string,
+  email: string,
+  expirationHours: number = 365 * 24 // Default: 1 year
+): Promise<string> {
+  const now = new Date();
+  const expirationDate = new Date(now.getTime() + expirationHours * 60 * 60 * 1000);
+
+  const token = await new SignJWT({
+    email,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(userId)
+    .setIssuedAt()
+    .setExpirationTime(expirationDate)
+    .sign(JWT_SECRET);
+
+  return token;
+}
+
+export function getUnsubscribeUrl(token: string, baseUrl?: string): string {
+  const url = new URL('/unsubscribe', baseUrl || process.env.NEXT_PUBLIC_APP_URL || 'https://masseurmatch.com');
+  url.searchParams.set('token', token);
+  return url.toString();
+}

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { jwtVerify } from 'jose';
 import { createSupabaseWebhookAdminClient } from '@/app/api/_lib/supabase-server';
-import { RouteError } from '@/app/api/_lib/http';
 
 const JWT_SECRET = new TextEncoder().encode(
   process.env.UNSUBSCRIBE_JWT_SECRET || process.env.JWT_SECRET || 'unsubscribe-secret-key'

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -24,8 +24,8 @@ export async function POST(request: NextRequest) {
     try {
       const verified = await jwtVerify(token, JWT_SECRET);
       const payload = verified.payload as Record<string, unknown>;
-      userId = payload.sub || payload.user_id;
-      email = payload.email || '';
+      userId = (payload.sub || payload.user_id) as string;
+      email = (payload.email as string) || '';
 
       if (!userId || typeof userId !== 'string') {
         return NextResponse.json(
@@ -44,11 +44,11 @@ export async function POST(request: NextRequest) {
     const adminClient = createSupabaseWebhookAdminClient();
 
     try {
-      const { data: existing, error: fetchError } = await adminClient
-        .from('marketing_preferences')
+      const { data: existing, error: fetchError } = await (adminClient
+        .from('marketing_preferences' as any)
         .select('*')
         .eq('user_id', userId)
-        .maybeSingle();
+        .maybeSingle() as any);
 
       if (fetchError) {
         console.error('[Unsubscribe] Database fetch error:', fetchError);
@@ -60,15 +60,15 @@ export async function POST(request: NextRequest) {
 
       if (existing) {
         // Update existing preferences
-        const { error: updateError } = await adminClient
-          .from('marketing_preferences')
+        const { error: updateError } = await (adminClient
+          .from('marketing_preferences' as any)
           .update({
             marketing_opt_in: false,
             newsletter_opt_in: false,
             updated_at: new Date().toISOString(),
             updated_by: 'unsubscribe-link',
           })
-          .eq('user_id', userId);
+          .eq('user_id', userId) as any);
 
         if (updateError) {
           console.error('[Unsubscribe] Database update error:', updateError);
@@ -79,14 +79,14 @@ export async function POST(request: NextRequest) {
         }
       } else {
         // Create new preferences record
-        const { error: insertError } = await adminClient
-          .from('marketing_preferences')
+        const { error: insertError } = await (adminClient
+          .from('marketing_preferences' as any)
           .insert({
             user_id: userId,
             marketing_opt_in: false,
             newsletter_opt_in: false,
             updated_by: 'unsubscribe-link',
-          });
+          }) as any);
 
         if (insertError) {
           console.error('[Unsubscribe] Database insert error:', insertError);

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { jwtVerify } from 'jose';
+import { createSupabaseWebhookAdminClient } from '@/app/api/_lib/supabase-server';
+import { RouteError } from '@/app/api/_lib/http';
+
+const JWT_SECRET = new TextEncoder().encode(
+  process.env.UNSUBSCRIBE_JWT_SECRET || process.env.JWT_SECRET || 'unsubscribe-secret-key'
+);
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { token } = body;
+
+    if (!token) {
+      return NextResponse.json(
+        { error: 'No unsubscribe token provided.' },
+        { status: 400 }
+      );
+    }
+
+    let userId: string;
+    let email: string;
+
+    try {
+      const verified = await jwtVerify(token, JWT_SECRET);
+      const payload = verified.payload as Record<string, unknown>;
+      userId = payload.sub || payload.user_id;
+      email = payload.email || '';
+
+      if (!userId || typeof userId !== 'string') {
+        return NextResponse.json(
+          { error: 'Invalid or expired unsubscribe link.' },
+          { status: 401 }
+        );
+      }
+    } catch (err) {
+      console.error('[Unsubscribe] JWT verification error:', err);
+      return NextResponse.json(
+        { error: 'Invalid or expired unsubscribe link.' },
+        { status: 401 }
+      );
+    }
+
+    const adminClient = createSupabaseWebhookAdminClient();
+
+    try {
+      const { data: existing, error: fetchError } = await adminClient
+        .from('marketing_preferences')
+        .select('*')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (fetchError) {
+        console.error('[Unsubscribe] Database fetch error:', fetchError);
+        return NextResponse.json(
+          { error: 'Failed to retrieve email preferences.' },
+          { status: 500 }
+        );
+      }
+
+      if (existing) {
+        // Update existing preferences
+        const { error: updateError } = await adminClient
+          .from('marketing_preferences')
+          .update({
+            marketing_opt_in: false,
+            newsletter_opt_in: false,
+            updated_at: new Date().toISOString(),
+            updated_by: 'unsubscribe-link',
+          })
+          .eq('user_id', userId);
+
+        if (updateError) {
+          console.error('[Unsubscribe] Database update error:', updateError);
+          return NextResponse.json(
+            { error: 'Failed to update preferences.' },
+            { status: 500 }
+          );
+        }
+      } else {
+        // Create new preferences record
+        const { error: insertError } = await adminClient
+          .from('marketing_preferences')
+          .insert({
+            user_id: userId,
+            marketing_opt_in: false,
+            newsletter_opt_in: false,
+            updated_by: 'unsubscribe-link',
+          });
+
+        if (insertError) {
+          console.error('[Unsubscribe] Database insert error:', insertError);
+          return NextResponse.json(
+            { error: 'Failed to update preferences.' },
+            { status: 500 }
+          );
+        }
+      }
+
+      // Get the user's email from auth if not in token
+      let userEmail = email;
+      if (!userEmail) {
+        try {
+          const { data: authUser, error: authError } = await adminClient.auth.admin.getUserById(userId);
+          if (!authError && authUser.user?.email) {
+            userEmail = authUser.user.email;
+          }
+        } catch (err) {
+          console.error('[Unsubscribe] Failed to fetch user email:', err);
+        }
+      }
+
+      return NextResponse.json(
+        {
+          success: true,
+          message: 'Successfully unsubscribed from marketing emails.',
+          email: userEmail,
+        },
+        { status: 200 }
+      );
+    } catch (err) {
+      console.error('[Unsubscribe] Unexpected error:', err);
+      return NextResponse.json(
+        { error: 'An unexpected error occurred.' },
+        { status: 500 }
+      );
+    }
+  } catch (err) {
+    console.error('[Unsubscribe] Request parsing error:', err);
+    return NextResponse.json(
+      { error: 'Invalid request.' },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,56 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowRight, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import { Suspense } from 'react';
+import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
-
-type Status = 'loading' | 'success' | 'error' | 'idle';
+import UnsubscribeClient from './unsubscribe-client';
 
 export default function UnsubscribePage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams.get('token');
-
-  const [status, setStatus] = useState<Status>('idle');
-  const [error, setError] = useState<string>('');
-  const [email, setEmail] = useState<string>('');
-
-  useEffect(() => {
-    if (!token) {
-      setStatus('error');
-      setError('No unsubscribe token provided. Please check your email link.');
-      return;
-    }
-
-    const unsubscribe = async () => {
-      setStatus('loading');
-      try {
-        const response = await fetch('/api/email/unsubscribe', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token }),
-        });
-
-        const data = await response.json();
-
-        if (!response.ok) {
-          setError(data.error || 'Failed to unsubscribe. Please try again later.');
-          setStatus('error');
-          return;
-        }
-
-        setEmail(data.email || '');
-        setStatus('success');
-      } catch (err) {
-        setError('An unexpected error occurred. Please try again later.');
-        setStatus('error');
-      }
-    };
-
-    unsubscribe();
-  }, [token]);
-
   return (
     <div className="min-h-screen bg-background">
       {/* Hero Section */}
@@ -73,131 +28,23 @@ export default function UnsubscribePage() {
       {/* Content Section */}
       <section className="py-16">
         <div className="container mx-auto max-w-2xl px-4">
-          {status === 'loading' && (
-            <div className="rounded-lg border border-border bg-soft p-8 text-center">
-              <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-primary" strokeWidth={2.25} />
-              <p className="text-foreground font-medium">Processing your request...</p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Please wait while we update your email preferences.
-              </p>
-            </div>
-          )}
-
-          {status === 'success' && (
-            <div className="space-y-6">
-              <div className="rounded-lg border border-green-200 bg-green-50 p-8">
-                <div className="flex items-start gap-4">
-                  <CheckCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-green-600" strokeWidth={2.25} />
-                  <div>
-                    <h2 className="text-lg font-semibold text-foreground">
-                      Unsubscribed Successfully
-                    </h2>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      {email && (
-                        <>
-                          We've removed <strong>{email}</strong> from our marketing email list.
-                        </>
-                      )}
-                      {!email && (
-                        <>
-                          We've updated your email preferences.
-                        </>
-                      )}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="rounded-lg border border-border bg-soft p-6">
-                <h3 className="font-semibold text-foreground">What to expect</h3>
-                <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
-                  <li className="flex items-start gap-3">
-                    <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
-                    <span>You'll no longer receive promotional emails or marketing updates.</span>
-                  </li>
-                  <li className="flex items-start gap-3">
-                    <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
-                    <span>
-                      You may still receive important transactional emails like account notifications
-                      and billing information.
-                    </span>
-                  </li>
-                  <li className="flex items-start gap-3">
-                    <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
-                    <span>Changes may take up to 10 business days to fully process.</span>
-                  </li>
-                </ul>
-              </div>
-
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Link
-                  href="/"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary/90"
-                >
-                  Return to MasseurMatch
-                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
-                </Link>
-                <Link
-                  href="/email-opt-out"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-foreground transition hover:bg-soft"
-                >
-                  Learn More About Emails
-                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
-                </Link>
-              </div>
-            </div>
-          )}
-
-          {status === 'error' && (
-            <div className="space-y-6">
-              <div className="rounded-lg border border-red-200 bg-red-50 p-8">
-                <div className="flex items-start gap-4">
-                  <AlertCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-red-600" strokeWidth={2.25} />
-                  <div>
-                    <h2 className="text-lg font-semibold text-foreground">
-                      Unable to Unsubscribe
-                    </h2>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      {error}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="rounded-lg border border-border bg-soft p-6">
-                <h3 className="font-semibold text-foreground">What you can do</h3>
-                <p className="mt-3 text-sm text-muted-foreground">
-                  To manage your email preferences manually, please email{' '}
-                  <a href="mailto:support@masseurmatch.com" className="font-medium text-primary hover:underline">
-                    support@masseurmatch.com
-                  </a>
-                  {' '}with the subject line "Unsubscribe" and include your email address.
-                </p>
-                <p className="mt-3 text-sm text-muted-foreground">
-                  We'll process your request within 10 business days in compliance with CAN-SPAM regulations.
+          <Suspense
+            fallback={
+              <div className="rounded-lg border border-border bg-soft p-8 text-center">
+                <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
+                <p className="text-foreground font-medium">Processing your request...</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Please wait while we update your email preferences.
                 </p>
               </div>
-
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Link
-                  href="/"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary/90"
-                >
-                  Return to MasseurMatch
-                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
-                </Link>
-                <Link
-                  href="/email-opt-out"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-foreground transition hover:bg-soft"
-                >
-                  Email Policy
-                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
-                </Link>
-              </div>
-            </div>
-          )}
+            }
+          >
+            <UnsubscribeClient />
+          </Suspense>
         </div>
       </section>
     </div>
   );
+}
+
 }

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { Suspense } from 'react';
-import { ArrowRight } from 'lucide-react';
-import Link from 'next/link';
 import UnsubscribeClient from './unsubscribe-client';
 
 export default function UnsubscribePage() {

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -46,5 +46,3 @@ export default function UnsubscribePage() {
     </div>
   );
 }
-
-}

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { ArrowRight, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+
+type Status = 'loading' | 'success' | 'error' | 'idle';
+
+export default function UnsubscribePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setError('No unsubscribe token provided. Please check your email link.');
+      return;
+    }
+
+    const unsubscribe = async () => {
+      setStatus('loading');
+      try {
+        const response = await fetch('/api/email/unsubscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          setError(data.error || 'Failed to unsubscribe. Please try again later.');
+          setStatus('error');
+          return;
+        }
+
+        setEmail(data.email || '');
+        setStatus('success');
+      } catch (err) {
+        setError('An unexpected error occurred. Please try again later.');
+        setStatus('error');
+      }
+    };
+
+    unsubscribe();
+  }, [token]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Hero Section */}
+      <section className="border-b border-border bg-white py-16">
+        <div className="container mx-auto max-w-2xl px-4">
+          <div className="text-center">
+            <p className="text-xs font-mono uppercase tracking-[0.18em] text-muted-foreground">
+              Email Preferences
+            </p>
+            <h1 className="mt-4 text-4xl font-bold tracking-tight text-foreground md:text-5xl">
+              Manage Subscriptions
+            </h1>
+            <p className="mt-4 text-lg text-muted-foreground">
+              Control which emails you receive from MasseurMatch.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Content Section */}
+      <section className="py-16">
+        <div className="container mx-auto max-w-2xl px-4">
+          {status === 'loading' && (
+            <div className="rounded-lg border border-border bg-soft p-8 text-center">
+              <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-primary" strokeWidth={2.25} />
+              <p className="text-foreground font-medium">Processing your request...</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Please wait while we update your email preferences.
+              </p>
+            </div>
+          )}
+
+          {status === 'success' && (
+            <div className="space-y-6">
+              <div className="rounded-lg border border-green-200 bg-green-50 p-8">
+                <div className="flex items-start gap-4">
+                  <CheckCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-green-600" strokeWidth={2.25} />
+                  <div>
+                    <h2 className="text-lg font-semibold text-foreground">
+                      Unsubscribed Successfully
+                    </h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {email && (
+                        <>
+                          We've removed <strong>{email}</strong> from our marketing email list.
+                        </>
+                      )}
+                      {!email && (
+                        <>
+                          We've updated your email preferences.
+                        </>
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border bg-soft p-6">
+                <h3 className="font-semibold text-foreground">What to expect</h3>
+                <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
+                  <li className="flex items-start gap-3">
+                    <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
+                    <span>You'll no longer receive promotional emails or marketing updates.</span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
+                    <span>
+                      You may still receive important transactional emails like account notifications
+                      and billing information.
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
+                    <span>Changes may take up to 10 business days to fully process.</span>
+                  </li>
+                </ul>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary/90"
+                >
+                  Return to MasseurMatch
+                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+                </Link>
+                <Link
+                  href="/email-opt-out"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-foreground transition hover:bg-soft"
+                >
+                  Learn More About Emails
+                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+                </Link>
+              </div>
+            </div>
+          )}
+
+          {status === 'error' && (
+            <div className="space-y-6">
+              <div className="rounded-lg border border-red-200 bg-red-50 p-8">
+                <div className="flex items-start gap-4">
+                  <AlertCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-red-600" strokeWidth={2.25} />
+                  <div>
+                    <h2 className="text-lg font-semibold text-foreground">
+                      Unable to Unsubscribe
+                    </h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {error}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border bg-soft p-6">
+                <h3 className="font-semibold text-foreground">What you can do</h3>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  To manage your email preferences manually, please email{' '}
+                  <a href="mailto:support@masseurmatch.com" className="font-medium text-primary hover:underline">
+                    support@masseurmatch.com
+                  </a>
+                  {' '}with the subject line "Unsubscribe" and include your email address.
+                </p>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  We'll process your request within 10 business days in compliance with CAN-SPAM regulations.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary/90"
+                >
+                  Return to MasseurMatch
+                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+                </Link>
+                <Link
+                  href="/email-opt-out"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-foreground transition hover:bg-soft"
+                >
+                  Email Policy
+                  <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/unsubscribe/unsubscribe-client.tsx
+++ b/src/app/unsubscribe/unsubscribe-client.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { ArrowRight, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+
+type Status = 'loading' | 'success' | 'error' | 'idle';
+
+export default function UnsubscribeClient() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setError('No unsubscribe token provided. Please check your email link.');
+      return;
+    }
+
+    const unsubscribe = async () => {
+      setStatus('loading');
+      try {
+        const response = await fetch('/api/email/unsubscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          setError(data.error || 'Failed to unsubscribe. Please try again later.');
+          setStatus('error');
+          return;
+        }
+
+        setEmail(data.email || '');
+        setStatus('success');
+      } catch (err) {
+        setError('An unexpected error occurred. Please try again later.');
+        setStatus('error');
+      }
+    };
+
+    unsubscribe();
+  }, [token]);
+
+  if (status === 'loading') {
+    return (
+      <div className="rounded-lg border border-border bg-soft p-8 text-center">
+        <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-primary" strokeWidth={2.25} />
+        <p className="text-foreground font-medium">Processing your request...</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Please wait while we update your email preferences.
+        </p>
+      </div>
+    );
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-lg border border-green-200 bg-green-50 p-8">
+          <div className="flex items-start gap-4">
+            <CheckCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-green-600" strokeWidth={2.25} />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">
+                Unsubscribed Successfully
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {email && (
+                  <>
+                    We've removed <strong>{email}</strong> from our marketing email list.
+                  </>
+                )}
+                {!email && (
+                  <>
+                    We've updated your email preferences.
+                  </>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-soft p-6">
+          <h3 className="font-semibold text-foreground">What to expect</h3>
+          <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
+            <li className="flex items-start gap-3">
+              <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
+              <span>You'll no longer receive promotional emails or marketing updates.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
+              <span>
+                You may still receive important transactional emails like account notifications
+                and billing information.
+              </span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-primary" />
+              <span>Changes may take up to 10 business days to fully process.</span>
+            </li>
+          </ul>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary/90"
+          >
+            Return to MasseurMatch
+            <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+          </Link>
+          <Link
+            href="/email-opt-out"
+            className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-foreground transition hover:bg-soft"
+          >
+            Learn More About Emails
+            <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-8">
+          <div className="flex items-start gap-4">
+            <AlertCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-red-600" strokeWidth={2.25} />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">
+                Unable to Unsubscribe
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {error}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-soft p-6">
+          <h3 className="font-semibold text-foreground">What you can do</h3>
+          <p className="mt-3 text-sm text-muted-foreground">
+            To manage your email preferences manually, please email{' '}
+            <a href="mailto:support@masseurmatch.com" className="font-medium text-primary hover:underline">
+              support@masseurmatch.com
+            </a>
+            {' '}with the subject line "Unsubscribe" and include your email address.
+          </p>
+          <p className="mt-3 text-sm text-muted-foreground">
+            We'll process your request within 10 business days in compliance with CAN-SPAM regulations.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition hover:bg-primary/90"
+          >
+            Return to MasseurMatch
+            <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+          </Link>
+          <Link
+            href="/email-opt-out"
+            className="inline-flex items-center justify-center gap-2 rounded-lg border border-border bg-white px-6 py-3 text-sm font-medium text-foreground transition hover:bg-soft"
+          >
+            Email Policy
+            <ArrowRight className="h-4 w-4" strokeWidth={2.25} />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Add a complete, premium email unsubscribe system for MasseurMatch including a dedicated unsubscribe page, API route, and token utility.

## Changes

### New Files

- **`src/app/unsubscribe/page.tsx`** - Premium unsubscribe page with:
  - Success state showing confirmation after unsubscribe
  - Error state with helpful guidance and support contact
  - Loading state during token verification
  - Clear explanation of what to expect after unsubscribing
  - Links to email policy and home page
  - Follows MasseurMatch design standards (Lucide icons, brand palette, Satoshi font)

- **`src/app/api/email/unsubscribe/route.ts`** - POST API endpoint that:
  - Verifies JWT tokens containing user_id and email
  - Updates or creates marketing preference records
  - Sets both `marketing_opt_in` and `newsletter_opt_in` to false
  - Returns user's email for confirmation
  - Includes comprehensive error handling

- **`src/app/api/_lib/unsubscribe-token.ts`** - Utility functions for:
  - `generateUnsubscribeToken()` - Creates HS256 JWT tokens with 1-year expiration
  - `getUnsubscribeUrl()` - Constructs full unsubscribe URLs with token

## Design Details

The unsubscribe page follows premium design standards:
- Green success state with CheckCircle icon
- Red error state with AlertCircle icon
- Loading spinner during token verification
- Informational cards explaining email preferences
- Clear CTAs back to homepage and email policy
- CAN-SPAM compliance messaging (10 business days)
- Responsive layout with proper spacing and typography

## Integration Guide

To integrate unsubscribe links into marketing emails:

```typescript
import { generateUnsubscribeToken, getUnsubscribeUrl } from '@/app/api/_lib/unsubscribe-token';

const token = await generateUnsubscribeToken(userId, userEmail);
const unsubscribeUrl = getUnsubscribeUrl(token);
// Include in email: ${unsubscribeUrl}
```

## CAN-SPAM Compliance

- Unsubscribe requests processed within 10 business days
- Clear messaging that transactional emails continue
- Support contact provided for manual unsubscribe requests
- Email policy documented at `/email-opt-out`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmVfWxN3B383jam7tKpneY)_