### PR TITLE
Fix platform health checks and Supabase migration drift

### DIFF
--- a/.github/workflows/demand-radar-collector.yml
+++ b/.github/workflows/demand-radar-collector.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Collect and ingest nationwide demand scores
         id: collect
+        continue-on-error: true
         shell: bash
         run: |
           mkdir -p artifacts
@@ -72,6 +73,44 @@ jobs:
             args+=(--dry-run)
           fi
           python scripts/collect_google_trends.py "${args[@]}"
+
+      - name: Evaluate collector result
+        id: evaluate
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          artifact = Path("artifacts/demand-radar-run.json")
+          if not artifact.exists():
+              print("Collector did not create an artifact", file=sys.stderr)
+              sys.exit(1)
+
+          data = json.loads(artifact.read_text())
+          run = data.get("run", {})
+          status = run.get("status", "failed")
+          errors = run.get("error_summary", []) or []
+          messages = [str(item.get("error", "")) if isinstance(item, dict) else str(item) for item in errors]
+          upstream_429 = bool(messages) and all("code 429" in message for message in messages)
+
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if output_path:
+              with open(output_path, "a", encoding="utf-8") as handle:
+                  handle.write(f"degraded={'true' if upstream_429 else 'false'}\n")
+
+          if status == "completed":
+              sys.exit(0)
+          if upstream_429:
+              print("::warning::Google Trends rate-limited the hosted runner (HTTP 429). Data collection is degraded, but application health is unaffected.")
+              sys.exit(0)
+
+          print(f"Collector status is {status}; treating as a real pipeline failure", file=sys.stderr)
+          sys.exit(1)
+          PY
 
       - name: Publish run summary
         if: always()
@@ -108,6 +147,22 @@ jobs:
           path: artifacts/
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Open or update upstream rate-limit alert
+        if: ${{ steps.evaluate.outputs.degraded == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Demand Radar upstream rate limiting";
+            const marker = "<!-- demand-radar-upstream-rate-limit -->";
+            const body = `${marker}\nGoogle Trends returned HTTP 429 for the scheduled Demand Radar collection on ${new Date().toISOString()}. The application remains healthy, but fresh demand data was not available.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: "open", per_page: 50 });
+            const existing = data.find(issue => !issue.pull_request && issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body });
+            }
 
       - name: Open or update failure alert
         if: failure()

--- a/supabase/migrations/20260812133112_align_identity_billing_contract_20260812.sql
+++ b/supabase/migrations/20260812133112_align_identity_billing_contract_20260812.sql
@@ -1,0 +1,60 @@
+-- Migration history alignment for the identity verification and billing contract.
+
+alter table public.identity_verifications
+  add column if not exists provider text default 'stripe',
+  add column if not exists metadata jsonb,
+  add column if not exists stripe_verification_report_id text;
+
+create table if not exists public.subscription_plans (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  name text not null,
+  description text,
+  price_cents integer not null default 0 check (price_cents >= 0),
+  currency text not null default 'USD',
+  billing_interval text not null default 'month' check (billing_interval in ('free', 'month', 'year')),
+  priority_rank integer not null default 0,
+  max_photos integer not null default 1,
+  can_publish boolean not null default true,
+  can_feature boolean not null default false,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  stripe_product_id text,
+  stripe_price_id text,
+  features jsonb not null default '{}'::jsonb
+);
+
+alter table public.subscription_plans enable row level security;
+
+create table if not exists public.therapist_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  therapist_profile_id uuid not null,
+  plan_id uuid not null references public.subscription_plans(id),
+  status text not null default 'active' check (status in ('trialing', 'active', 'past_due', 'canceled', 'expired')),
+  provider text,
+  provider_subscription_id text,
+  current_period_start timestamptz,
+  current_period_end timestamptz,
+  cancel_at_period_end boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  profile_id uuid references public.profiles(id)
+);
+
+alter table public.therapist_subscriptions enable row level security;
+
+create table if not exists public.checkout_sessions (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  therapist_profile_id uuid,
+  plan_id uuid references public.subscription_plans(id),
+  stripe_checkout_session_id text unique,
+  stripe_customer_id text,
+  status text not null default 'created' check (status in ('created', 'open', 'complete', 'expired', 'failed')),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.checkout_sessions enable row level security;

--- a/supabase/migrations/20260813225500_restore_billing_rls.sql
+++ b/supabase/migrations/20260813225500_restore_billing_rls.sql
@@ -1,0 +1,30 @@
+drop policy if exists "therapist_subscriptions_select_own_or_admin" on public.therapist_subscriptions;
+create policy "therapist_subscriptions_select_own_or_admin"
+  on public.therapist_subscriptions for select
+  to authenticated
+  using (
+    public.is_admin()
+    or exists (
+      select 1 from public.profiles p
+      where p.id = therapist_subscriptions.profile_id
+        and (p.user_id = (select auth.uid()) or p.id = (select auth.uid()))
+    )
+    or exists (
+      select 1 from public.therapist_profiles tp
+      where tp.id = therapist_subscriptions.therapist_profile_id
+        and tp.user_id = (select auth.uid())
+    )
+  );
+
+drop policy if exists "checkout_sessions_select_own_or_admin" on public.checkout_sessions;
+create policy "checkout_sessions_select_own_or_admin"
+  on public.checkout_sessions for select
+  to authenticated
+  using (
+    public.is_admin()
+    or exists (
+      select 1 from public.profiles p
+      where p.id = checkout_sessions.profile_id
+        and (p.user_id = (select auth.uid()) or p.id = (select auth.uid()))
+    )
+  );

--- a/supabase/migrations/20260813225600_secure_therapist_analytics_view.sql
+++ b/supabase/migrations/20260813225600_secure_therapist_analytics_view.sql
@@ -1,0 +1,1 @@
+alter view public.therapist_analytics_daily set (security_invoker = true);


### PR DESCRIPTION
## Summary

This PR addresses the remaining non-green platform signals found across GitHub, Vercel, and Supabase.

### Fixes

- Restores the production-only Supabase migration `20260812133112_align_identity_billing_contract_20260812.sql` to repository history so preview branches can replay production schema consistently.
- Restores authenticated owner/admin SELECT policies for `therapist_subscriptions` and `checkout_sessions`.
- Changes `therapist_analytics_daily` to `security_invoker` so underlying RLS applies as the caller.
- Classifies Google Trends HTTP 429 responses as an upstream degradation instead of an application failure while preserving an explicit alert and keeping genuine collector failures red.

### Why

Current production CI and Vercel deployment are healthy, but the scheduled Demand Radar workflow was red because every Google Trends request from the GitHub-hosted runner was rate-limited with HTTP 429. Supabase also reported migration-history drift and missing security coverage on billing tables / analytics view.

### Merge rule

Merge only after CI, Vercel preview, and Supabase preview checks pass.