### PR TITLE
Make Pro Trust the canonical ID verification screen

### DIFF
--- a/src/app/api/provider/verification/route.ts
+++ b/src/app/api/provider/verification/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: Request) {
     const [identityResult, textResult] = await Promise.all([
       adminClient
         .from("identity_verifications")
-        .select("id, status, stripe_session_id, created_at, updated_at")
+        .select("id, status, stripe_session_id, last_error, created_at, updated_at")
         .eq("user_id", session.userId)
         .order("created_at", { ascending: false, nullsFirst: false })
         .order("updated_at", { ascending: false, nullsFirst: false })
@@ -36,11 +36,19 @@ export async function GET(request: Request) {
             id: identityRow.id,
             status: identityStatus,
             stripeSessionId: identityRow.stripe_session_id,
+            lastError: identityRow.last_error,
             createdAt: identityRow.created_at,
             updatedAt: identityRow.updated_at,
             verifiedAt: identityStatus === "verified" ? identityRow.updated_at : null,
           }
-        : { status: "not_started", verifiedAt: null },
+        : {
+            status: "not_started",
+            stripeSessionId: null,
+            lastError: null,
+            createdAt: null,
+            updatedAt: null,
+            verifiedAt: null,
+          },
       text: textRow
         ? {
             id: textRow.id,

--- a/src/app/pro/trust/page.tsx
+++ b/src/app/pro/trust/page.tsx
@@ -1,43 +1,92 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
-  ShieldCheck, FileCheck, CheckCircle2, Clock, AlertCircle, Loader2, ExternalLink,
+  ShieldCheck,
+  FileCheck,
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  Loader2,
+  ExternalLink,
+  RefreshCw,
+  XCircle,
 } from "lucide-react";
 import { LicenseUpload } from "@/components/pro/LicenseUpload";
 
+type IdentityStatus =
+  | "not_started"
+  | "pending"
+  | "processing"
+  | "requires_input"
+  | "failed"
+  | "canceled"
+  | "verified";
+
+interface IdentityVerification {
+  status: IdentityStatus;
+  stripeSessionId?: string | null;
+  lastError?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  verifiedAt?: string | null;
+}
+
 interface VerificationData {
-  identity: { status: string };
+  identity: IdentityVerification;
   text: { status: string };
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
 }
 
 export default function TrustAndVerificationPage() {
   const [verification, setVerification] = useState<VerificationData | null>(null);
   const [hasLicense, setHasLicense] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  const loadVerification = useCallback(async (manual = false) => {
+    if (manual) setRefreshing(true);
+    setPageError(null);
+    try {
+      const [vRes, dRes] = await Promise.all([
+        fetch("/api/provider/verification", { cache: "no-store" }),
+        fetch("/api/provider/identity-documents", { cache: "no-store" }),
+      ]);
+
+      if (!vRes.ok) throw new Error("Unable to load your identity verification status.");
+
+      const v = await vRes.json();
+      setVerification({ identity: v.identity, text: v.text });
+
+      if (dRes.ok) {
+        const d = await dRes.json();
+        const docs = (d.documents ?? []) as Array<{ type: string }>;
+        setHasLicense(docs.some((doc) => doc.type === "professional_license"));
+      }
+    } catch (error) {
+      setPageError(error instanceof Error ? error.message : "Unable to load verification status.");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
 
   useEffect(() => {
-    async function load() {
-      try {
-        const [vRes, dRes] = await Promise.all([
-          fetch("/api/provider/verification"),
-          fetch("/api/provider/identity-documents"),
-        ]);
-        if (vRes.ok) {
-          const v = await vRes.json();
-          setVerification({ identity: v.identity, text: v.text });
-        }
-        if (dRes.ok) {
-          const d = await dRes.json();
-          const docs = (d.documents ?? []) as Array<{ type: string }>;
-          setHasLicense(docs.some((doc) => doc.type === "professional_license"));
-        }
-      } finally {
-        setLoading(false);
-      }
-    }
-    void load();
-  }, []);
+    void loadVerification();
+  }, [loadVerification]);
 
   if (loading) {
     return (
@@ -47,22 +96,40 @@ export default function TrustAndVerificationPage() {
     );
   }
 
-  const identityStatus = verification?.identity.status ?? "not_started";
-  const isVerified = identityStatus === "verified";
-  const isPending = identityStatus === "pending" || identityStatus === "processing";
+  const identity = verification?.identity ?? { status: "not_started" as IdentityStatus };
+  const isVerified = identity.status === "verified";
+  const isPending = identity.status === "pending" || identity.status === "processing";
+  const needsAction = ["requires_input", "failed", "canceled"].includes(identity.status);
 
   return (
     <div className="mx-auto max-w-4xl space-y-8 p-6 pb-32 md:p-10">
-      <div>
-        <h1 className="font-display text-3xl font-medium tracking-tight text-slate-900">
-          Trust &amp; Verification
-        </h1>
-        <p className="mt-2 font-sans text-slate-500">
-          Complete verification to earn a trust badge and reassure clients before they reach out.
-        </p>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <h1 className="font-display text-3xl font-medium tracking-tight text-slate-900">
+            Trust &amp; Verification
+          </h1>
+          <p className="mt-2 font-sans text-slate-500">
+            Check your identity verification status and complete any action required to keep your trust badge current.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadVerification(true)}
+          disabled={refreshing}
+          className="inline-flex items-center justify-center gap-2 border border-slate-200 bg-white px-4 py-2 font-mono text-xs uppercase tracking-wider text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          Refresh Status
+        </button>
       </div>
 
-      {/* Overall status banner */}
+      {pageError && (
+        <div className="flex items-start gap-3 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{pageError}</span>
+        </div>
+      )}
+
       {isVerified ? (
         <div className="flex items-center justify-between rounded-xl border border-emerald-200 bg-emerald-50 p-6">
           <div className="flex items-center gap-4">
@@ -72,102 +139,202 @@ export default function TrustAndVerificationPage() {
             <div>
               <h3 className="font-sans font-semibold text-emerald-900">Identity Verified</h3>
               <p className="font-sans text-sm text-emerald-700">
-                Your badge is active on your public profile.
+                Your identity check is complete and your verified identity status is active.
               </p>
             </div>
           </div>
           <span className="hidden rounded-full bg-emerald-600 px-3 py-1.5 font-mono text-xs uppercase tracking-widest text-white sm:block">
-            Active
+            Verified
           </span>
         </div>
+      ) : needsAction ? (
+        <div className="flex items-start gap-4 rounded-xl border border-rose-200 bg-rose-50 p-6">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-rose-100">
+            <AlertCircle className="h-6 w-6 text-rose-600" />
+          </div>
+          <div>
+            <h3 className="font-sans font-semibold text-rose-900">Identity Verification Needs Attention</h3>
+            <p className="font-sans text-sm text-rose-700">
+              Your previous identity check was not completed. Review the status below and submit a new verification.
+            </p>
+          </div>
+        </div>
       ) : (
-        <div className="flex items-center gap-4 rounded-xl border border-amber-200 bg-amber-50 p-6">
+        <div className="flex items-start gap-4 rounded-xl border border-amber-200 bg-amber-50 p-6">
           <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-100">
             <ShieldCheck className="h-6 w-6 text-amber-600" />
           </div>
           <div>
-            <h3 className="font-sans font-semibold text-amber-900">Verification incomplete</h3>
+            <h3 className="font-sans font-semibold text-amber-900">
+              {isPending ? "Identity Verification in Progress" : "Identity Verification Required"}
+            </h3>
             <p className="font-sans text-sm text-amber-700">
               {isPending
-                ? "Your identity check is in progress — usually completes within minutes."
-                : "Complete identity verification to unlock your verified badge."}
+                ? "Your identity check is being processed. Refresh this page to see the latest status."
+                : "Complete identity verification to establish your verified identity status."}
             </p>
           </div>
         </div>
       )}
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        <IdentityCard status={identityStatus} />
-        <LicenseCard
-          hasLicense={hasLicense ?? false}
-          onUploaded={() => setHasLicense(true)}
-        />
+        <IdentityCard identity={identity} onRefresh={() => loadVerification(true)} />
+        <LicenseCard hasLicense={hasLicense ?? false} onUploaded={() => setHasLicense(true)} />
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+        <strong className="text-slate-800">Need to return from an email?</strong>{" "}
+        This page is the permanent MasseurMatch verification page. You can safely bookmark
+        <span className="font-medium text-slate-900"> masseurmatch.com/pro/trust</span> and return here to check status or retry.
       </div>
     </div>
   );
 }
 
-function IdentityCard({ status }: { status: string }) {
+function IdentityCard({
+  identity,
+  onRefresh,
+}: {
+  identity: IdentityVerification;
+  onRefresh: () => Promise<void>;
+}) {
   const [starting, setStarting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const status = identity.status;
   const verified = status === "verified";
   const pending = status === "pending" || status === "processing";
-  const failed = status === "failed" || status === "requires_input";
+  const requiresInput = status === "requires_input";
+  const failed = status === "failed";
+  const canceled = status === "canceled";
+  const canStart = !verified && !pending;
+
+  const statusCopy: Record<IdentityStatus, { label: string; description: string }> = {
+    verified: {
+      label: "Verified",
+      description: "Your government-issued ID was successfully validated by Stripe Identity.",
+    },
+    pending: {
+      label: "Pending",
+      description: "Your verification was submitted and is waiting to be processed.",
+    },
+    processing: {
+      label: "Processing",
+      description: "Stripe is processing your identity verification. This usually completes within minutes.",
+    },
+    requires_input: {
+      label: "Additional Information Required",
+      description: "Stripe needs additional information or a new submission before verification can be completed.",
+    },
+    failed: {
+      label: "Verification Failed",
+      description: "Your previous identity verification could not be completed. You can submit a new attempt below.",
+    },
+    canceled: {
+      label: "Verification Canceled",
+      description: "The previous verification session was canceled. Start a new verification to continue.",
+    },
+    not_started: {
+      label: "Not Started",
+      description: "Verify your government-issued ID with Stripe Identity to complete this trust check.",
+    },
+  };
 
   async function startVerification() {
     setStarting(true);
+    setActionError(null);
     try {
-      const res = await fetch("/api/stripe/identity/create-session", {
+      const res = await fetch("/api/provider/verification/identity/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
-      const data = await res.json();
-      if (data.url) window.location.href = data.url;
-    } finally {
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error ?? "Unable to start identity verification.");
+      if (!data.url) throw new Error("Stripe did not return a verification link. Please try again.");
+      window.location.assign(data.url);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to start identity verification.");
       setStarting(false);
     }
   }
 
-  const barColor = verified ? "bg-emerald-500" : pending ? "bg-amber-400" : "bg-slate-200";
+  const updatedAt = formatDate(identity.updatedAt);
+  const verifiedAt = formatDate(identity.verifiedAt);
+  const barColor = verified
+    ? "bg-emerald-500"
+    : pending
+      ? "bg-amber-400"
+      : requiresInput || failed || canceled
+        ? "bg-rose-500"
+        : "bg-slate-300";
 
   return (
-    <div className="relative flex flex-col items-center gap-4 overflow-hidden border border-slate-200/60 bg-white p-6 text-center shadow-sm">
+    <div className="relative flex flex-col gap-5 overflow-hidden border border-slate-200/60 bg-white p-6 shadow-sm">
       <div className={`absolute left-0 top-0 h-1 w-full ${barColor}`} />
-      {verified ? (
-        <CheckCircle2 className="mt-2 h-8 w-8 text-emerald-500" />
-      ) : pending ? (
-        <Clock className="mt-2 h-8 w-8 text-amber-500" />
-      ) : (
-        <AlertCircle className={`mt-2 h-8 w-8 ${failed ? "text-rose-400" : "text-slate-400"}`} />
-      )}
-      <div>
-        <h4 className="font-display text-lg font-medium text-slate-900">
-          Identity Verification
-        </h4>
-        <p className="mt-1 font-sans text-sm text-slate-500">
-          {verified
-            ? "Passport or Driver's License successfully validated by Stripe."
-            : pending
-            ? "Verification in progress — usually completes within a few minutes."
-            : failed
-            ? "Verification could not be completed. Please try again."
-            : "Verify your government-issued ID to earn your trusted badge."}
-        </p>
+      <div className="flex items-start gap-3">
+        {verified ? (
+          <CheckCircle2 className="mt-0.5 h-8 w-8 shrink-0 text-emerald-500" />
+        ) : pending ? (
+          <Clock className="mt-0.5 h-8 w-8 shrink-0 text-amber-500" />
+        ) : canceled ? (
+          <XCircle className="mt-0.5 h-8 w-8 shrink-0 text-rose-500" />
+        ) : (
+          <AlertCircle className={`mt-0.5 h-8 w-8 shrink-0 ${requiresInput || failed ? "text-rose-500" : "text-slate-400"}`} />
+        )}
+        <div>
+          <h4 className="font-display text-lg font-medium text-slate-900">Identity Verification</h4>
+          <div className="mt-1 font-mono text-xs font-semibold uppercase tracking-wider text-slate-700">
+            {statusCopy[status].label}
+          </div>
+          <p className="mt-2 font-sans text-sm leading-relaxed text-slate-500">
+            {statusCopy[status].description}
+          </p>
+        </div>
       </div>
-      {!verified && !pending && (
-        <button
-          onClick={startVerification}
-          disabled={starting}
-          className="mt-2 flex items-center gap-2 bg-slate-900 px-4 py-2 font-mono text-xs uppercase tracking-wider text-white transition-colors hover:bg-slate-700 disabled:opacity-60"
-        >
-          {starting ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
-          ) : (
-            <ExternalLink className="h-3 w-3" />
-          )}
-          {failed ? "Retry Verification" : "Start Verification"}
-        </button>
+
+      {identity.lastError && (requiresInput || failed || canceled) && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-left">
+          <div className="font-mono text-[10px] font-semibold uppercase tracking-wider text-rose-700">
+            Verification issue
+          </div>
+          <p className="mt-1 break-words text-sm text-rose-800">{identity.lastError}</p>
+        </div>
       )}
+
+      {(updatedAt || verifiedAt) && (
+        <div className="border-t border-slate-100 pt-3 text-xs text-slate-400">
+          {verifiedAt ? `Verified ${verifiedAt}` : updatedAt ? `Last updated ${updatedAt}` : null}
+        </div>
+      )}
+
+      {actionError && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800">
+          {actionError}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {canStart && (
+          <button
+            type="button"
+            onClick={startVerification}
+            disabled={starting}
+            className="inline-flex items-center gap-2 bg-slate-900 px-4 py-2 font-mono text-xs uppercase tracking-wider text-white transition-colors hover:bg-slate-700 disabled:opacity-60"
+          >
+            {starting ? <Loader2 className="h-3 w-3 animate-spin" /> : <ExternalLink className="h-3 w-3" />}
+            {requiresInput || failed ? "Retry Verification" : canceled ? "Restart Verification" : "Start Verification"}
+          </button>
+        )}
+        {pending && (
+          <button
+            type="button"
+            onClick={() => void onRefresh()}
+            className="inline-flex items-center gap-2 border border-slate-200 bg-white px-4 py-2 font-mono text-xs uppercase tracking-wider text-slate-700 transition hover:bg-slate-50"
+          >
+            <RefreshCw className="h-3 w-3" /> Check Status
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What changed
- Shows canonical Stripe Identity status in `/pro/trust`: verified, pending, processing, requires input, failed, canceled, or not started.
- Exposes the latest identity verification `last_error` from the provider verification API.
- Shows verification error/reason when action is required.
- Adds Retry Verification for failed/requires-input states.
- Adds Restart Verification for canceled sessions.
- Adds Start Verification for users who have not started.
- Prevents duplicate starts while a verification is pending/processing and provides Check Status instead.
- Adds manual Refresh Status.
- Uses the provider identity start API as the canonical session creation endpoint.
- Makes `https://masseurmatch.com/pro/trust` the stable page users can return to from verification emails.

## Flow
Email -> `/pro/trust` -> current status/error -> Retry/Restart -> Stripe Identity -> return -> refresh status.

## Notes
Stripe verification URLs remain dynamic and are generated only when the provider clicks the action button; emails should link to `/pro/trust`, not directly to a Stripe session URL.