### PR TITLE
Harden manual identity verification and remove Stripe dependency

### DIFF
--- a/src/app/api/provider/verification/identity/manual/start/route.ts
+++ b/src/app/api/provider/verification/identity/manual/start/route.ts
@@ -3,6 +3,40 @@ import { randomInt, randomUUID } from "node:crypto";
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
 
+const CHALLENGE_TTL_MS = 30 * 60 * 1000;
+
+export async function GET(request: Request) {
+  try {
+    const session = await requireSession(request);
+    const verificationId = new URL(request.url).searchParams.get("verificationId")?.trim() ?? "";
+    if (!verificationId) throw new RouteError(400, "verificationId is required.");
+
+    const admin = createSupabaseAdminClient();
+    const { data: verification, error } = await admin
+      .from("identity_verifications")
+      .select("id, user_id, provider, status, metadata")
+      .eq("id", verificationId)
+      .eq("user_id", session.userId)
+      .maybeSingle();
+
+    if (error) throw new RouteError(500, error.message);
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Identity verification not found.");
+    if (!["not_started", "pending"].includes(verification.status)) throw new RouteError(409, "This verification is no longer active.");
+
+    const metadata = (verification.metadata ?? {}) as Record<string, unknown>;
+    const manual = (metadata.manual ?? {}) as Record<string, unknown>;
+    const challengeCode = typeof manual.challengeCode === "string" ? manual.challengeCode : "";
+    const expiresAt = typeof manual.expiresAt === "string" ? manual.expiresAt : "";
+
+    if (!challengeCode || !expiresAt) throw new RouteError(409, "Verification challenge is unavailable. Start a new verification.");
+    if (Date.parse(expiresAt) <= Date.now()) throw new RouteError(410, "Verification challenge expired. Start a new verification.");
+
+    return json({ ok: true, verificationId, challengeCode, expiresAt });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
 export async function POST(request: Request) {
   try {
     const session = await requireSession(request);
@@ -17,12 +51,13 @@ export async function POST(request: Request) {
     if (profileError) throw new RouteError(500, profileError.message);
     if (!profile) throw new RouteError(404, "Provider profile not found.");
 
-    const now = new Date().toISOString();
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const expiresAt = new Date(now.getTime() + CHALLENGE_TTL_MS).toISOString();
 
-    // Only one active manual attempt should be authoritative at a time.
     await admin
       .from("identity_verifications")
-      .update({ status: "canceled", updated_at: now })
+      .update({ status: "canceled", updated_at: nowIso })
       .eq("user_id", session.userId)
       .eq("provider", "manual")
       .in("status", ["not_started", "pending"]);
@@ -31,8 +66,9 @@ export async function POST(request: Request) {
     const challengeCode = String(randomInt(100000, 1000000));
     const metadata = {
       manual: {
-        version: 1,
+        version: 2,
         challengeCode,
+        expiresAt,
         files: {},
         submittedAt: null,
         reviewedAt: null,
@@ -48,12 +84,12 @@ export async function POST(request: Request) {
       status: "not_started",
       last_error: null,
       metadata,
-      updated_at: now,
+      updated_at: nowIso,
     });
 
     if (insertError) throw new RouteError(500, insertError.message);
 
-    return json({ ok: true, verificationId, challengeCode });
+    return json({ ok: true, verificationId, expiresAt });
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/api/provider/verification/identity/manual/submit/route.ts
+++ b/src/app/api/provider/verification/identity/manual/submit/route.ts
@@ -25,12 +25,17 @@ export async function POST(request: Request) {
       .maybeSingle();
 
     if (verificationError) throw new RouteError(500, verificationError.message);
-    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Manual verification not found.");
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Identity verification not found.");
     if (!["not_started", "pending"].includes(verification.status)) throw new RouteError(409, "This verification has already been submitted.");
 
     const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
     const manual = ((currentMetadata.manual ?? {}) as Record<string, unknown>);
     const files = ((manual.files ?? {}) as Record<string, unknown>);
+    const expiresAt = typeof manual.expiresAt === "string" ? manual.expiresAt : "";
+
+    if (!expiresAt || Date.parse(expiresAt) <= Date.now()) {
+      throw new RouteError(410, "Verification challenge expired. Start a new verification.");
+    }
 
     if (!files.id_front || !files.selfie) {
       throw new RouteError(400, "Upload the front of your ID and a current selfie before submitting.");
@@ -63,9 +68,9 @@ export async function POST(request: Request) {
 
     const appUrl = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") || "https://www.masseurmatch.com";
     await notifyAdmin({
-      subject: "Manual identity verification requires review",
+      subject: "Identity verification requires review",
       heading: "Identity verification review",
-      intro: "A provider submitted a government ID and live challenge selfie for manual review.",
+      intro: "A provider submitted a government ID and current challenge selfie for review.",
       fields: [
         { label: "Provider", value: profile?.display_name || profile?.full_name || "Provider" },
         { label: "Email", value: profile?.email_address || profile?.email || session.email },

--- a/src/app/api/provider/verification/identity/start/route.ts
+++ b/src/app/api/provider/verification/identity/start/route.ts
@@ -1,7 +1,7 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { requireSession } from "@/app/api/_lib/supabase-server";
 
-async function startManualFallback(request: Request) {
+async function startManualVerification(request: Request) {
   const manualRes = await fetch(new URL("/api/provider/verification/identity/manual/start", request.url).toString(), {
     method: "POST",
     headers: {
@@ -14,14 +14,11 @@ async function startManualFallback(request: Request) {
   if (!manualRes.ok) {
     throw new RouteError(
       manualRes.status as 400 | 401 | 403 | 404 | 500,
-      manualData.error ?? "Unable to start manual identity verification.",
+      manualData.error ?? "Unable to start identity verification.",
     );
   }
 
-  const params = new URLSearchParams({
-    verificationId: manualData.verificationId,
-    challengeCode: manualData.challengeCode,
-  });
+  const params = new URLSearchParams({ verificationId: manualData.verificationId });
 
   return json({
     ok: true,
@@ -34,41 +31,7 @@ async function startManualFallback(request: Request) {
 export async function POST(request: Request) {
   try {
     await requireSession(request);
-
-    if (process.env.IDENTITY_VERIFICATION_MODE === "manual") {
-      return startManualFallback(request);
-    }
-
-    const res = await fetch(new URL("/api/stripe/identity/create-session", request.url).toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        cookie: request.headers.get("cookie") ?? "",
-      },
-      body: JSON.stringify({ returnTo: "pro_trust" }),
-    });
-    const data = await res.json().catch(() => ({}));
-
-    if (res.ok && data.url) {
-      return json({ ok: true, mode: "stripe", ...data });
-    }
-
-    const message = typeof data.error === "string" ? data.error.toLowerCase() : "";
-    const accountRestricted =
-      res.status >= 500 ||
-      message.includes("unable to perform this action") ||
-      message.includes("contact us via") ||
-      message.includes("account") && message.includes("restricted");
-
-    if (accountRestricted) {
-      console.warn("[identity/start] Stripe unavailable; using manual identity verification fallback.");
-      return startManualFallback(request);
-    }
-
-    throw new RouteError(
-      res.status as 400 | 401 | 403 | 404 | 500,
-      data.error ?? "Failed to start identity verification.",
-    );
+    return startManualVerification(request);
   } catch (error) {
     return errorResponse(error);
   }

--- a/src/app/pro/trust/verify/page.tsx
+++ b/src/app/pro/trust/verify/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { AlertCircle, CheckCircle2, Loader2, ShieldCheck, Upload } from "lucide-react";
 
@@ -25,7 +25,8 @@ function ManualIdentityVerificationContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const verificationId = searchParams.get("verificationId") ?? "";
-  const challengeCode = searchParams.get("challengeCode") ?? "";
+  const [challengeCode, setChallengeCode] = useState("");
+  const [challengeLoading, setChallengeLoading] = useState(true);
   const [documentType, setDocumentType] = useState("drivers_license");
   const [documentCountry, setDocumentCountry] = useState("US");
   const [files, setFiles] = useState<Partial<Record<UploadKind, File>>>({});
@@ -33,10 +34,33 @@ function ManualIdentityVerificationContent() {
   const [error, setError] = useState<string | null>(null);
   const [complete, setComplete] = useState(false);
 
+  useEffect(() => {
+    if (!verificationId) {
+      setChallengeLoading(false);
+      return;
+    }
+
+    let active = true;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/provider/verification/identity/manual/start?verificationId=${encodeURIComponent(verificationId)}`, { cache: "no-store" });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error ?? "Verification challenge unavailable.");
+        if (active) setChallengeCode(data.challengeCode ?? "");
+      } catch (err) {
+        if (active) setError(err instanceof Error ? err.message : "Verification challenge unavailable.");
+      } finally {
+        if (active) setChallengeLoading(false);
+      }
+    })();
+
+    return () => { active = false; };
+  }, [verificationId]);
+
   const needsBack = documentType !== "passport";
   const ready = useMemo(
-    () => Boolean(verificationId && files.id_front && files.selfie && (!needsBack || files.id_back)),
-    [files, needsBack, verificationId],
+    () => Boolean(verificationId && challengeCode && files.id_front && files.selfie && (!needsBack || files.id_back)),
+    [challengeCode, files, needsBack, verificationId],
   );
 
   async function upload(kind: UploadKind, file: File) {
@@ -74,22 +98,26 @@ function ManualIdentityVerificationContent() {
     }
   }
 
-  if (!verificationId || !challengeCode) {
+  if (!verificationId || (!challengeLoading && !challengeCode)) {
     return (
       <div className="mx-auto max-w-2xl p-6 md:p-10">
         <div className="rounded-xl border border-rose-200 bg-rose-50 p-5 text-rose-800">
-          <div className="flex gap-3"><AlertCircle className="mt-0.5 h-5 w-5" /><div><h1 className="font-semibold">Verification session unavailable</h1><p className="mt-1 text-sm">Return to Trust &amp; Verification and start identity verification again.</p></div></div>
+          <div className="flex gap-3"><AlertCircle className="mt-0.5 h-5 w-5" /><div><h1 className="font-semibold">Verification session unavailable</h1><p className="mt-1 text-sm">{error || "Return to Trust & Verification and start identity verification again."}</p></div></div>
         </div>
       </div>
     );
   }
 
+  if (challengeLoading) {
+    return <div className="flex min-h-[420px] items-center justify-center"><Loader2 className="h-7 w-7 animate-spin text-slate-400" /></div>;
+  }
+
   return (
     <div className="mx-auto max-w-3xl space-y-6 p-6 pb-24 md:p-10">
       <div>
-        <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-slate-600"><ShieldCheck className="h-3.5 w-3.5" /> Secure manual review</div>
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-slate-600"><ShieldCheck className="h-3.5 w-3.5" /> Secure identity review</div>
         <h1 className="font-display text-3xl font-medium tracking-tight text-slate-900">Verify your identity</h1>
-        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-500">MasseurMatch is temporarily reviewing identity documents manually. Your documents are stored privately and removed after the review decision.</p>
+        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-500">Submit a government-issued ID and a current selfie with the one-time challenge code below. Documents are stored privately and removed after the review decision.</p>
       </div>
 
       {complete ? (
@@ -99,9 +127,9 @@ function ManualIdentityVerificationContent() {
       ) : (
         <>
           <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
-            <div className="text-xs font-semibold uppercase tracking-wider text-amber-700">Live selfie challenge</div>
+            <div className="text-xs font-semibold uppercase tracking-wider text-amber-700">One-time selfie challenge</div>
             <div className="mt-2 font-mono text-4xl font-bold tracking-[0.18em] text-amber-950">{challengeCode}</div>
-            <p className="mt-3 text-sm leading-relaxed text-amber-800">For your selfie, hold a paper showing this six-digit code next to your face. Your face and the entire code must be clearly visible. This helps prevent use of an old or stolen photo.</p>
+            <p className="mt-3 text-sm leading-relaxed text-amber-800">Write this six-digit code on paper and hold it next to your face in the selfie. Your face and the full code must be clearly visible. The challenge expires after 30 minutes.</p>
           </div>
 
           <div className="grid gap-5 rounded-xl border border-slate-200 bg-white p-6 shadow-sm md:grid-cols-2">
@@ -121,7 +149,7 @@ function ManualIdentityVerificationContent() {
             <FilePicker label="Current selfie with challenge code" required accept="image/jpeg,image/png,image/webp" file={files.selfie} onChange={(file) => setFiles((prev) => ({ ...prev, selfie: file }))} />
           </div>
 
-          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs leading-relaxed text-slate-600">Identity verification confirms that MasseurMatch reviewed a government-issued identity document and a current selfie. It does not verify professional licensing, background history, qualifications, or services.</div>
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs leading-relaxed text-slate-600">Identity verification confirms only that MasseurMatch reviewed a government-issued identity document and a current selfie. It does not verify professional licensing, background history, qualifications, or services.</div>
 
           {error && <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">{error}</div>}
 


### PR DESCRIPTION
Makes MasseurMatch manual identity verification the default provider flow and removes Stripe Identity from new verification starts.

Includes:
- manual identity verification only for new sessions
- challenge code removed from URL
- authenticated server fetch for the challenge code
- 30-minute challenge expiration
- expired challenges rejected at submission
- provider copy updated on the secure verification page

Existing admin review and post-decision document deletion remain unchanged.

No payment code changed.