### PR TITLE
Show call, text, and consented email contact buttons on profiles

### DIFF
--- a/src/app/therapists/[slug]/_components/vox/VoxProfile.tsx
+++ b/src/app/therapists/[slug]/_components/vox/VoxProfile.tsx
@@ -8,6 +8,8 @@ import {
   Crown,
   Star,
   MessageCircle,
+  MessageSquare,
+  Phone,
   Mail,
   Globe,
   Clock,
@@ -109,10 +111,12 @@ export function VoxProfile({
   education?: Array<{ label?: string | null; institution?: string | null } | string> | string;
 }) {
   const firstName = profile.name.split(" ")[0] || profile.name;
-  const phoneHref = contactHref("whatsapp", profile.phone);
+  const callHref = contactHref("phone", profile.phone);
+  const smsHref = contactHref("sms", profile.phone);
   const whatsappHref = contactHref("whatsapp", profile.whatsapp);
-  const emailHref = contactHref("email", profile.email);
+  const emailHref = profile.showEmail ? contactHref("email", profile.email) : null;
   const websiteHref = contactHref("website", profile.website);
+  const primaryContactHref = callHref || smsHref || whatsappHref || emailHref;
 
   const handlePhoneClick = () => trackConversion("contact", profile.id);
   const handleEmailClick = () => trackConversion("email", profile.id);
@@ -268,30 +272,44 @@ export function VoxProfile({
 
               {/* Contact CTAs */}
               <div id="contact" className="mt-8 flex flex-wrap items-center gap-3">
-                {phoneHref && (
+                {callHref && (
                   <a
-                    href={phoneHref}
+                    href={callHref}
                     onClick={handlePhoneClick}
-                    className="inline-flex h-12 items-center gap-2 rounded-full bg-[#8B1E2D] px-7 font-semibold text-white shadow-[0_0_32px_rgba(139, 30, 45,0.4)] transition-transform hover:-translate-y-0.5"
+                    className="inline-flex h-12 items-center gap-2 rounded-full bg-[#8B1E2D] px-7 font-semibold text-white shadow-[0_0_32px_rgba(139,30,45,0.4)] transition-transform hover:-translate-y-0.5"
                   >
-                    <MessageCircle className="h-4 w-4" strokeWidth={2.5} />
-                    WhatsApp {firstName}
+                    <Phone className="h-4 w-4" strokeWidth={2.5} />
+                    Call {firstName}
                   </a>
                 )}
-                {profile.phone && !phoneHref && (
-                  <span className="inline-flex h-12 items-center gap-2 rounded-full border border-white/20 bg-white/[0.07] px-5 font-semibold text-white">
-                    <MessageCircle className="h-4 w-4 text-[#8B1E2D]" strokeWidth={2.5} />
-                    {profile.phone}
-                  </span>
+                {smsHref && (
+                  <a
+                    href={smsHref}
+                    onClick={handlePhoneClick}
+                    className="inline-flex h-12 items-center gap-2 rounded-full border border-white/20 bg-white/[0.07] px-6 font-semibold text-white transition-colors hover:border-white/40"
+                  >
+                    <MessageSquare className="h-4 w-4 text-[#8B1E2D]" strokeWidth={2.5} />
+                    Text
+                  </a>
                 )}
-                {emailHref && !phoneHref && !whatsappHref && (
+                {whatsappHref && (
+                  <a
+                    href={whatsappHref}
+                    onClick={handlePhoneClick}
+                    className="inline-flex h-12 items-center gap-2 rounded-full border border-white/20 bg-white/[0.07] px-6 font-semibold text-white transition-colors hover:border-white/40"
+                  >
+                    <MessageCircle className="h-4 w-4 text-[#8B1E2D]" strokeWidth={2.5} />
+                    WhatsApp
+                  </a>
+                )}
+                {emailHref && (
                   <a
                     href={emailHref}
                     onClick={handleEmailClick}
-                    className="inline-flex h-12 items-center gap-2 rounded-full bg-[#8B1E2D] px-7 font-semibold text-white"
+                    className="inline-flex h-12 items-center gap-2 rounded-full border border-white/20 bg-white/[0.07] px-6 font-semibold text-white transition-colors hover:border-white/40"
                   >
-                    <Mail className="h-4 w-4" strokeWidth={2.5} />
-                    Email {firstName}
+                    <Mail className="h-4 w-4 text-[#8B1E2D]" strokeWidth={2.5} />
+                    Email
                   </a>
                 )}
                 {websiteHref && (
@@ -785,9 +803,9 @@ export function VoxProfile({
             Message {firstName} directly to confirm fit, availability, and location. No signup, no middlemen.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-3">
-            {(phoneHref || whatsappHref || emailHref) && (
+            {primaryContactHref && (
               <a
-                href={phoneHref || whatsappHref || emailHref || "#contact"}
+                href={primaryContactHref}
                 className="inline-flex h-12 items-center gap-2 rounded-full bg-[#8B1E2D] px-7 font-semibold text-white shadow-[0_0_32px_rgba(139, 30, 45,0.35)] transition-transform hover:-translate-y-0.5"
               >
                 <Sparkles className="h-4 w-4" strokeWidth={2.5} />
@@ -811,7 +829,10 @@ export function VoxProfile({
       <VoxStickyContact
         name={profile.name}
         startingPrice={profile.startingPrice}
-        phoneHref={phoneHref}
+        callHref={callHref}
+        smsHref={smsHref}
+        whatsappHref={whatsappHref}
+        emailHref={emailHref}
         profileId={profile.id}
       />
     </div>

--- a/src/app/therapists/[slug]/_components/vox/VoxStickyContact.tsx
+++ b/src/app/therapists/[slug]/_components/vox/VoxStickyContact.tsx
@@ -1,40 +1,75 @@
-﻿"use client";
+"use client";
 
-import { MessageCircle } from "lucide-react";
+import { Mail, MessageCircle, MessageSquare, Phone } from "lucide-react";
 import { trackConversion } from "@/lib/seo-tracking-config";
 
-// Mobile-only sticky contact bar. Mirrors the primary contact actions from the
-// hero so reaching out is always one tap away on small screens.
+// Mobile-only sticky contact bar. Mirrors the contact actions from the hero so
+// reaching out is always one tap away on small screens. The first available
+// method renders as the labeled primary button; the rest collapse to icons.
 export function VoxStickyContact({
   name,
   startingPrice,
-  phoneHref,
+  callHref,
+  smsHref,
+  whatsappHref,
+  emailHref,
   profileId,
 }: {
   name: string;
   startingPrice: string;
-  phoneHref: string | null;
+  callHref: string | null;
+  smsHref: string | null;
+  whatsappHref: string | null;
+  emailHref: string | null;
   profileId?: string;
 }) {
-  if (!phoneHref) return null;
+  const firstName = name.split(" ")[0];
 
-  const handlePhoneClick = () => {
+  const track = (conversion: "contact" | "email") => () => {
     if (profileId) {
-      trackConversion("contact", profileId);
+      trackConversion(conversion, profileId);
     }
   };
+
+  const actions = [
+    callHref && { key: "call", href: callHref, label: `Call ${firstName}`, Icon: Phone, onClick: track("contact") },
+    smsHref && { key: "sms", href: smsHref, label: `Text ${firstName}`, Icon: MessageSquare, onClick: track("contact") },
+    whatsappHref && { key: "whatsapp", href: whatsappHref, label: `WhatsApp ${firstName}`, Icon: MessageCircle, onClick: track("contact") },
+    emailHref && { key: "email", href: emailHref, label: `Email ${firstName}`, Icon: Mail, onClick: track("email") },
+  ].filter(Boolean) as Array<{
+    key: string;
+    href: string;
+    label: string;
+    Icon: typeof Phone;
+    onClick: () => void;
+  }>;
+
+  if (actions.length === 0) return null;
+
+  const [primary, ...secondary] = actions;
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 border-t border-[#E5E5E5] bg-white/95 p-3 backdrop-blur-xl lg:hidden">
       <div className="flex items-center gap-2">
         <a
-          href={phoneHref}
-          onClick={handlePhoneClick}
-          className="flex h-12 flex-1 items-center justify-center gap-2 rounded-full bg-[#8B1E2D] font-semibold text-white shadow-[0_0_20px_rgba(139, 30, 45,0.35)]"
+          href={primary.href}
+          onClick={primary.onClick}
+          className="flex h-12 flex-1 items-center justify-center gap-2 rounded-full bg-[#8B1E2D] font-semibold text-white shadow-[0_0_20px_rgba(139,30,45,0.35)]"
         >
-          <MessageCircle className="h-4 w-4" strokeWidth={2.5} />
-          WhatsApp {name.split(" ")[0]}
+          <primary.Icon className="h-4 w-4" strokeWidth={2.5} />
+          {primary.label}
         </a>
+        {secondary.map(({ key, href, label, Icon, onClick }) => (
+          <a
+            key={key}
+            href={href}
+            onClick={onClick}
+            aria-label={label}
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-[#D9D9D9] bg-white text-[#8B1E2D]"
+          >
+            <Icon className="h-4 w-4" strokeWidth={2.5} />
+          </a>
+        ))}
       </div>
       {startingPrice && startingPrice !== "Contact for rates" && (
         <p className="mt-1.5 text-center text-xs text-[#5a5147]">Sessions from {startingPrice}</p>

--- a/src/components/profile/profile-utils.ts
+++ b/src/components/profile/profile-utils.ts
@@ -61,6 +61,7 @@ export type ProfileViewModel = {
   website: string | null;
   instagram: string | null;
   email: string | null;
+  showEmail: boolean;
   preferredContactMethod: string;
   isVerified: boolean;
   isFeatured: boolean;
@@ -232,12 +233,13 @@ export function buildProfileViewModel(profile: PublicTherapist, photos: ProfileP
     lastActiveAt: fullDateLabel(p.last_active_at || profile.updated_at, "Recently active"),
     responseTime: String(p.response_time || (profile.available_now ? "Typically responds quickly" : "Response time available after contact")),
     memberSince: dateLabel(p.member_since || p.created_at || profile.updated_at, "Member profile active"),
-    phone: profile.whatsapp_number || profile.phone,
-    whatsapp: null,
+    phone: profile.phone || profile.whatsapp_number,
+    whatsapp: profile.whatsapp_number,
     telegram: typeof p.telegram === "string" ? p.telegram : typeof p.telegram_handle === "string" ? p.telegram_handle : null,
     website: profile.website,
     instagram: typeof p.instagram === "string" ? p.instagram : null,
     email: profile.email_address,
+    showEmail: Boolean(profile.show_email),
     preferredContactMethod: String(p.preferred_contact_method || p.preferred_contact || (profile.whatsapp_number ? "WhatsApp" : profile.phone ? "Phone" : "Email")),
     isVerified: Boolean(p.is_verified ?? profile.is_verified_identity ?? profile.is_verified_profile ?? profile.verification_status === "verified"),
     isFeatured: Boolean(profile.is_featured),
@@ -256,9 +258,10 @@ export function buildProfileViewModel(profile: PublicTherapist, photos: ProfileP
   };
 }
 
-export function contactHref(type: "phone" | "whatsapp" | "telegram" | "email" | "website" | "instagram", value: string | null) {
+export function contactHref(type: "phone" | "sms" | "whatsapp" | "telegram" | "email" | "website" | "instagram", value: string | null) {
   if (!value) return null;
   if (type === "phone") return `tel:${value.replace(/[^+\d]/g, "")}`;
+  if (type === "sms") return `sms:${value.replace(/[^+\d]/g, "")}`;
   if (type === "whatsapp") return `https://wa.me/${value.replace(/[^\d]/g, "")}`;
   if (type === "telegram") return value.startsWith("http") ? value : `https://t.me/${value.replace(/^@/, "")}`;
   if (type === "email") return `mailto:${value}`;


### PR DESCRIPTION
## Summary

Profiles showed a **WhatsApp** button for every phone number, with no way to call or text. Two bugs combined to cause this:

1. `buildProfileViewModel` mapped `phone: profile.whatsapp_number || profile.phone` and hardcoded `whatsapp: null`, so the WhatsApp number swallowed the phone slot.
2. `VoxProfile` then wrapped that value in `contactHref("whatsapp", …)`, producing a `wa.me/` link labeled "WhatsApp" regardless of what the therapist entered.

Email was also only shown as a last-resort fallback (when no phone existed at all) and ignored the therapist's `show_email` consent flag.

## Changes

- **`src/components/profile/profile-utils.ts`**
  - Map `phone` and `whatsapp` separately (`phone: profile.phone || profile.whatsapp_number`, `whatsapp: profile.whatsapp_number`).
  - Add `showEmail` to the view model from the profile's `show_email` column.
  - Add an `sms` variant to `contactHref` (`sms:` links).
- **`VoxProfile.tsx`** (hero + final CTA band)
  - Primary **Call** button (`tel:`, `Phone` icon) and secondary **Text** button (`sms:`, `MessageSquare` icon).
  - **WhatsApp** button only when the therapist has a WhatsApp number set.
  - **Email** button (`Mail` icon) only when the therapist has enabled `show_email`.
- **`VoxStickyContact.tsx`** (mobile sticky bar)
  - The first available method renders as the labeled primary button; the rest collapse to accessible icon buttons (with `aria-label`s), so Call/Text/WhatsApp/Email all stay one tap away.

Conversion tracking is preserved (`contact` for call/text/WhatsApp, `email` for email).

## Verification

- `npx tsc --noEmit` — exit 0
- `npx eslint` on changed files — clean
- `pnpm run build` — compiles, all 288 static pages generate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nfdb2kKE5DFtGGxV6FV92t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nfdb2kKE5DFtGGxV6FV92t)_