### PR TITLE
Fix Pro Trust live identity status and retry flow

### DIFF
--- a/src/app/api/provider/verification/identity/start/route.ts
+++ b/src/app/api/provider/verification/identity/start/route.ts
@@ -3,21 +3,22 @@ import { requireSession } from "@/app/api/_lib/supabase-server";
 
 export async function POST(request: Request) {
   try {
-    const session = await requireSession(request);
-    // Delegate to the existing Stripe identity session creator
-    const res = await fetch(
-      new URL("/api/stripe/identity/create-session", request.url).toString(),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          cookie: request.headers.get("cookie") ?? "",
-        },
-        body: JSON.stringify({}),
-      }
-    );
+    await requireSession(request);
+    const res = await fetch(new URL("/api/stripe/identity/create-session", request.url).toString(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        cookie: request.headers.get("cookie") ?? "",
+      },
+      body: JSON.stringify({ returnTo: "pro_trust" }),
+    });
     const data = await res.json();
-    if (!res.ok) throw new RouteError(res.status as 400 | 401 | 403 | 404 | 500, data.error ?? "Failed to start identity verification.");
+    if (!res.ok) {
+      throw new RouteError(
+        res.status as 400 | 401 | 403 | 404 | 500,
+        data.error ?? "Failed to start identity verification.",
+      );
+    }
     return json({ ok: true, ...data });
   } catch (error) {
     return errorResponse(error);

--- a/src/app/api/provider/verification/route.ts
+++ b/src/app/api/provider/verification/route.ts
@@ -1,6 +1,16 @@
+import Stripe from "stripe";
 import { errorResponse, json } from "@/app/api/_lib/http";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
 import { normalizeIdentityStatus } from "@/app/_lib/identity-verification";
+import { STRIPE_API_VERSION } from "@/app/api/_lib/stripe-config";
+
+function mapStripeStatus(status: Stripe.Identity.VerificationSession.Status) {
+  if (status === "verified") return "verified";
+  if (status === "processing") return "processing";
+  if (status === "canceled") return "canceled";
+  if (status === "requires_input") return "requires_input";
+  return "failed";
+}
 
 export async function GET(request: Request) {
   try {
@@ -25,8 +35,48 @@ export async function GET(request: Request) {
         .maybeSingle(),
     ]);
 
-    const identityRow = identityResult.data;
+    let identityRow = identityResult.data;
     const textRow = textResult.data;
+
+    // Stripe is the source of truth for an existing verification session. This
+    // makes /pro/trust recover even if a webhook was delayed or missed.
+    if (identityRow?.stripe_session_id && process.env.STRIPE_SECRET_KEY) {
+      try {
+        const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: STRIPE_API_VERSION });
+        const stripeSession = await stripe.identity.verificationSessions.retrieve(identityRow.stripe_session_id);
+        const stripeStatus = mapStripeStatus(stripeSession.status);
+        const lastError = stripeSession.last_error?.reason ?? null;
+
+        if (stripeStatus !== normalizeIdentityStatus(identityRow.status) || lastError !== identityRow.last_error) {
+          const updatedAt = new Date().toISOString();
+          await adminClient
+            .from("identity_verifications")
+            .update({ status: stripeStatus, last_error: lastError, updated_at: updatedAt })
+            .eq("id", identityRow.id);
+
+          identityRow = {
+            ...identityRow,
+            status: stripeStatus,
+            last_error: lastError,
+            updated_at: updatedAt,
+          };
+
+          await adminClient
+            .from("profiles")
+            .update({
+              is_verified_identity: stripeStatus === "verified",
+              verification_status: stripeStatus,
+              identity_verified_at: stripeStatus === "verified" ? updatedAt : null,
+              updated_at: updatedAt,
+            })
+            .eq("user_id", session.userId);
+        }
+      } catch (stripeError) {
+        // Do not make Trust unusable if Stripe is temporarily unavailable.
+        console.error("Unable to sync identity status from Stripe", stripeError);
+      }
+    }
+
     const identityStatus = normalizeIdentityStatus(identityRow?.status);
 
     return json({

--- a/src/app/api/stripe/identity/create-session/route.ts
+++ b/src/app/api/stripe/identity/create-session/route.ts
@@ -12,9 +12,7 @@ import {
 
 function getStripe() {
   const key = process.env.STRIPE_SECRET_KEY;
-  if (!key) {
-    throw new Error("STRIPE_SECRET_KEY is not configured. Please ensure the Stripe connector is enabled.");
-  }
+  if (!key) throw new Error("STRIPE_SECRET_KEY is not configured. Please ensure the Stripe connector is enabled.");
   return new Stripe(key, { apiVersion: STRIPE_API_VERSION });
 }
 
@@ -28,24 +26,19 @@ export async function POST(request: NextRequest) {
     let targetUserId = session.userId;
     let targetEmail = session.email || "";
 
-    const requestedUserId =
-      typeof body.userId === "string" && body.userId.trim() ? body.userId.trim() : null;
-    const requestedEmail =
-      typeof body.email === "string" && body.email.trim() ? body.email.trim().toLowerCase() : null;
+    const requestedUserId = typeof body.userId === "string" && body.userId.trim() ? body.userId.trim() : null;
+    const requestedEmail = typeof body.email === "string" && body.email.trim() ? body.email.trim().toLowerCase() : null;
+    const returnToTrust = body.returnTo === "pro_trust";
 
     if (requesterRole === "admin" && (requestedUserId || requestedEmail)) {
       if (requestedUserId) {
         const { data, error } = await adminClient.auth.admin.getUserById(requestedUserId);
-        if (error || !data.user) {
-          return NextResponse.json({ error: "Target user not found." }, { status: 404 });
-        }
+        if (error || !data.user) return NextResponse.json({ error: "Target user not found." }, { status: 404 });
         targetUserId = data.user.id;
         targetEmail = data.user.email ?? requestedEmail ?? "";
       } else if (requestedEmail) {
         const targetUser = await getUserByEmail(requestedEmail);
-        if (!targetUser) {
-          return NextResponse.json({ error: "Target user not found." }, { status: 404 });
-        }
+        if (!targetUser) return NextResponse.json({ error: "Target user not found." }, { status: 404 });
         targetUserId = targetUser.id;
         targetEmail = targetUser.email ?? requestedEmail;
       }
@@ -57,12 +50,10 @@ export async function POST(request: NextRequest) {
     const stripe = getStripe();
     const verificationSession = await stripe.identity.verificationSessions.create({
       type: "document",
-      return_url: `${SITE_URL}/signup/verify?identity_return=1`,
-      metadata: {
-        userId: targetUserId,
-        email: targetEmail,
-        requestedBy: session.userId,
-      },
+      return_url: returnToTrust
+        ? `${SITE_URL}/pro/trust?identity_return=1`
+        : `${SITE_URL}/signup/verify?identity_return=1`,
+      metadata: { userId: targetUserId, email: targetEmail, requestedBy: session.userId },
       options: {
         document: {
           allowed_types: ["driving_license", "passport", "id_card"],
@@ -79,20 +70,17 @@ export async function POST(request: NextRequest) {
       .limit(1)
       .maybeSingle();
 
+    const verificationValues = {
+      stripe_session_id: verificationSession.id,
+      status: "pending",
+      last_error: null,
+      updated_at: new Date().toISOString(),
+    };
+
     if (existingVerification?.id) {
-      await adminClient
-        .from("identity_verifications")
-        .update({
-          stripe_session_id: verificationSession.id,
-          status: "pending",
-        })
-        .eq("id", existingVerification.id);
+      await adminClient.from("identity_verifications").update(verificationValues).eq("id", existingVerification.id);
     } else {
-      await adminClient.from("identity_verifications").insert({
-        user_id: targetUserId,
-        stripe_session_id: verificationSession.id,
-        status: "pending",
-      });
+      await adminClient.from("identity_verifications").insert({ user_id: targetUserId, ...verificationValues });
     }
 
     await adminClient
@@ -112,8 +100,7 @@ export async function POST(request: NextRequest) {
       url: verificationSession.url,
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Failed to create identity verification session.";
+    const message = error instanceof Error ? error.message : "Failed to create identity verification session.";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }


### PR DESCRIPTION
Fixes the production behavior where /pro/trust could remain stuck on a stale Supabase status and therefore hide Retry Verification.

Changes:
- `/api/provider/verification` now retrieves the latest Stripe Identity VerificationSession directly when a session ID exists, treats Stripe as source of truth, and repairs the Supabase/profile status when webhook state is stale.
- Captures Stripe `last_error.reason` during the live sync.
- Identity sessions started from `/pro/trust` now return to `/pro/trust?identity_return=1` instead of `/signup/verify`.
- Starting a new attempt clears stale `last_error`.

Expected result:
`/pro/trust` shows the actual Stripe status. `requires_input`, `failed`, and `canceled` states expose Retry/Restart. Verified shows green. Pending/processing shows Check Status.