### PR TITLE
fix(referrals): handle pluralization of reward months correctly

### DIFF
--- a/src/app/pro/referrals/page.tsx
+++ b/src/app/pro/referrals/page.tsx
@@ -213,7 +213,7 @@ export default function ReferralsPage() {
                       </td>
                       <td className="px-3 py-4">{formatDate(referral.paid_at)}</td>
                       <td className="px-3 py-4 text-right font-semibold">
-                        {referral.reward_months ? `+${referral.reward_months} Standard month` : "—"}
+                        {referral.reward_months ? `+${referral.reward_months} Standard month${referral.reward_months === 1 ? "" : "s"}` : "—"}
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary

Fixed pluralization of reward months display on the referrals page. When displaying rewards, the page now correctly shows "1 Standard month" for a single month reward and "X Standard months" for multiple months.

## Changes

- Fixed reward display in referral dashboard to properly pluralize "month" vs "months" based on reward count

## Testing

- All unit tests pass ✓
- All API tests pass ✓
- Build completes successfully ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_019QUdPnQ4SUdfQMeUHbJdYo)_