### PR TITLE
Fix referrals 500 and stabilize client rendering

### DIFF
--- a/src/app/api/pro/referrals/route.ts
+++ b/src/app/api/pro/referrals/route.ts
@@ -28,21 +28,62 @@ function parseDashboard(value: Json | null): ReferralDashboardPayload {
   return { summary, referrals };
 }
 
+function emptySummary() {
+  return {
+    code: "",
+    referralCount: 0,
+    premiumMonthsEarned: 0,
+    pendingReferrals: 0,
+    paidReferrals: 0,
+    maxPremiumMonths: 6,
+    remainingPremiumMonths: 6,
+    bonusExpiresAt: null,
+    bonusTier: null,
+    referralLink: null,
+  };
+}
+
 export async function GET(request: Request) {
   try {
     const session = await requireRequestSession(request);
     const supabase = createReferralSupabaseAdminClient();
 
+    // Expiration is maintenance work, not a prerequisite for rendering the
+    // referral dashboard. A stale/missing expiration RPC must not take the
+    // entire page down.
     const { error: expireError } = await supabase.rpc("expire_referral_bonus_for_user", {
       p_user_id: session.userId,
     });
-    if (expireError) throw new Error(expireError.message);
+    if (expireError) {
+      console.error("[api/pro/referrals] unable to expire referral bonus", {
+        userId: session.userId,
+        code: expireError.code,
+        message: expireError.message,
+      });
+    }
 
     const { data: dashboardData, error: dashboardError } = await supabase.rpc(
       "get_referral_dashboard",
       { p_user_id: session.userId },
     );
-    if (dashboardError) throw new Error(dashboardError.message);
+
+    if (dashboardError) {
+      console.error("[api/pro/referrals] unable to load referral dashboard", {
+        userId: session.userId,
+        code: dashboardError.code,
+        message: dashboardError.message,
+      });
+
+      // Keep the authenticated page usable while a referral migration/RPC is
+      // being rolled out or repaired. The client receives a stable response
+      // shape instead of a 500 that cascades into the page error state.
+      return json({
+        ok: true,
+        summary: emptySummary(),
+        referrals: [],
+        unavailable: true,
+      });
+    }
 
     const dashboard = parseDashboard(dashboardData);
     const summary = dashboard.summary ?? {};
@@ -52,10 +93,12 @@ export async function GET(request: Request) {
     return json({
       ok: true,
       summary: {
+        ...emptySummary(),
         ...summary,
         referralLink: code ? `${appUrl}/signup?ref=${encodeURIComponent(code)}` : null,
       },
       referrals: dashboard.referrals ?? [],
+      unavailable: false,
     });
   } catch (error) {
     return errorResponse(error);

--- a/src/app/pro/referrals/page.tsx
+++ b/src/app/pro/referrals/page.tsx
@@ -31,6 +31,7 @@ interface ReferralResponse {
   ok: boolean;
   summary: ReferralSummary;
   referrals: ReferralRow[];
+  unavailable?: boolean;
 }
 
 function formatDate(value: string | null) {
@@ -39,6 +40,7 @@ function formatDate(value: string | null) {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   }).format(new Date(value));
 }
 
@@ -124,6 +126,14 @@ export default function ReferralsPage() {
         </p>
       </header>
 
+      {data.unavailable ? (
+        <Card>
+          <CardContent className="p-5 text-sm text-muted-foreground">
+            Referral data is temporarily unavailable. Your account and existing rewards are not affected. Please try again shortly.
+          </CardContent>
+        </Card>
+      ) : null}
+
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardContent className="p-5">
@@ -161,15 +171,15 @@ export default function ReferralsPage() {
         </CardHeader>
         <CardContent className="space-y-5">
           <div className="rounded-xl border border-border bg-muted/30 p-4">
-            <p className="break-all font-mono text-sm text-foreground">{summary.referralLink}</p>
-            <p className="mt-2 text-xs text-muted-foreground">Code: {summary.code}</p>
+            <p className="break-all font-mono text-sm text-foreground">{summary.referralLink ?? "Referral link temporarily unavailable"}</p>
+            <p className="mt-2 text-xs text-muted-foreground">Code: {summary.code || "—"}</p>
           </div>
           <div className="flex flex-wrap gap-3">
-            <Button onClick={() => void copyLink()}>
+            <Button disabled={!summary.referralLink} onClick={() => void copyLink()}>
               {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
               {copied ? "Copied" : "Copy link"}
             </Button>
-            <Button variant="outline" onClick={() => void shareLink()}>
+            <Button disabled={!summary.referralLink} variant="outline" onClick={() => void shareLink()}>
               <Share2 className="mr-2 h-4 w-4" /> Share
             </Button>
           </div>


### PR DESCRIPTION
## What changed

- Prevents the non-critical referral-expiration RPC from crashing `/api/pro/referrals`.
- Returns a stable, typed empty referral payload when the referral dashboard RPC is temporarily unavailable instead of cascading a server-side 500 into the UI.
- Logs Supabase RPC error code/message server-side for diagnosis.
- Adds a clear temporary-unavailable state to the referrals page and disables copy/share when no link is available.
- Pins referral date formatting to UTC so date output is deterministic across environments.

## Why

Production reports show repeated `500` responses from `/api/pro/referrals` together with React hydration error #418. The route previously threw on either referral RPC failure, making migration/RPC rollout problems fatal to the entire dashboard.

## Risk

Low and isolated to the referral dashboard. Authentication and configuration failures still use the existing error handler; only referral-specific RPC failures degrade gracefully.