### PR TITLE
ci: only fail preview-url when a preview should have existed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,27 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const sha = context.payload.pull_request.head.sha;
-            const deadlineMs = Date.now() + 10 * 60 * 1000;
+            const pullRequest = context.payload.pull_request;
+            const sha = pullRequest.head.sha;
             const isPreview = (u) => !!u && /vercel\.app/.test(u);
+
+            // Vercel decides whether to build at the moment it receives a push and
+            // never revisits that decision. A head commit that already existed when
+            // the pull request was opened was therefore pushed while
+            // scripts/vercel-ignore-build.mjs had no pull request to key on, so its
+            // build was skipped and no preview is ever coming for that exact commit.
+            //
+            // That is unavoidable, not a fault: a branch must exist on the remote
+            // before a pull request can be opened against it, so the first push of
+            // every new branch lands in this state. Treat it as a warning and keep
+            // the wait short. Any later commit does get a preview, so a missing one
+            // there is a real failure worth blocking on.
+            const headCommit = await github.rest.repos.getCommit({
+              owner: context.repo.owner, repo: context.repo.repo, ref: sha,
+            });
+            const previewImpossible =
+              Date.parse(headCommit.data.commit.committer.date) < Date.parse(pullRequest.created_at);
+            const deadlineMs = Date.now() + (previewImpossible ? 90 * 1000 : 10 * 60 * 1000);
             while (Date.now() < deadlineMs) {
               const deployments = await github.rest.repos.listDeployments({
                 owner: context.repo.owner, repo: context.repo.repo, sha, per_page: 100,
@@ -191,22 +209,33 @@ jobs:
               await new Promise((r) => setTimeout(r, 15000));
             }
             core.setOutput('url', '');
+
+            if (previewImpossible) {
+              core.warning(
+                [
+                  `E2E and accessibility suites did NOT run for ${sha.slice(0, 7)}.`,
+                  '',
+                  'This commit predates the pull request, so Vercel skipped its build and no',
+                  'preview exists to test against. Expected for the first push of a branch.',
+                  '',
+                  'To exercise the UI before merging, push another commit: it will build a',
+                  'preview and both suites will run against it.',
+                ].join('\n'),
+              );
+              return;
+            }
+
             core.setFailed(
               [
                 'No Vercel preview URL resolved for this pull request.',
                 '',
-                'Without a preview there is nothing for the E2E and accessibility suites to',
-                'run against, and they would be skipped silently — a green pull request that',
-                'never exercised the UI. Failing loudly instead.',
+                'This commit was pushed while the pull request was already open, so Vercel',
+                'should have built a preview for it. Without one there is nothing for the E2E',
+                'and accessibility suites to run against and they would skip silently, leaving',
+                'a green pull request that never exercised the UI.',
                 '',
-                'Most likely cause: the branch was pushed BEFORE the pull request existed, so',
-                'scripts/vercel-ignore-build.mjs skipped the build (a pull request is what makes',
-                'a preview worth building) and Vercel does not rebuild that commit when the pull',
-                'request opens later.',
-                '',
-                'Fix: push any new commit to this branch. Now that the pull request is open the',
-                'preview will build, and this job will pass. Opening the pull request as a draft',
-                'before the first push avoids the situation entirely.',
+                'Check the Vercel dashboard: the build likely failed, or scripts/vercel-ignore',
+                '-build.mjs skipped it unexpectedly.',
               ].join('\n'),
             );
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,18 @@ after the next commit fixes it. Open a pull request — a draft is enough — as
 soon as you want a preview URL or CI coverage; both are keyed to the pull
 request, not to the branch.
 
-**Open the draft pull request before the first push.** Vercel decides whether to
-build at the moment it receives the push, and it does not revisit that decision
-when a pull request opens afterwards. Push first and that commit never gets a
-preview — which means `E2E Tests` and `Accessibility (WCAG 2.1 AA)` have nothing
-to run against. The `preview-url` job fails in that case rather than skipping
-them quietly, so the pull request goes red until you push again. Opening the
-draft first costs nothing and avoids the round trip.
+**The first commit of a branch never gets a preview.** Vercel decides whether to
+build at the moment it receives a push and never revisits that decision, and a
+branch has to exist on the remote before a pull request can be opened against
+it. So the first push always arrives with no pull request to key on, is skipped,
+and stays skipped once the pull request opens. There is no way to order it
+differently — this is a property of the setup, not a mistake.
+
+The practical consequence: on that first commit `E2E Tests` and
+`Accessibility (WCAG 2.1 AA)` do not run. `preview-url` says so with a warning
+instead of failing, since nothing is wrong. **Push a second commit before
+merging anything whose UI matters** — it builds a preview and both suites run
+against it.
+
+If a preview is missing for a commit pushed *after* the pull request was opened,
+that is a genuine fault and `preview-url` fails: Vercel should have built one.


### PR DESCRIPTION
## Why

Fixes a defect I introduced in #678, which is now on `main`.

Codex flagged it as P1 on that pull request and was right. #678 made `preview-url` fail whenever no preview resolved, and I described that as rare. It is not rare — it fires on **every new pull request**:

A branch has to exist on the remote before a pull request can be opened against it. So the first push always reaches `scripts/vercel-ignore-build.mjs` with no pull request to key on, gets skipped, and Vercel never revisits that decision when the pull request opens. The result on `main` today is that every new pull request burns ten minutes and then goes red until someone pushes a throwaway commit.

My own two pull requests are the evidence, and I had the data in hand without connecting it:

```
#669: push 9664b64 → Ignored | push 4e5a954 → preview Ready
#678: push 77fd228 → Ignored | push e3520d9 → preview Ready
```

Both needed a second push. I read that as coincidence twice.

## What changed

Separate "no preview was possible" from "a preview should have existed", by comparing the head commit's timestamp against the pull request's `created_at`:

| Head commit | No preview resolved | Wait |
| --- | --- | --- |
| Predates the pull request | **Warning**, job passes | 90s |
| Pushed after the pull request opened | **Failure** | 10 min |

The first row is the unavoidable case, so it does not block — but it says loudly that `E2E Tests` and `Accessibility (WCAG 2.1 AA)` did not run for that commit, and how to fix it. The second row is a genuine fault worth blocking on: Vercel had a pull request to key on and still produced nothing.

The short wait on the first row also stops CI from idling ten minutes for an outcome that is known up front.

## CLAUDE.md

The guidance added in #678 told readers to open the draft pull request before the first push. That is not possible, for the same reason the defect exists. Replaced with what actually applies: the first commit never gets a preview, and you should push a second commit before merging anything whose UI matters.

## Verification

Resolve script extracted from the workflow and driven against a stubbed `github`/`core`, deadlines shortened so the poll loop terminates:

| Scenario | `url` | fails | warns |
| --- | --- | --- | --- |
| Preview ready, commit after PR | preview URL | no | no |
| Preview ready, commit before PR | preview URL | no | no |
| First push: commit before PR, no preview | `""` | **no** | yes |
| Later push: commit after PR, no preview | `""` | **yes** | no |
| Later push: build failed | `""` | **yes** | yes |

`ci.yml` parses as valid YAML; `lint`, `typecheck` and `test:unit` pass.

## Note

This pull request will itself hit the first-push case — its own head commit predates it, and the workflow that runs is the one from `main`, which still has the #678 behaviour. Expect `preview-url` to fail here once. Pushing any commit clears it, and merging this makes that a warning for everyone afterwards.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr9DuKEBZ1VEnRVTYRLHMq)_