### PR TITLE
Reconcile Supabase migration history

### DIFF
--- a/supabase/migrations/20260810182139_profile_coach_premium_email_and_9am_sender.sql
+++ b/supabase/migrations/20260810182139_profile_coach_premium_email_and_9am_sender.sql
@@ -1,0 +1,6 @@
+-- Migration history reconciliation.
+-- This migration was applied directly to the linked Supabase project on 2026-08-10
+-- and is already recorded remotely as profile_coach_premium_email_and_9am_sender.
+-- The schema change itself is intentionally not replayed here: this file restores the
+-- missing local migration version so Supabase branch/preview history remains consistent.
+-- Subsequent recorded migrations on the same date contain the follow-up fixes.

--- a/supabase/migrations/20260810190905_fix_profile_coach_queue_status.sql
+++ b/supabase/migrations/20260810190905_fix_profile_coach_queue_status.sql
@@ -1,0 +1,4 @@
+-- Migration history reconciliation.
+-- Applied directly to the linked Supabase project on 2026-08-10 and already
+-- recorded remotely as fix_profile_coach_queue_status.
+-- No-op locally to restore the missing migration version without replaying production DDL.

--- a/supabase/migrations/20260810192151_fix_profile_coach_queue_status.sql
+++ b/supabase/migrations/20260810192151_fix_profile_coach_queue_status.sql
@@ -1,0 +1,4 @@
+-- Migration history reconciliation.
+-- Applied directly to the linked Supabase project on 2026-08-10 and already
+-- recorded remotely as fix_profile_coach_queue_status.
+-- No-op locally to restore the missing migration version without replaying production DDL.

--- a/supabase/migrations/20260810192358_fix_profile_coach_queue_status.sql
+++ b/supabase/migrations/20260810192358_fix_profile_coach_queue_status.sql
@@ -1,0 +1,4 @@
+-- Migration history reconciliation.
+-- Applied directly to the linked Supabase project on 2026-08-10 and already
+-- recorded remotely as fix_profile_coach_queue_status.
+-- No-op locally to restore the missing migration version without replaying production DDL.

--- a/supabase/migrations/20260810192850_fix_profile_coach_link.sql
+++ b/supabase/migrations/20260810192850_fix_profile_coach_link.sql
@@ -1,0 +1,4 @@
+-- Migration history reconciliation.
+-- Applied directly to the linked Supabase project on 2026-08-10 and already
+-- recorded remotely as fix_profile_coach_link.
+-- No-op locally to restore the missing migration version without replaying production DDL.

--- a/supabase/migrations/20260810193240_fix_profile_coach_queue_status.sql
+++ b/supabase/migrations/20260810193240_fix_profile_coach_queue_status.sql
@@ -1,0 +1,4 @@
+-- Migration history reconciliation.
+-- Applied directly to the linked Supabase project on 2026-08-10 and already
+-- recorded remotely as fix_profile_coach_queue_status.
+-- No-op locally to restore the missing migration version without replaying production DDL.


### PR DESCRIPTION
## Summary

Restores the six local migration-version files that were applied directly to the linked Supabase project on August 10, 2026 but were missing from `supabase/migrations`.

## Why

Supabase Preview was failing with `Remote migration versions not found in local migrations directory.` after otherwise-green application CI.

## Safety

- No production schema mutation in this PR.
- No remote migration-history deletion or repair.
- Files are explicit no-op reconciliation records for already-applied remote versions.
- Existing remote migration history remains authoritative.

## Validation gate

Merge only after Supabase Preview and repository CI are green.