### PR TITLE
Harden identity document uploads and abuse protection

### DIFF
--- a/src/app/api/_lib/rate-limit.ts
+++ b/src/app/api/_lib/rate-limit.ts
@@ -1,4 +1,3 @@
-import type { NextRequest } from "next/server";
 import { Redis } from "@upstash/redis";
 
 const memoryBuckets = new Map<string, { count: number; resetAt: number }>();
@@ -19,7 +18,7 @@ function getRedis() {
   return redisClient;
 }
 
-function requestIp(request: NextRequest): string {
+function requestIp(request: Request): string {
   return (
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
     request.headers.get("x-real-ip") ||
@@ -45,7 +44,7 @@ function memoryRateLimit(key: string, windowMs: number, max: number): boolean {
 }
 
 export function isRateLimited(
-  request: NextRequest,
+  request: Request,
   options: { keyPrefix: string; windowMs: number; max: number; userId?: string | null },
 ): boolean {
   const actor = options.userId || requestIp(request);
@@ -53,8 +52,8 @@ export function isRateLimited(
   return memoryRateLimit(key, options.windowMs, options.max);
 }
 
-async function isRateLimitedDistributed(
-  request: NextRequest,
+export async function isRateLimitedDistributed(
+  request: Request,
   options: { keyPrefix: string; windowMs: number; max: number; userId?: string | null },
 ): Promise<boolean> {
   const actor = options.userId || requestIp(request);
@@ -77,8 +76,4 @@ async function isRateLimitedDistributed(
     console.error("rate_limit_redis_failed", { keyPrefix: options.keyPrefix, error });
     return memoryRateLimit(key, options.windowMs, options.max);
   }
-}
-
-function getRequestIp(request: NextRequest): string {
-  return requestIp(request);
 }

--- a/src/app/api/provider/verification/identity/manual/start/route.ts
+++ b/src/app/api/provider/verification/identity/manual/start/route.ts
@@ -1,9 +1,26 @@
 import { randomInt, randomUUID } from "node:crypto";
 
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { isRateLimitedDistributed } from "@/app/api/_lib/rate-limit";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
 
 const CHALLENGE_TTL_MS = 30 * 60 * 1000;
+
+function manualFilePaths(metadata: unknown): string[] {
+  if (!metadata || typeof metadata !== "object") return [];
+  const manual = (metadata as Record<string, unknown>).manual;
+  if (!manual || typeof manual !== "object") return [];
+  const files = (manual as Record<string, unknown>).files;
+  if (!files || typeof files !== "object") return [];
+
+  return Object.values(files as Record<string, unknown>)
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const path = (entry as Record<string, unknown>).path;
+      return typeof path === "string" && path.length > 0 ? path : null;
+    })
+    .filter((path): path is string => Boolean(path));
+}
 
 export async function GET(request: Request) {
   try {
@@ -40,6 +57,18 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     const session = await requireSession(request);
+
+    if (
+      await isRateLimitedDistributed(request, {
+        keyPrefix: "identity-start",
+        windowMs: 60 * 60 * 1000,
+        max: 5,
+        userId: session.userId,
+      })
+    ) {
+      throw new RouteError(429, "Too many identity verification attempts. Please try again later.");
+    }
+
     const admin = createSupabaseAdminClient();
 
     const { data: profile, error: profileError } = await admin
@@ -55,6 +84,25 @@ export async function POST(request: Request) {
     const nowIso = now.toISOString();
     const expiresAt = new Date(now.getTime() + CHALLENGE_TTL_MS).toISOString();
 
+    const { data: activeAttempts, error: activeError } = await admin
+      .from("identity_verifications")
+      .select("id, metadata")
+      .eq("user_id", session.userId)
+      .eq("provider", "manual")
+      .in("status", ["not_started", "pending"]);
+
+    if (activeError) throw new RouteError(500, activeError.message);
+
+    for (const attempt of activeAttempts ?? []) {
+      const paths = manualFilePaths(attempt.metadata);
+      if (paths.length > 0) {
+        const { error: removeError } = await admin.storage.from("identity-documents").remove(paths);
+        if (removeError) {
+          throw new RouteError(500, "Could not securely remove documents from the previous verification attempt.");
+        }
+      }
+    }
+
     await admin
       .from("identity_verifications")
       .update({ status: "canceled", updated_at: nowIso })
@@ -66,7 +114,7 @@ export async function POST(request: Request) {
     const challengeCode = String(randomInt(100000, 1000000));
     const metadata = {
       manual: {
-        version: 2,
+        version: 3,
         challengeCode,
         expiresAt,
         files: {},

--- a/src/app/api/provider/verification/identity/manual/submit/route.ts
+++ b/src/app/api/provider/verification/identity/manual/submit/route.ts
@@ -1,11 +1,24 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { notifyAdmin } from "@/app/api/_lib/admin-notify";
+import { isRateLimitedDistributed } from "@/app/api/_lib/rate-limit";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
 import type { Json } from "@/integrations/supabase/types";
 
 export async function POST(request: Request) {
   try {
     const session = await requireSession(request);
+
+    if (
+      await isRateLimitedDistributed(request, {
+        keyPrefix: "identity-submit",
+        windowMs: 60 * 60 * 1000,
+        max: 6,
+        userId: session.userId,
+      })
+    ) {
+      throw new RouteError(429, "Too many identity verification submissions. Please try again later.");
+    }
+
     const admin = createSupabaseAdminClient();
     const body = await request.json().catch(() => ({} as Record<string, unknown>));
     const verificationId = typeof body.verificationId === "string" ? body.verificationId.trim() : "";
@@ -16,6 +29,7 @@ export async function POST(request: Request) {
     if (!new Set(["drivers_license", "passport", "state_id", "military_id"]).has(documentType)) {
       throw new RouteError(400, "Select a valid document type.");
     }
+    if (!/^[A-Z]{2}$/.test(documentCountry)) throw new RouteError(400, "Issuing country must use a two-letter country code.");
 
     const { data: verification, error: verificationError } = await admin
       .from("identity_verifications")
@@ -29,8 +43,8 @@ export async function POST(request: Request) {
     if (!["not_started", "pending"].includes(verification.status)) throw new RouteError(409, "This verification has already been submitted.");
 
     const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
-    const manual = ((currentMetadata.manual ?? {}) as Record<string, unknown>);
-    const files = ((manual.files ?? {}) as Record<string, unknown>);
+    const manual = (currentMetadata.manual ?? {}) as Record<string, unknown>;
+    const files = (manual.files ?? {}) as Record<string, unknown>;
     const expiresAt = typeof manual.expiresAt === "string" ? manual.expiresAt : "";
 
     if (!expiresAt || Date.parse(expiresAt) <= Date.now()) {
@@ -41,13 +55,17 @@ export async function POST(request: Request) {
       throw new RouteError(400, "Upload the front of your ID and a current selfie before submitting.");
     }
 
+    if (documentType !== "passport" && !files.id_back) {
+      throw new RouteError(400, "Upload the back of your ID before submitting.");
+    }
+
     const submittedAt = new Date().toISOString();
     const metadata = {
       ...currentMetadata,
       manual: {
         ...manual,
         documentType,
-        documentCountry: documentCountry || "US",
+        documentCountry,
         submittedAt,
       },
     };

--- a/src/app/api/provider/verification/identity/manual/upload/route.ts
+++ b/src/app/api/provider/verification/identity/manual/upload/route.ts
@@ -1,20 +1,53 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
+import { isRateLimitedDistributed } from "@/app/api/_lib/rate-limit";
 import { createSupabaseAdminClient, requireSession } from "@/app/api/_lib/supabase-server";
 import type { Json } from "@/integrations/supabase/types";
 
-const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "application/pdf"]);
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+const MAX_FILE_SIZE_BYTES = 8 * 1024 * 1024;
 const ALLOWED_KINDS = new Set(["id_front", "id_back", "selfie"]);
 const EXT_MAP: Record<string, string> = {
   "image/jpeg": "jpg",
   "image/png": "png",
   "image/webp": "webp",
-  "application/pdf": "pdf",
 };
+
+function matchesMagicBytes(bytes: Uint8Array, mimeType: string) {
+  if (mimeType === "image/jpeg") {
+    return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  }
+
+  if (mimeType === "image/png") {
+    const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    return bytes.length >= signature.length && signature.every((value, index) => bytes[index] === value);
+  }
+
+  if (mimeType === "image/webp") {
+    return (
+      bytes.length >= 12 &&
+      String.fromCharCode(...bytes.slice(0, 4)) === "RIFF" &&
+      String.fromCharCode(...bytes.slice(8, 12)) === "WEBP"
+    );
+  }
+
+  return false;
+}
 
 export async function POST(request: Request) {
   try {
     const session = await requireSession(request);
+
+    if (
+      await isRateLimitedDistributed(request, {
+        keyPrefix: "identity-upload",
+        windowMs: 10 * 60 * 1000,
+        max: 12,
+        userId: session.userId,
+      })
+    ) {
+      throw new RouteError(429, "Too many identity upload attempts. Please try again later.");
+    }
+
     const admin = createSupabaseAdminClient();
     const formData = await request.formData();
     const file = formData.get("file") as File | null;
@@ -24,9 +57,8 @@ export async function POST(request: Request) {
     if (!verificationId) throw new RouteError(400, "verificationId is required.");
     if (!ALLOWED_KINDS.has(kind)) throw new RouteError(400, "Invalid document kind.");
     if (!file) throw new RouteError(400, "No file provided.");
-    if (!ALLOWED_MIME_TYPES.has(file.type)) throw new RouteError(400, "Only JPEG, PNG, WebP, or PDF files are allowed.");
-    if (file.size > MAX_FILE_SIZE_BYTES) throw new RouteError(400, "File must be under 10 MB.");
-    if (kind === "selfie" && file.type === "application/pdf") throw new RouteError(400, "Selfie must be an image.");
+    if (!ALLOWED_MIME_TYPES.has(file.type)) throw new RouteError(400, "Only JPEG, PNG, or WebP images are allowed.");
+    if (file.size <= 0 || file.size > MAX_FILE_SIZE_BYTES) throw new RouteError(400, "File must be between 1 byte and 8 MB.");
 
     const { data: verification, error: verificationError } = await admin
       .from("identity_verifications")
@@ -36,29 +68,45 @@ export async function POST(request: Request) {
       .maybeSingle();
 
     if (verificationError) throw new RouteError(500, verificationError.message);
-    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Manual verification not found.");
+    if (!verification || verification.provider !== "manual") throw new RouteError(404, "Identity verification not found.");
     if (!["not_started", "pending"].includes(verification.status)) throw new RouteError(409, "This verification can no longer accept uploads.");
 
-    const ext = EXT_MAP[file.type] ?? "bin";
+    const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
+    const manual = (currentMetadata.manual ?? {}) as Record<string, unknown>;
+    const expiresAt = typeof manual.expiresAt === "string" ? manual.expiresAt : "";
+
+    if (!expiresAt || Date.parse(expiresAt) <= Date.now()) {
+      throw new RouteError(410, "Verification challenge expired. Start a new verification.");
+    }
+
+    const buffer = await file.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    if (!matchesMagicBytes(bytes, file.type)) {
+      throw new RouteError(400, "The uploaded file content does not match its declared image format.");
+    }
+
+    const ext = EXT_MAP[file.type];
     const storagePath = `${session.userId}/manual/${verificationId}/${kind}.${ext}`;
-    const bytes = await file.arrayBuffer();
 
     const { error: uploadError } = await admin.storage
       .from("identity-documents")
-      .upload(storagePath, bytes, { contentType: file.type, upsert: true });
+      .upload(storagePath, buffer, { contentType: file.type, upsert: true });
 
     if (uploadError) throw new RouteError(500, "Upload failed. Please try again.");
 
-    const currentMetadata = (verification.metadata ?? {}) as Record<string, unknown>;
-    const manual = ((currentMetadata.manual ?? {}) as Record<string, unknown>);
-    const files = ((manual.files ?? {}) as Record<string, unknown>);
+    const files = (manual.files ?? {}) as Record<string, unknown>;
     const metadata = {
       ...currentMetadata,
       manual: {
         ...manual,
         files: {
           ...files,
-          [kind]: { path: storagePath, mimeType: file.type, uploadedAt: new Date().toISOString() },
+          [kind]: {
+            path: storagePath,
+            mimeType: file.type,
+            size: file.size,
+            uploadedAt: new Date().toISOString(),
+          },
         },
       },
     };

--- a/src/app/pro/trust/verify/page.tsx
+++ b/src/app/pro/trust/verify/page.tsx
@@ -11,6 +11,9 @@ const DOCUMENT_TYPES = [
   ["military_id", "Military ID"],
 ] as const;
 
+const ACCEPTED_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+const MAX_FILE_SIZE_BYTES = 8 * 1024 * 1024;
+
 type UploadKind = "id_front" | "id_back" | "selfie";
 
 export default function ManualIdentityVerificationPage() {
@@ -62,6 +65,19 @@ function ManualIdentityVerificationContent() {
     () => Boolean(verificationId && challengeCode && files.id_front && files.selfie && (!needsBack || files.id_back)),
     [challengeCode, files, needsBack, verificationId],
   );
+
+  function setValidatedFile(kind: UploadKind, file: File) {
+    if (!ACCEPTED_IMAGE_TYPES.has(file.type)) {
+      setError("Only JPEG, PNG, or WebP images are allowed.");
+      return;
+    }
+    if (file.size <= 0 || file.size > MAX_FILE_SIZE_BYTES) {
+      setError("Each image must be 8 MB or smaller.");
+      return;
+    }
+    setError(null);
+    setFiles((prev) => ({ ...prev, [kind]: file }));
+  }
 
   async function upload(kind: UploadKind, file: File) {
     const form = new FormData();
@@ -139,14 +155,14 @@ function ManualIdentityVerificationContent() {
               </select>
             </label>
             <label className="space-y-2 text-sm font-medium text-slate-700">Issuing country
-              <input value={documentCountry} onChange={(e) => setDocumentCountry(e.target.value.toUpperCase().slice(0, 2))} placeholder="US" className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2.5 text-sm uppercase outline-none focus:border-slate-400" />
+              <input value={documentCountry} onChange={(e) => setDocumentCountry(e.target.value.toUpperCase().replace(/[^A-Z]/g, "").slice(0, 2))} placeholder="US" className="mt-2 w-full rounded-lg border border-slate-200 px-3 py-2.5 text-sm uppercase outline-none focus:border-slate-400" />
             </label>
           </div>
 
           <div className="space-y-4">
-            <FilePicker label="Government ID — front" required file={files.id_front} onChange={(file) => setFiles((prev) => ({ ...prev, id_front: file }))} />
-            {needsBack && <FilePicker label="Government ID — back" required file={files.id_back} onChange={(file) => setFiles((prev) => ({ ...prev, id_back: file }))} />}
-            <FilePicker label="Current selfie with challenge code" required accept="image/jpeg,image/png,image/webp" file={files.selfie} onChange={(file) => setFiles((prev) => ({ ...prev, selfie: file }))} />
+            <FilePicker label="Government ID — front" required file={files.id_front} onChange={(file) => setValidatedFile("id_front", file)} />
+            {needsBack && <FilePicker label="Government ID — back" required file={files.id_back} onChange={(file) => setValidatedFile("id_back", file)} />}
+            <FilePicker label="Current selfie with challenge code" required file={files.selfie} onChange={(file) => setValidatedFile("selfie", file)} />
           </div>
 
           <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-xs leading-relaxed text-slate-600">Identity verification confirms only that MasseurMatch reviewed a government-issued identity document and a current selfie. It does not verify professional licensing, background history, qualifications, or services.</div>
@@ -163,14 +179,14 @@ function ManualIdentityVerificationContent() {
   );
 }
 
-function FilePicker({ label, required, accept = "image/jpeg,image/png,image/webp,application/pdf", file, onChange }: { label: string; required?: boolean; accept?: string; file?: File; onChange: (file: File) => void }) {
+function FilePicker({ label, required, file, onChange }: { label: string; required?: boolean; file?: File; onChange: (file: File) => void }) {
   return (
     <label className="block cursor-pointer rounded-xl border border-dashed border-slate-300 bg-white p-5 transition hover:border-slate-400 hover:bg-slate-50">
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-100"><Upload className="h-5 w-5 text-slate-600" /></div>
-        <div className="min-w-0"><div className="text-sm font-semibold text-slate-800">{label}{required ? " *" : ""}</div><div className="mt-0.5 truncate text-xs text-slate-500">{file ? file.name : "JPEG, PNG, WebP or PDF · max 10 MB"}</div></div>
+        <div className="min-w-0"><div className="text-sm font-semibold text-slate-800">{label}{required ? " *" : ""}</div><div className="mt-0.5 truncate text-xs text-slate-500">{file ? file.name : "JPEG, PNG, or WebP · max 8 MB"}</div></div>
       </div>
-      <input type="file" accept={accept} className="sr-only" onChange={(e) => { const next = e.target.files?.[0]; if (next) onChange(next); }} />
+      <input type="file" accept="image/jpeg,image/png,image/webp" className="sr-only" onChange={(e) => { const next = e.target.files?.[0]; if (next) onChange(next); }} />
     </label>
   );
 }


### PR DESCRIPTION
Hardens the manual identity verification upload flow.

Includes:
- removes PDF support from identity uploads
- accepts JPEG, PNG, and WebP only
- validates image magic bytes against declared MIME type
- reduces max upload size to 8 MB
- distributed per-user rate limits for start/upload/submit using existing Upstash infrastructure with memory fallback
- deletes files from abandoned active attempts before starting a new challenge
- enforces back-of-ID submission for non-passport documents
- validates two-letter issuing country codes
- updates provider UI to match the hardened upload contract

No payment code changed. No schema migration required.