### PR TITLE
ci: stop the pull-request suites from testing production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,9 +247,13 @@ jobs:
       options: --ipc=host
     needs: [build, preview-url]
     env:
-      PLAYWRIGHT_BASE_URL: ${{ needs.preview-url.outputs.url != '' && needs.preview-url.outputs.url || vars.PLAYWRIGHT_BASE_URL }}
+      # The preview for THIS pull request, and nothing else. Falling back to a
+      # fixed URL here used to point the suite at production, so a pull request
+      # whose commit had no preview reported a green E2E run having never
+      # exercised its own code. Production is covered by production-smoke.yml.
+      PLAYWRIGHT_BASE_URL: ${{ needs.preview-url.outputs.url }}
       VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
-    if: ${{ always() && needs.build.result == 'success' && (needs.preview-url.outputs.url != '' || vars.PLAYWRIGHT_BASE_URL != '') }}
+    if: ${{ always() && needs.build.result == 'success' && needs.preview-url.outputs.url != '' }}
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -278,9 +282,10 @@ jobs:
       options: --ipc=host
     needs: [build, preview-url]
     env:
-      PLAYWRIGHT_BASE_URL: ${{ needs.preview-url.outputs.url != '' && needs.preview-url.outputs.url || vars.PLAYWRIGHT_BASE_URL }}
+      # Same rule as the E2E job: the preview for THIS pull request only.
+      PLAYWRIGHT_BASE_URL: ${{ needs.preview-url.outputs.url }}
       VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
-    if: ${{ always() && needs.build.result == 'success' && (needs.preview-url.outputs.url != '' || vars.PLAYWRIGHT_BASE_URL != '') }}
+    if: ${{ always() && needs.build.result == 'success' && needs.preview-url.outputs.url != '' }}
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,52 @@
+# This suite used to run inside CI as the pull-request E2E gate, via a
+# `PLAYWRIGHT_BASE_URL` fallback that pointed at production. That made every
+# pull request whose commit had no preview report a green E2E run while never
+# touching its own code — it was checking that masseurmatch.com was up, which
+# is a useful claim but not the one a pull request needs.
+#
+# Splitting it out keeps the claim and makes it honest: green here means
+# production is healthy. Green on a pull request means that pull request was
+# exercised. The two no longer masquerade as each other.
+
+name: Production Smoke
+
+on:
+  schedule:
+    # Every six hours. Production changes only when main deploys, so this is
+    # about catching drift and outages, not about gating changes.
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: production-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Production smoke (masseurmatch.com)
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
+      options: --ipc=host
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ vars.PLAYWRIGHT_BASE_URL }}
+    if: ${{ vars.PLAYWRIGHT_BASE_URL != '' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.32.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Run smoke tests against production
+        run: pnpm exec playwright test
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: production-smoke-report
+          path: playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## The problem

The `e2e` and `a11y` jobs fell back to `vars.PLAYWRIGHT_BASE_URL` whenever no preview URL resolved. That repository variable is set to `https://masseurmatch.com`.

The first push of any pull request never gets a preview (a branch must exist before a pull request can be opened against it, so that push is always skipped by `scripts/vercel-ignore-build.mjs`). Which means: on every new pull request, the suites fell through to production and reported green.

Confirmed in the actual run for #692 — this is not inference:

```
PLAYWRIGHT_BASE_URL: https://masseurmatch.com
Running 261 tests using 2 workers
236 passed (3.2m), 25 skipped
```

Two distinct problems:

1. **The pull request claimed coverage it never had.** A green `E2E Tests` check on #692 meant "masseurmatch.com works", not "this change works". The pull request's own code was never loaded.
2. **Every pull request drove a full 261-test suite against the live site**, including whatever those tests write.

This is worse than the silent skip I described in #678 and #692. In both of those I wrote that the suites "skip silently" and set the fallback aside as out of scope. They did not skip — they tested the wrong target and passed. The fallback was the most serious of the three issues, and I walked past it twice.

## The split

**Pull-request gate** — `e2e` and `a11y` now take `needs.preview-url.outputs.url` and nothing else, and their `if` requires it to be non-empty. With no preview they genuinely skip, which is exactly what `preview-url` already warns about. There is no path left where a pull request check reports on a target that is not its own preview.

**Production check** — moved to `.github/workflows/production-smoke.yml`, on a six-hour schedule plus `workflow_dispatch`. Production only changes when `main` deploys, so this is about catching drift and outages, not gating changes. It keeps the useful claim and drops the misleading one.

The two now say different things and can no longer be mistaken for each other.

## Verification

Both workflows parse as valid YAML. Asserted programmatically that neither pull-request job can reach the fixed URL any more:

```
e2e  base url : ${{ needs.preview-url.outputs.url }}
     if       : ... && needs.preview-url.outputs.url != ''
a11y base url : ${{ needs.preview-url.outputs.url }}
     if       : ... && needs.preview-url.outputs.url != ''

OK: neither PR job can fall back to a fixed URL
```

`vars.PLAYWRIGHT_BASE_URL` now appears only in `production-smoke.yml`.

## What to expect on this pull request

Its own head commit predates it, so there is no preview and `E2E Tests` / `Accessibility` will show as **skipped** rather than green — the new, honest behaviour, visible on the change that introduces it. That is not a coverage gap here: this pull request touches only CI configuration and ships no UI. For a change that does touch UI, push a second commit to get a preview and both suites will run against it.

## Follow-up worth considering

With the fallback gone, a UI pull request merged on its first commit has genuinely untested UI. Requiring `E2E Tests` as a status check under branch protection would close that — it cannot pass without a preview, which forces the second push exactly when it matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr9DuKEBZ1VEnRVTYRLHMq)_