### PR TITLE
Manual identity verification fallback while Stripe is restricted

### DIFF
--- a/src/app/admin/verification/manual/page.tsx
+++ b/src/app/admin/verification/manual/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, RefreshCw, ShieldCheck, XCircle } from "lucide-react";
+
+import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type ManualMetadata = {
+  manual?: {
+    challengeCode?: string;
+    documentType?: string;
+    documentCountry?: string;
+    submittedAt?: string | null;
+    reviewedAt?: string | null;
+    decision?: string | null;
+    rejectionReason?: string | null;
+    files?: Record<string, { path?: string; mimeType?: string; uploadedAt?: string }>;
+  };
+};
+
+type Verification = {
+  id: string;
+  user_id: string;
+  status: string;
+  last_error: string | null;
+  metadata: ManualMetadata | null;
+  created_at: string;
+  updated_at: string;
+  user_name: string | null;
+  user_email: string | null;
+};
+
+export default function ManualVerificationAdminPage() {
+  const [rows, setRows] = useState<Verification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/verification/manual", { credentials: "include", cache: "no-store" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error ?? "Could not load manual identity reviews.");
+      setRows(data.verifications ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load manual identity reviews.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  async function review(id: string, decision: "approve" | "reject") {
+    let reason = "";
+    if (decision === "reject") {
+      reason = window.prompt("Reason shown to the provider:", "Document or selfie could not be verified. Please submit a new clear attempt.")?.trim() ?? "";
+      if (!reason) return;
+    }
+
+    setBusyId(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/verification/${id}/manual-review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision, reason }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error ?? "Review action failed.");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Review action failed.");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const pending = rows.filter((row) => row.status === "pending");
+  const history = rows.filter((row) => row.status !== "pending");
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader title="Manual Identity Review" description="Temporary identity verification queue while Stripe Identity is unavailable." />
+
+      {error && <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="font-display text-base">Pending review ({pending.length})</CardTitle>
+          <Button size="sm" variant="outline" onClick={() => void load()} disabled={loading}><RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />Refresh</Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {loading ? <div className="flex justify-center py-12"><Loader2 className="h-7 w-7 animate-spin text-muted-foreground" /></div> : pending.length === 0 ? <div className="py-10 text-center text-sm text-muted-foreground">No manual identity verifications are waiting.</div> : pending.map((row) => <ReviewCard key={row.id} row={row} busy={busyId === row.id} onReview={review} />)}
+        </CardContent>
+      </Card>
+
+      {history.length > 0 && (
+        <Card>
+          <CardHeader><CardTitle className="font-display text-base">Recent decisions</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {history.slice(0, 20).map((row) => {
+              const manual = row.metadata?.manual;
+              return <div key={row.id} className="flex flex-col justify-between gap-2 rounded-lg border p-4 sm:flex-row sm:items-center"><div><div className="font-medium">{row.user_name || "Provider"}</div><div className="text-xs text-muted-foreground">{row.user_email || row.user_id}</div></div><div className="text-right"><Badge variant={row.status === "verified" ? "default" : "destructive"}>{row.status === "verified" ? "Verified" : "Needs resubmission"}</Badge><div className="mt-1 text-xs text-muted-foreground">{manual?.reviewedAt ? new Date(manual.reviewedAt).toLocaleString() : new Date(row.updated_at).toLocaleString()}</div></div></div>;
+            })}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function ReviewCard({ row, busy, onReview }: { row: Verification; busy: boolean; onReview: (id: string, decision: "approve" | "reject") => Promise<void> }) {
+  const manual = row.metadata?.manual;
+  const hasBack = Boolean(manual?.files?.id_back?.path);
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-start">
+        <div>
+          <div className="flex items-center gap-2"><ShieldCheck className="h-5 w-5 text-slate-700" /><h2 className="font-semibold text-slate-900">{row.user_name || "Unnamed provider"}</h2></div>
+          <div className="mt-1 text-sm text-slate-500">{row.user_email || row.user_id}</div>
+          <div className="mt-3 grid gap-2 text-xs text-slate-600 sm:grid-cols-3"><div><strong>Document:</strong> {manual?.documentType?.replaceAll("_", " ") || "Unknown"}</div><div><strong>Country:</strong> {manual?.documentCountry || "US"}</div><div><strong>Challenge:</strong> <span className="font-mono font-bold">{manual?.challengeCode || "—"}</span></div></div>
+        </div>
+        <Badge variant="secondary">Pending manual review</Badge>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <DocumentLink id={row.id} kind="id_front" label="Open ID front" />
+        {hasBack ? <DocumentLink id={row.id} kind="id_back" label="Open ID back" /> : <div className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">No ID back required</div>}
+        <DocumentLink id={row.id} kind="selfie" label="Open challenge selfie" />
+      </div>
+
+      <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-900"><AlertTriangle className="mr-1 inline h-3.5 w-3.5" />Approve only when the ID appears valid and unexpired, the selfie appears to match the ID photo, and the selfie visibly includes challenge code <strong className="font-mono">{manual?.challengeCode || "—"}</strong>. Approval verifies identity only, not licensing or background history.</div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <Button onClick={() => void onReview(row.id, "approve")} disabled={busy}><CheckCircle2 className="mr-2 h-4 w-4" />Approve identity</Button>
+        <Button variant="destructive" onClick={() => void onReview(row.id, "reject")} disabled={busy}><XCircle className="mr-2 h-4 w-4" />Reject / resubmit</Button>
+        {busy && <div className="flex items-center px-2 text-sm text-muted-foreground"><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving decision...</div>}
+      </div>
+    </div>
+  );
+}
+
+function DocumentLink({ id, kind, label }: { id: string; kind: "id_front" | "id_back" | "selfie"; label: string }) {
+  return <a href={`/api/admin/verification/${id}/manual-document?kind=${kind}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 text-sm font-medium text-slate-700 transition hover:bg-slate-100"><ExternalLink className="h-4 w-4" />{label}</a>;
+}

--- a/src/app/api/admin/verification/[id]/manual-document/route.ts
+++ b/src/app/api/admin/verification/[id]/manual-document/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import { errorResponse, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireAdminSession } from "@/app/api/_lib/supabase-server";
+
+const ALLOWED_KINDS = new Set(["id_front", "id_back", "selfie"]);
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    await requireAdminSession(request);
+    const { id } = await params;
+    const url = new URL(request.url);
+    const kind = url.searchParams.get("kind") ?? "selfie";
+    if (!ALLOWED_KINDS.has(kind)) throw new RouteError(400, "Invalid document kind.");
+
+    const admin = createSupabaseAdminClient();
+    const { data: verification, error } = await admin
+      .from("identity_verifications")
+      .select("provider, metadata")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Manual verification not found.");
+
+    const metadata = (verification.metadata ?? {}) as Record<string, unknown>;
+    const manual = (metadata.manual ?? {}) as Record<string, unknown>;
+    const files = (manual.files ?? {}) as Record<string, { path?: string }>;
+    const path = files[kind]?.path;
+    if (!path) throw new RouteError(404, "Document not found.");
+
+    const { data, error: signedUrlError } = await admin.storage
+      .from("identity-documents")
+      .createSignedUrl(path, 60);
+
+    if (signedUrlError || !data?.signedUrl) throw new RouteError(500, "Could not open document.");
+    return NextResponse.redirect(data.signedUrl, 302);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/verification/[id]/manual-review/route.ts
+++ b/src/app/api/admin/verification/[id]/manual-review/route.ts
@@ -1,0 +1,77 @@
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await requireAdminSession(request);
+    const { id } = await params;
+    const body = await request.json().catch(() => ({} as Record<string, unknown>));
+    const decision = body.decision === "approve" ? "approve" : body.decision === "reject" ? "reject" : null;
+    const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
+
+    if (!decision) throw new RouteError(400, "Decision must be approve or reject.");
+    if (decision === "reject" && !reason) throw new RouteError(400, "A rejection reason is required.");
+
+    const admin = createSupabaseAdminClient();
+    const { data: verification, error } = await admin
+      .from("identity_verifications")
+      .select("id, user_id, provider, status, metadata")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Manual verification not found.");
+    if (verification.status !== "pending") throw new RouteError(409, "Only pending manual verifications can be reviewed.");
+
+    const reviewedAt = new Date().toISOString();
+    const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
+    const manual = (currentMetadata.manual ?? {}) as Record<string, unknown>;
+    const files = (manual.files ?? {}) as Record<string, { path?: string }>;
+    const paths = Object.values(files).map((entry) => entry?.path).filter((path): path is string => Boolean(path));
+
+    const metadata = {
+      ...currentMetadata,
+      manual: {
+        ...manual,
+        reviewedAt,
+        reviewedBy: session.userId,
+        decision,
+        rejectionReason: decision === "reject" ? reason : null,
+        files: {},
+        documentsDeletedAt: reviewedAt,
+      },
+    };
+
+    const nextStatus = decision === "approve" ? "verified" : "requires_input";
+    const { error: updateError } = await admin
+      .from("identity_verifications")
+      .update({
+        status: nextStatus,
+        last_error: decision === "reject" ? reason : null,
+        metadata,
+        updated_at: reviewedAt,
+      })
+      .eq("id", id);
+
+    if (updateError) throw new RouteError(500, updateError.message);
+
+    if (paths.length > 0) {
+      const { error: removeError } = await admin.storage.from("identity-documents").remove(paths);
+      if (removeError) console.error("[manual-review] Failed to delete sensitive files:", removeError.message);
+    }
+
+    await recordAuditLog(session.userId, `manual_identity_${decision}`, "identity_verification", id, {
+      user_id: verification.user_id,
+      decision,
+      reason: decision === "reject" ? reason : null,
+    });
+
+    return json({ ok: true, status: nextStatus });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/admin/verification/[id]/manual-review/route.ts
+++ b/src/app/api/admin/verification/[id]/manual-review/route.ts
@@ -33,6 +33,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const files = (manual.files ?? {}) as Record<string, { path?: string }>;
     const paths = Object.values(files).map((entry) => entry?.path).filter((path): path is string => Boolean(path));
 
+    // Privacy-first: a review decision is not finalized unless the sensitive
+    // source files can be removed from storage in the same operation.
+    if (paths.length > 0) {
+      const { error: removeError } = await admin.storage.from("identity-documents").remove(paths);
+      if (removeError) throw new RouteError(500, "Could not securely remove identity documents. Review was not finalized.");
+    }
+
     const metadata = {
       ...currentMetadata,
       manual: {
@@ -58,11 +65,6 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       .eq("id", id);
 
     if (updateError) throw new RouteError(500, updateError.message);
-
-    if (paths.length > 0) {
-      const { error: removeError } = await admin.storage.from("identity-documents").remove(paths);
-      if (removeError) console.error("[manual-review] Failed to delete sensitive files:", removeError.message);
-    }
 
     await recordAuditLog(session.userId, `manual_identity_${decision}`, "identity_verification", id, {
       user_id: verification.user_id,

--- a/src/app/api/admin/verification/[id]/manual-review/route.ts
+++ b/src/app/api/admin/verification/[id]/manual-review/route.ts
@@ -4,6 +4,7 @@ import {
   recordAuditLog,
   requireAdminSession,
 } from "@/app/api/_lib/supabase-server";
+import type { Json } from "@/integrations/supabase/types";
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -59,7 +60,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       .update({
         status: nextStatus,
         last_error: decision === "reject" ? reason : null,
-        metadata,
+        metadata: metadata as Json,
         updated_at: reviewedAt,
       })
       .eq("id", id);

--- a/src/app/api/admin/verification/manual/route.ts
+++ b/src/app/api/admin/verification/manual/route.ts
@@ -1,0 +1,49 @@
+export const dynamic = "force-dynamic";
+
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireAdminSession } from "@/app/api/_lib/supabase-server";
+
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    const admin = createSupabaseAdminClient();
+
+    const { data: rows, error } = await admin
+      .from("identity_verifications")
+      .select("id,user_id,profile_id,status,provider,last_error,metadata,created_at,updated_at")
+      .eq("provider", "manual")
+      .order("created_at", { ascending: false })
+      .limit(100);
+
+    if (error) throw new RouteError(500, error.message);
+
+    const userIds = Array.from(new Set((rows ?? []).map((row) => row.user_id).filter((id): id is string => Boolean(id))));
+    const profiles = new Map<string, { name: string | null; email: string | null }>();
+
+    if (userIds.length > 0) {
+      const { data: profileRows } = await admin
+        .from("profiles")
+        .select("user_id,display_name,full_name,email_address,email")
+        .in("user_id", userIds);
+
+      for (const profile of profileRows ?? []) {
+        if (!profile.user_id) continue;
+        profiles.set(profile.user_id, {
+          name: profile.display_name || profile.full_name || null,
+          email: profile.email_address || profile.email || null,
+        });
+      }
+    }
+
+    return json({
+      ok: true,
+      verifications: (rows ?? []).map((row) => ({
+        ...row,
+        user_name: row.user_id ? profiles.get(row.user_id)?.name ?? null : null,
+        user_email: row.user_id ? profiles.get(row.user_id)?.email ?? null : null,
+      })),
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/provider/verification/identity/manual/start/route.ts
+++ b/src/app/api/provider/verification/identity/manual/start/route.ts
@@ -1,0 +1,60 @@
+import { randomInt, randomUUID } from "node:crypto";
+
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+
+export async function POST(request: Request) {
+  try {
+    const session = await requireSession(request);
+    const admin = createSupabaseAdminClient();
+
+    const { data: profile, error: profileError } = await admin
+      .from("profiles")
+      .select("id")
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    if (profileError) throw new RouteError(500, profileError.message);
+    if (!profile) throw new RouteError(404, "Provider profile not found.");
+
+    const now = new Date().toISOString();
+
+    // Only one active manual attempt should be authoritative at a time.
+    await admin
+      .from("identity_verifications")
+      .update({ status: "canceled", updated_at: now })
+      .eq("user_id", session.userId)
+      .eq("provider", "manual")
+      .in("status", ["not_started", "pending"]);
+
+    const verificationId = randomUUID();
+    const challengeCode = String(randomInt(100000, 1000000));
+    const metadata = {
+      manual: {
+        version: 1,
+        challengeCode,
+        files: {},
+        submittedAt: null,
+        reviewedAt: null,
+        documentsDeletedAt: null,
+      },
+    };
+
+    const { error: insertError } = await admin.from("identity_verifications").insert({
+      id: verificationId,
+      user_id: session.userId,
+      profile_id: profile.id,
+      provider: "manual",
+      status: "not_started",
+      last_error: null,
+      metadata,
+      updated_at: now,
+    });
+
+    if (insertError) throw new RouteError(500, insertError.message);
+
+    return json({ ok: true, verificationId, challengeCode });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/provider/verification/identity/manual/submit/route.ts
+++ b/src/app/api/provider/verification/identity/manual/submit/route.ts
@@ -1,6 +1,7 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { notifyAdmin } from "@/app/api/_lib/admin-notify";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+import type { Json } from "@/integrations/supabase/types";
 
 export async function POST(request: Request) {
   try {
@@ -48,7 +49,7 @@ export async function POST(request: Request) {
 
     const { error: updateError } = await admin
       .from("identity_verifications")
-      .update({ provider: "manual", status: "pending", last_error: null, metadata, updated_at: submittedAt })
+      .update({ provider: "manual", status: "pending", last_error: null, metadata: metadata as Json, updated_at: submittedAt })
       .eq("id", verificationId)
       .eq("user_id", session.userId);
 

--- a/src/app/api/provider/verification/identity/manual/submit/route.ts
+++ b/src/app/api/provider/verification/identity/manual/submit/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
         { label: "Document", value: documentType.replaceAll("_", " ") },
         { label: "Verification ID", value: verificationId },
       ],
-      action: { label: "Review verification", url: `${appUrl}/admin/verification` },
+      action: { label: "Review verification", url: `${appUrl}/admin/verification/manual` },
       replyTo: profile?.email_address || profile?.email || session.email || null,
     });
 

--- a/src/app/api/provider/verification/identity/manual/submit/route.ts
+++ b/src/app/api/provider/verification/identity/manual/submit/route.ts
@@ -1,0 +1,82 @@
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { notifyAdmin } from "@/app/api/_lib/admin-notify";
+import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+
+export async function POST(request: Request) {
+  try {
+    const session = await requireSession(request);
+    const admin = createSupabaseAdminClient();
+    const body = await request.json().catch(() => ({} as Record<string, unknown>));
+    const verificationId = typeof body.verificationId === "string" ? body.verificationId.trim() : "";
+    const documentType = typeof body.documentType === "string" ? body.documentType.trim() : "";
+    const documentCountry = typeof body.documentCountry === "string" ? body.documentCountry.trim().toUpperCase() : "US";
+
+    if (!verificationId) throw new RouteError(400, "verificationId is required.");
+    if (!new Set(["drivers_license", "passport", "state_id", "military_id"]).has(documentType)) {
+      throw new RouteError(400, "Select a valid document type.");
+    }
+
+    const { data: verification, error: verificationError } = await admin
+      .from("identity_verifications")
+      .select("id, user_id, provider, status, metadata")
+      .eq("id", verificationId)
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    if (verificationError) throw new RouteError(500, verificationError.message);
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Manual verification not found.");
+    if (!["not_started", "pending"].includes(verification.status)) throw new RouteError(409, "This verification has already been submitted.");
+
+    const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
+    const manual = ((currentMetadata.manual ?? {}) as Record<string, unknown>);
+    const files = ((manual.files ?? {}) as Record<string, unknown>);
+
+    if (!files.id_front || !files.selfie) {
+      throw new RouteError(400, "Upload the front of your ID and a current selfie before submitting.");
+    }
+
+    const submittedAt = new Date().toISOString();
+    const metadata = {
+      ...currentMetadata,
+      manual: {
+        ...manual,
+        documentType,
+        documentCountry: documentCountry || "US",
+        submittedAt,
+      },
+    };
+
+    const { error: updateError } = await admin
+      .from("identity_verifications")
+      .update({ provider: "manual", status: "pending", last_error: null, metadata, updated_at: submittedAt })
+      .eq("id", verificationId)
+      .eq("user_id", session.userId);
+
+    if (updateError) throw new RouteError(500, updateError.message);
+
+    const { data: profile } = await admin
+      .from("profiles")
+      .select("display_name, full_name, email_address, email")
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://www.masseurmatch.com";
+    await notifyAdmin({
+      subject: "Manual identity verification requires review",
+      heading: "Identity verification review",
+      intro: "A provider submitted a government ID and live challenge selfie for manual review.",
+      fields: [
+        { label: "Provider", value: profile?.display_name || profile?.full_name || "Provider" },
+        { label: "Email", value: profile?.email_address || profile?.email || session.email },
+        { label: "Document", value: documentType.replaceAll("_", " ") },
+        { label: "Verification ID", value: verificationId },
+      ],
+      action: { label: "Review verification", url: `${appUrl}/admin/verification` },
+      replyTo: profile?.email_address || profile?.email || session.email || null,
+    });
+
+    return json({ ok: true, status: "pending" });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/provider/verification/identity/manual/upload/route.ts
+++ b/src/app/api/provider/verification/identity/manual/upload/route.ts
@@ -1,0 +1,80 @@
+import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+
+const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "application/pdf"]);
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_KINDS = new Set(["id_front", "id_back", "selfie"]);
+const EXT_MAP: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "application/pdf": "pdf",
+};
+
+export async function POST(request: Request) {
+  try {
+    const session = await requireSession(request);
+    const admin = createSupabaseAdminClient();
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    const verificationId = String(formData.get("verificationId") ?? "").trim();
+    const kind = String(formData.get("kind") ?? "").trim();
+
+    if (!verificationId) throw new RouteError(400, "verificationId is required.");
+    if (!ALLOWED_KINDS.has(kind)) throw new RouteError(400, "Invalid document kind.");
+    if (!file) throw new RouteError(400, "No file provided.");
+    if (!ALLOWED_MIME_TYPES.has(file.type)) throw new RouteError(400, "Only JPEG, PNG, WebP, or PDF files are allowed.");
+    if (file.size > MAX_FILE_SIZE_BYTES) throw new RouteError(400, "File must be under 10 MB.");
+    if (kind === "selfie" && file.type === "application/pdf") throw new RouteError(400, "Selfie must be an image.");
+
+    const { data: verification, error: verificationError } = await admin
+      .from("identity_verifications")
+      .select("id, user_id, provider, status, metadata")
+      .eq("id", verificationId)
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    if (verificationError) throw new RouteError(500, verificationError.message);
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Manual verification not found.");
+    if (!["not_started", "pending"].includes(verification.status)) throw new RouteError(409, "This verification can no longer accept uploads.");
+
+    const ext = EXT_MAP[file.type] ?? "bin";
+    const storagePath = `${session.userId}/manual/${verificationId}/${kind}.${ext}`;
+    const bytes = await file.arrayBuffer();
+
+    const { error: uploadError } = await admin.storage
+      .from("identity-documents")
+      .upload(storagePath, bytes, { contentType: file.type, upsert: true });
+
+    if (uploadError) throw new RouteError(500, "Upload failed. Please try again.");
+
+    const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
+    const manual = ((currentMetadata.manual ?? {}) as Record<string, unknown>);
+    const files = ((manual.files ?? {}) as Record<string, unknown>);
+    const metadata = {
+      ...currentMetadata,
+      manual: {
+        ...manual,
+        files: {
+          ...files,
+          [kind]: { path: storagePath, mimeType: file.type, uploadedAt: new Date().toISOString() },
+        },
+      },
+    };
+
+    const { error: updateError } = await admin
+      .from("identity_verifications")
+      .update({ metadata, updated_at: new Date().toISOString() })
+      .eq("id", verificationId)
+      .eq("user_id", session.userId);
+
+    if (updateError) {
+      await admin.storage.from("identity-documents").remove([storagePath]);
+      throw new RouteError(500, updateError.message);
+    }
+
+    return json({ ok: true, kind });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/provider/verification/identity/manual/upload/route.ts
+++ b/src/app/api/provider/verification/identity/manual/upload/route.ts
@@ -1,5 +1,6 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
+import type { Json } from "@/integrations/supabase/types";
 
 const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "application/pdf"]);
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -64,7 +65,7 @@ export async function POST(request: Request) {
 
     const { error: updateError } = await admin
       .from("identity_verifications")
-      .update({ metadata, updated_at: new Date().toISOString() })
+      .update({ metadata: metadata as Json, updated_at: new Date().toISOString() })
       .eq("id", verificationId)
       .eq("user_id", session.userId);
 

--- a/src/app/api/provider/verification/identity/start/route.ts
+++ b/src/app/api/provider/verification/identity/start/route.ts
@@ -1,9 +1,44 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { requireSession } from "@/app/api/_lib/supabase-server";
 
+async function startManualFallback(request: Request) {
+  const manualRes = await fetch(new URL("/api/provider/verification/identity/manual/start", request.url).toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      cookie: request.headers.get("cookie") ?? "",
+    },
+    body: JSON.stringify({}),
+  });
+  const manualData = await manualRes.json().catch(() => ({}));
+  if (!manualRes.ok) {
+    throw new RouteError(
+      manualRes.status as 400 | 401 | 403 | 404 | 500,
+      manualData.error ?? "Unable to start manual identity verification.",
+    );
+  }
+
+  const params = new URLSearchParams({
+    verificationId: manualData.verificationId,
+    challengeCode: manualData.challengeCode,
+  });
+
+  return json({
+    ok: true,
+    mode: "manual",
+    url: `/pro/trust/verify?${params.toString()}`,
+    verificationId: manualData.verificationId,
+  });
+}
+
 export async function POST(request: Request) {
   try {
     await requireSession(request);
+
+    if (process.env.IDENTITY_VERIFICATION_MODE === "manual") {
+      return startManualFallback(request);
+    }
+
     const res = await fetch(new URL("/api/stripe/identity/create-session", request.url).toString(), {
       method: "POST",
       headers: {
@@ -12,14 +47,28 @@ export async function POST(request: Request) {
       },
       body: JSON.stringify({ returnTo: "pro_trust" }),
     });
-    const data = await res.json();
-    if (!res.ok) {
-      throw new RouteError(
-        res.status as 400 | 401 | 403 | 404 | 500,
-        data.error ?? "Failed to start identity verification.",
-      );
+    const data = await res.json().catch(() => ({}));
+
+    if (res.ok && data.url) {
+      return json({ ok: true, mode: "stripe", ...data });
     }
-    return json({ ok: true, ...data });
+
+    const message = typeof data.error === "string" ? data.error.toLowerCase() : "";
+    const accountRestricted =
+      res.status >= 500 ||
+      message.includes("unable to perform this action") ||
+      message.includes("contact us via") ||
+      message.includes("account") && message.includes("restricted");
+
+    if (accountRestricted) {
+      console.warn("[identity/start] Stripe unavailable; using manual identity verification fallback.");
+      return startManualFallback(request);
+    }
+
+    throw new RouteError(
+      res.status as 400 | 401 | 403 | 404 | 500,
+      data.error ?? "Failed to start identity verification.",
+    );
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/pro/trust/verify/page.tsx
+++ b/src/app/pro/trust/verify/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { AlertCircle, CheckCircle2, Loader2, ShieldCheck, Upload } from "lucide-react";
 
@@ -14,6 +14,14 @@ const DOCUMENT_TYPES = [
 type UploadKind = "id_front" | "id_back" | "selfie";
 
 export default function ManualIdentityVerificationPage() {
+  return (
+    <Suspense fallback={<div className="flex min-h-[420px] items-center justify-center"><Loader2 className="h-7 w-7 animate-spin text-slate-400" /></div>}>
+      <ManualIdentityVerificationContent />
+    </Suspense>
+  );
+}
+
+function ManualIdentityVerificationContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const verificationId = searchParams.get("verificationId") ?? "";

--- a/src/app/pro/trust/verify/page.tsx
+++ b/src/app/pro/trust/verify/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { AlertCircle, CheckCircle2, Loader2, ShieldCheck, Upload } from "lucide-react";
+
+const DOCUMENT_TYPES = [
+  ["drivers_license", "Driver's license"],
+  ["passport", "Passport"],
+  ["state_id", "State ID"],
+  ["military_id", "Military ID"],
+] as const;
+
+type UploadKind = "id_front" | "id_back" | "selfie";
+
+export default function ManualIdentityVerificationPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const verificationId = searchParams.get("verificationId") ?? "";
+  const challengeCode = searchParams.get("challengeCode") ?? "";
+  const [documentType, setDocumentType] = useState("drivers_license");
+  const [documentCountry, setDocumentCountry] = useState("US");
+  const [files, setFiles] = useState<Partial<Record<UploadKind, File>>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [complete, setComplete] = useState(false);
+
+  const needsBack = documentType !== "passport";
+  const ready = useMemo(
+    () => Boolean(verificationId && files.id_front && files.selfie && (!needsBack || files.id_back)),
+    [files, needsBack, verificationId],
+  );
+
+  async function upload(kind: UploadKind, file: File) {
+    const form = new FormData();
+    form.set("verificationId", verificationId);
+    form.set("kind", kind);
+    form.set("file", file);
+    const res = await fetch("/api/provider/verification/identity/manual/upload", { method: "POST", body: form });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error ?? `Could not upload ${kind}.`);
+  }
+
+  async function submit() {
+    if (!ready) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await upload("id_front", files.id_front!);
+      if (needsBack && files.id_back) await upload("id_back", files.id_back);
+      await upload("selfie", files.selfie!);
+
+      const res = await fetch("/api/provider/verification/identity/manual/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ verificationId, documentType, documentCountry }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error ?? "Could not submit identity verification.");
+      setComplete(true);
+      window.setTimeout(() => router.replace("/pro/trust"), 1200);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not submit identity verification.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!verificationId || !challengeCode) {
+    return (
+      <div className="mx-auto max-w-2xl p-6 md:p-10">
+        <div className="rounded-xl border border-rose-200 bg-rose-50 p-5 text-rose-800">
+          <div className="flex gap-3"><AlertCircle className="mt-0.5 h-5 w-5" /><div><h1 className="font-semibold">Verification session unavailable</h1><p className="mt-1 text-sm">Return to Trust &amp; Verification and start identity verification again.</p></div></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6 pb-24 md:p-10">
+      <div>
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-slate-600"><ShieldCheck className="h-3.5 w-3.5" /> Secure manual review</div>
+        <h1 className="font-display text-3xl font-medium tracking-tight text-slate-900">Verify your identity</h1>
+        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-500">MasseurMatch is temporarily reviewing identity documents manually. Your documents are stored privately and removed after the review decision.</p>
+      </div>
+
+      {complete ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6 text-emerald-900">
+          <div className="flex items-center gap-3"><CheckCircle2 className="h-6 w-6" /><div><h2 className="font-semibold">Submitted for review</h2><p className="mt-1 text-sm text-emerald-700">Your identity verification is now pending admin review.</p></div></div>
+        </div>
+      ) : (
+        <>
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+            <div className="text-xs font-semibold uppercase tracking-wider text-amber-700">Live selfie challenge</div>
+            <div className="mt-2 font-mono text-4xl font-bold tracking-[0.18em] text-amber-950">{challengeCode}</div>
+            <p className="mt-3 text-sm leading-relaxed text-amber-800">For your selfie, hold a paper showing this six-digit code next to your face. Your face and the entire code must be clearly visible. This helps prevent use of an old or stolen photo.</p>
+          </div>
+
+          <div className="grid gap-5 rounded-xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
+            <label className="space-y-2 text-sm font-medium text-slate-700">Document type
+              <select value={documentType} onChange={(e) => setDocumentType(e.target.value)} className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm outline-none focus:border-slate-400">
+                {DOCUMENT_TYPES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+            <label className="space-y-2 text-sm font-medium text-slate-700">Issuing country
+              <input value={documentCountry} onChange={(e) => setDocumentCountry(e.target.value.toUpperCase().slice(0, 2))} placeholder="US" className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2.5 text-sm uppercase outline-none focus:border-slate-400" />
+            </label>
+          </div>
+
+          <div className="space-y-4">
+            <FilePicker label="Government ID — front" required file={files.id_front} onChange={(file) => setFiles((prev) => ({ ...prev, id_front: file }))} />
+            {needsBack && <FilePicker label="Government ID — back" required file={files.id_back} onChange={(file) => setFiles((prev) => ({ ...prev, id_back: file }))} />}
+            <FilePicker label="Current selfie with challenge code" required accept="image/jpeg,image/png,image/webp" file={files.selfie} onChange={(file) => setFiles((prev) => ({ ...prev, selfie: file }))} />
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs leading-relaxed text-slate-600">Identity verification confirms that MasseurMatch reviewed a government-issued identity document and a current selfie. It does not verify professional licensing, background history, qualifications, or services.</div>
+
+          {error && <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">{error}</div>}
+
+          <button type="button" onClick={() => void submit()} disabled={!ready || submitting} className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50">
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+            {submitting ? "Uploading securely..." : "Submit for identity review"}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FilePicker({ label, required, accept = "image/jpeg,image/png,image/webp,application/pdf", file, onChange }: { label: string; required?: boolean; accept?: string; file?: File; onChange: (file: File) => void }) {
+  return (
+    <label className="block cursor-pointer rounded-xl border border-dashed border-slate-300 bg-white p-5 transition hover:border-slate-400 hover:bg-slate-50">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-100"><Upload className="h-5 w-5 text-slate-600" /></div>
+        <div className="min-w-0"><div className="text-sm font-semibold text-slate-800">{label}{required ? " *" : ""}</div><div className="mt-0.5 truncate text-xs text-slate-500">{file ? file.name : "JPEG, PNG, WebP or PDF · max 10 MB"}</div></div>
+      </div>
+      <input type="file" accept={accept} className="sr-only" onChange={(e) => { const next = e.target.files?.[0]; if (next) onChange(next); }} />
+    </label>
+  );
+}


### PR DESCRIPTION
Implements a temporary manual identity verification fallback without removing the existing Stripe Identity flow.

What changed:
- Automatically falls back to manual verification when Stripe Identity returns an account restriction/server error.
- Adds secure manual verification session creation with a 6-digit live selfie challenge.
- Adds ID front/back and challenge-selfie uploads to the existing private identity-documents bucket.
- Adds provider submission flow and admin notification.
- Adds authenticated admin review queue with short-lived document links.
- Adds approve/reject actions with audit logging.
- Uses canonical `verified` / `requires_input` statuses so existing profile verification sync continues to work.
- Deletes sensitive uploaded identity files when the review decision is finalized.

No schema migration is required: this uses the current production `identity_verifications.metadata` JSONB field and existing private storage bucket.