### PR TITLE
Make manual identity review auditable

### DIFF
--- a/src/app/admin/verification/manual/page.tsx
+++ b/src/app/admin/verification/manual/page.tsx
@@ -1,12 +1,31 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, RefreshCw, ShieldCheck, XCircle } from "lucide-react";
 
 import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const APPROVAL_CRITERIA = [
+  ["document_valid", "Government ID appears authentic and readable"],
+  ["document_unexpired", "Government ID appears unexpired"],
+  ["selfie_matches", "Selfie appears to match the ID photo"],
+  ["challenge_visible", "Current selfie clearly shows the challenge code"],
+] as const;
+
+const REJECTION_OPTIONS = [
+  ["document_unreadable", "Document unreadable"],
+  ["document_expired", "Document expired"],
+  ["document_invalid", "Document appears invalid"],
+  ["selfie_mismatch", "Selfie does not match ID"],
+  ["challenge_missing", "Challenge code missing"],
+  ["challenge_unreadable", "Challenge code unreadable"],
+  ["suspected_tampering", "Suspected tampering"],
+  ["missing_document_side", "Required document side missing"],
+  ["other", "Other"],
+] as const;
 
 type ManualMetadata = {
   manual?: {
@@ -16,7 +35,9 @@ type ManualMetadata = {
     submittedAt?: string | null;
     reviewedAt?: string | null;
     decision?: string | null;
+    rejectionCode?: string | null;
     rejectionReason?: string | null;
+    approvalCriteria?: string[];
     files?: Record<string, { path?: string; mimeType?: string; uploadedAt?: string }>;
   };
 };
@@ -31,6 +52,13 @@ type Verification = {
   updated_at: string;
   user_name: string | null;
   user_email: string | null;
+};
+
+type ReviewPayload = {
+  decision: "approve" | "reject";
+  criteria?: string[];
+  rejectionCode?: string;
+  reason?: string;
 };
 
 export default function ManualVerificationAdminPage() {
@@ -56,20 +84,14 @@ export default function ManualVerificationAdminPage() {
 
   useEffect(() => { void load(); }, [load]);
 
-  async function review(id: string, decision: "approve" | "reject") {
-    let reason = "";
-    if (decision === "reject") {
-      reason = window.prompt("Reason shown to the provider:", "Document or selfie could not be verified. Please submit a new clear attempt.")?.trim() ?? "";
-      if (!reason) return;
-    }
-
+  async function review(id: string, payload: ReviewPayload) {
     setBusyId(id);
     setError(null);
     try {
       const res = await fetch(`/api/admin/verification/${id}/manual-review`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ decision, reason }),
+        body: JSON.stringify(payload),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error ?? "Review action failed.");
@@ -86,7 +108,7 @@ export default function ManualVerificationAdminPage() {
 
   return (
     <div className="space-y-6">
-      <AdminPageHeader title="Manual Identity Review" description="Temporary identity verification queue while Stripe Identity is unavailable." />
+      <AdminPageHeader title="Identity Review" description="Review identity evidence using required, auditable criteria before approving or requesting resubmission." />
 
       {error && <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
 
@@ -96,7 +118,7 @@ export default function ManualVerificationAdminPage() {
           <Button size="sm" variant="outline" onClick={() => void load()} disabled={loading}><RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />Refresh</Button>
         </CardHeader>
         <CardContent className="space-y-4">
-          {loading ? <div className="flex justify-center py-12"><Loader2 className="h-7 w-7 animate-spin text-muted-foreground" /></div> : pending.length === 0 ? <div className="py-10 text-center text-sm text-muted-foreground">No manual identity verifications are waiting.</div> : pending.map((row) => <ReviewCard key={row.id} row={row} busy={busyId === row.id} onReview={review} />)}
+          {loading ? <div className="flex justify-center py-12"><Loader2 className="h-7 w-7 animate-spin text-muted-foreground" /></div> : pending.length === 0 ? <div className="py-10 text-center text-sm text-muted-foreground">No identity verifications are waiting.</div> : pending.map((row) => <ReviewCard key={row.id} row={row} busy={busyId === row.id} onReview={review} />)}
         </CardContent>
       </Card>
 
@@ -106,7 +128,19 @@ export default function ManualVerificationAdminPage() {
           <CardContent className="space-y-3">
             {history.slice(0, 20).map((row) => {
               const manual = row.metadata?.manual;
-              return <div key={row.id} className="flex flex-col justify-between gap-2 rounded-lg border p-4 sm:flex-row sm:items-center"><div><div className="font-medium">{row.user_name || "Provider"}</div><div className="text-xs text-muted-foreground">{row.user_email || row.user_id}</div></div><div className="text-right"><Badge variant={row.status === "verified" ? "default" : "destructive"}>{row.status === "verified" ? "Verified" : "Needs resubmission"}</Badge><div className="mt-1 text-xs text-muted-foreground">{manual?.reviewedAt ? new Date(manual.reviewedAt).toLocaleString() : new Date(row.updated_at).toLocaleString()}</div></div></div>;
+              return (
+                <div key={row.id} className="flex flex-col justify-between gap-2 rounded-lg border p-4 sm:flex-row sm:items-center">
+                  <div>
+                    <div className="font-medium">{row.user_name || "Provider"}</div>
+                    <div className="text-xs text-muted-foreground">{row.user_email || row.user_id}</div>
+                    {manual?.rejectionCode && <div className="mt-1 text-xs text-rose-700">Reason: {manual.rejectionCode.replaceAll("_", " ")}</div>}
+                  </div>
+                  <div className="text-right">
+                    <Badge variant={row.status === "verified" ? "default" : "destructive"}>{row.status === "verified" ? "Verified" : "Needs resubmission"}</Badge>
+                    <div className="mt-1 text-xs text-muted-foreground">{manual?.reviewedAt ? new Date(manual.reviewedAt).toLocaleString() : new Date(row.updated_at).toLocaleString()}</div>
+                  </div>
+                </div>
+              );
             })}
           </CardContent>
         </Card>
@@ -115,9 +149,15 @@ export default function ManualVerificationAdminPage() {
   );
 }
 
-function ReviewCard({ row, busy, onReview }: { row: Verification; busy: boolean; onReview: (id: string, decision: "approve" | "reject") => Promise<void> }) {
+function ReviewCard({ row, busy, onReview }: { row: Verification; busy: boolean; onReview: (id: string, payload: ReviewPayload) => Promise<void> }) {
   const manual = row.metadata?.manual;
   const hasBack = Boolean(manual?.files?.id_back?.path);
+  const [criteria, setCriteria] = useState<Record<string, boolean>>({});
+  const [rejectionCode, setRejectionCode] = useState("");
+  const [reason, setReason] = useState("");
+
+  const allApproved = useMemo(() => APPROVAL_CRITERIA.every(([value]) => criteria[value]), [criteria]);
+
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
       <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-start">
@@ -126,7 +166,7 @@ function ReviewCard({ row, busy, onReview }: { row: Verification; busy: boolean;
           <div className="mt-1 text-sm text-slate-500">{row.user_email || row.user_id}</div>
           <div className="mt-3 grid gap-2 text-xs text-slate-600 sm:grid-cols-3"><div><strong>Document:</strong> {manual?.documentType?.replaceAll("_", " ") || "Unknown"}</div><div><strong>Country:</strong> {manual?.documentCountry || "US"}</div><div><strong>Challenge:</strong> <span className="font-mono font-bold">{manual?.challengeCode || "—"}</span></div></div>
         </div>
-        <Badge variant="secondary">Pending manual review</Badge>
+        <Badge variant="secondary">Pending review</Badge>
       </div>
 
       <div className="mt-5 grid gap-3 sm:grid-cols-3">
@@ -135,13 +175,32 @@ function ReviewCard({ row, busy, onReview }: { row: Verification; busy: boolean;
         <DocumentLink id={row.id} kind="selfie" label="Open challenge selfie" />
       </div>
 
-      <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-900"><AlertTriangle className="mr-1 inline h-3.5 w-3.5" />Approve only when the ID appears valid and unexpired, the selfie appears to match the ID photo, and the selfie visibly includes challenge code <strong className="font-mono">{manual?.challengeCode || "—"}</strong>. Approval verifies identity only, not licensing or background history.</div>
+      <div className="mt-5 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-900"><AlertTriangle className="mr-1 inline h-3.5 w-3.5" />Identity approval confirms only identity evidence reviewed by MasseurMatch. It does not verify professional licensing, background history, qualifications, or services.</div>
 
-      <div className="mt-5 flex flex-wrap gap-2">
-        <Button onClick={() => void onReview(row.id, "approve")} disabled={busy}><CheckCircle2 className="mr-2 h-4 w-4" />Approve identity</Button>
-        <Button variant="destructive" onClick={() => void onReview(row.id, "reject")} disabled={busy}><XCircle className="mr-2 h-4 w-4" />Reject / resubmit</Button>
-        {busy && <div className="flex items-center px-2 text-sm text-muted-foreground"><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving decision...</div>}
+      <div className="mt-5 rounded-xl border border-slate-200 p-4">
+        <div className="text-sm font-semibold text-slate-900">Required approval checklist</div>
+        <div className="mt-3 space-y-2">
+          {APPROVAL_CRITERIA.map(([value, label]) => (
+            <label key={value} className="flex items-start gap-3 text-sm text-slate-700">
+              <input type="checkbox" className="mt-1" checked={Boolean(criteria[value])} onChange={(e) => setCriteria((prev) => ({ ...prev, [value]: e.target.checked }))} />
+              <span>{label}</span>
+            </label>
+          ))}
+        </div>
+        <Button className="mt-4" onClick={() => void onReview(row.id, { decision: "approve", criteria: APPROVAL_CRITERIA.map(([value]) => value) })} disabled={busy || !allApproved}><CheckCircle2 className="mr-2 h-4 w-4" />Approve identity</Button>
       </div>
+
+      <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50/40 p-4">
+        <div className="text-sm font-semibold text-rose-900">Request resubmission</div>
+        <select value={rejectionCode} onChange={(e) => setRejectionCode(e.target.value)} className="mt-3 w-full rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm">
+          <option value="">Select reason</option>
+          {REJECTION_OPTIONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+        </select>
+        <textarea value={reason} onChange={(e) => setReason(e.target.value.slice(0, 500))} placeholder="Optional note to provider. Required only for Other." className="mt-3 min-h-20 w-full rounded-lg border border-rose-200 bg-white px-3 py-2 text-sm" />
+        <Button variant="destructive" className="mt-3" onClick={() => void onReview(row.id, { decision: "reject", rejectionCode, reason })} disabled={busy || !rejectionCode || (rejectionCode === "other" && !reason.trim())}><XCircle className="mr-2 h-4 w-4" />Reject / resubmit</Button>
+      </div>
+
+      {busy && <div className="mt-4 flex items-center text-sm text-muted-foreground"><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving decision...</div>}
     </div>
   );
 }

--- a/src/app/api/admin/verification/[id]/manual-review/route.ts
+++ b/src/app/api/admin/verification/[id]/manual-review/route.ts
@@ -6,6 +6,19 @@ import {
 } from "@/app/api/_lib/supabase-server";
 import type { Json } from "@/integrations/supabase/types";
 
+const APPROVAL_CRITERIA = ["document_valid", "document_unexpired", "selfie_matches", "challenge_visible"] as const;
+const REJECTION_CODES = new Set([
+  "document_unreadable",
+  "document_expired",
+  "document_invalid",
+  "selfie_mismatch",
+  "challenge_missing",
+  "challenge_unreadable",
+  "suspected_tampering",
+  "missing_document_side",
+  "other",
+]);
+
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const session = await requireAdminSession(request);
@@ -13,9 +26,24 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const body = await request.json().catch(() => ({} as Record<string, unknown>));
     const decision = body.decision === "approve" ? "approve" : body.decision === "reject" ? "reject" : null;
     const reason = typeof body.reason === "string" ? body.reason.trim().slice(0, 500) : "";
+    const rejectionCode = typeof body.rejectionCode === "string" ? body.rejectionCode.trim() : "";
+    const criteria = Array.isArray(body.criteria)
+      ? body.criteria.filter((value): value is string => typeof value === "string")
+      : [];
 
     if (!decision) throw new RouteError(400, "Decision must be approve or reject.");
-    if (decision === "reject" && !reason) throw new RouteError(400, "A rejection reason is required.");
+
+    if (decision === "approve") {
+      const missing = APPROVAL_CRITERIA.filter((criterion) => !criteria.includes(criterion));
+      if (missing.length > 0) {
+        throw new RouteError(400, `All approval criteria are required: ${missing.join(", ")}.`);
+      }
+    }
+
+    if (decision === "reject") {
+      if (!REJECTION_CODES.has(rejectionCode)) throw new RouteError(400, "Select a valid rejection reason.");
+      if (rejectionCode === "other" && !reason) throw new RouteError(400, "Add a rejection note for Other.");
+    }
 
     const admin = createSupabaseAdminClient();
     const { data: verification, error } = await admin
@@ -34,8 +62,6 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const files = (manual.files ?? {}) as Record<string, { path?: string }>;
     const paths = Object.values(files).map((entry) => entry?.path).filter((path): path is string => Boolean(path));
 
-    // Privacy-first: a review decision is not finalized unless the sensitive
-    // source files can be removed from storage in the same operation.
     if (paths.length > 0) {
       const { error: removeError } = await admin.storage.from("identity-documents").remove(paths);
       if (removeError) throw new RouteError(500, "Could not securely remove identity documents. Review was not finalized.");
@@ -48,18 +74,25 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         reviewedAt,
         reviewedBy: session.userId,
         decision,
-        rejectionReason: decision === "reject" ? reason : null,
+        approvalCriteria: decision === "approve" ? APPROVAL_CRITERIA : [],
+        rejectionCode: decision === "reject" ? rejectionCode : null,
+        rejectionReason: decision === "reject" ? reason || null : null,
         files: {},
         documentsDeletedAt: reviewedAt,
       },
     };
 
     const nextStatus = decision === "approve" ? "verified" : "requires_input";
+    const providerMessage =
+      decision === "reject"
+        ? reason || rejectionCode.replaceAll("_", " ")
+        : null;
+
     const { error: updateError } = await admin
       .from("identity_verifications")
       .update({
         status: nextStatus,
-        last_error: decision === "reject" ? reason : null,
+        last_error: providerMessage,
         metadata: metadata as Json,
         updated_at: reviewedAt,
       })
@@ -70,7 +103,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     await recordAuditLog(session.userId, `manual_identity_${decision}`, "identity_verification", id, {
       user_id: verification.user_id,
       decision,
-      reason: decision === "reject" ? reason : null,
+      criteria: decision === "approve" ? APPROVAL_CRITERIA : [],
+      rejection_code: decision === "reject" ? rejectionCode : null,
+      reason: decision === "reject" ? reason || null : null,
     });
 
     return json({ ok: true, status: nextStatus });

--- a/src/app/api/admin/verification/[id]/manual-review/route.ts
+++ b/src/app/api/admin/verification/[id]/manual-review/route.ts
@@ -67,6 +67,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       if (removeError) throw new RouteError(500, "Could not securely remove identity documents. Review was not finalized.");
     }
 
+    const approvedCriteria = decision === "approve" ? Array.from(APPROVAL_CRITERIA) : [];
     const metadata = {
       ...currentMetadata,
       manual: {
@@ -74,7 +75,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
         reviewedAt,
         reviewedBy: session.userId,
         decision,
-        approvalCriteria: decision === "approve" ? APPROVAL_CRITERIA : [],
+        approvalCriteria: approvedCriteria,
         rejectionCode: decision === "reject" ? rejectionCode : null,
         rejectionReason: decision === "reject" ? reason || null : null,
         files: {},
@@ -83,10 +84,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     };
 
     const nextStatus = decision === "approve" ? "verified" : "requires_input";
-    const providerMessage =
-      decision === "reject"
-        ? reason || rejectionCode.replaceAll("_", " ")
-        : null;
+    const providerMessage = decision === "reject" ? reason || rejectionCode.replaceAll("_", " ") : null;
 
     const { error: updateError } = await admin
       .from("identity_verifications")
@@ -103,7 +101,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     await recordAuditLog(session.userId, `manual_identity_${decision}`, "identity_verification", id, {
       user_id: verification.user_id,
       decision,
-      criteria: decision === "approve" ? APPROVAL_CRITERIA : [],
+      criteria: approvedCriteria,
       rejection_code: decision === "reject" ? rejectionCode : null,
       reason: decision === "reject" ? reason || null : null,
     });


### PR DESCRIPTION
Adds structured safeguards to manual identity decisions.

Includes:
- required four-item approval checklist in admin UI
- backend enforcement of every approval criterion
- structured rejection codes with optional provider note
- backend validation of rejection codes
- rejection code and approval criteria stored in verification metadata
- audit log includes decision criteria or rejection code
- recent decision history displays structured rejection reason
- removes temporary Stripe wording from the manual review page

No schema migration required. No payment code changed.