### PR TITLE
Fix legacy Profile Coach email URL

### DIFF
--- a/src/app/dashboard/profile/coach/page.tsx
+++ b/src/app/dashboard/profile/coach/page.tsx
@@ -1,0 +1,5 @@
+import { permanentRedirect } from "next/navigation";
+
+export default function LegacyProfileCoachRedirectPage() {
+  permanentRedirect("/pro/ai-coach");
+}


### PR DESCRIPTION
Adds `/dashboard/profile/coach` as a permanent compatibility redirect to the canonical `/pro/ai-coach` route. This repairs the URL contained in Profile Coach emails that were already sent without duplicating the existing AI Coach page.