### PR TITLE
Upgrade KNOTTY with official MasseurMatch knowledge

### DIFF
--- a/src/lib/ai/llm.ts
+++ b/src/lib/ai/llm.ts
@@ -4,6 +4,7 @@ import {
   HarmCategory,
 } from "@google/generative-ai";
 import { envAny } from "@/app/api/_lib/env";
+import { getKnottyWebsiteKnowledge } from "@/lib/knotty/website-knowledge";
 
 /**
  * Shared text-completion helper for MasseurMatch's AI features (Knotty, the
@@ -32,6 +33,21 @@ export type CompleteOptions = {
 
 export function hasAnyLlmKey(): boolean {
   return Boolean(envAny(["OPENAI_API_KEY", "DEEPSEEK_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"], ""));
+}
+
+function enrichKnottySystemPrompt(system: string): string {
+  const isKnottyPrompt = /\bknotty\b/i.test(system) && /\bmasseurmatch\b/i.test(system);
+  if (!isKnottyPrompt) return system;
+
+  return `${system}\n\n${getKnottyWebsiteKnowledge()}`;
+}
+
+function enrichKnottyChatMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((message) =>
+    message.role === "system"
+      ? { ...message, content: enrichKnottySystemPrompt(message.content) }
+      : message,
+  );
 }
 
 async function tryOpenAI(apiKey: string, o: CompleteOptions): Promise<string | null> {
@@ -229,10 +245,12 @@ export async function chatMessages(
   messages: ChatMessage[],
   o: { temperature?: number; maxTokens?: number; timeoutMs?: number } = {},
 ): Promise<LlmResult> {
+  const enrichedMessages = enrichKnottyChatMessages(messages);
+
   const deepseekKey = envAny(["DEEPSEEK_API_KEY"], "");
   if (deepseekKey) {
     try {
-      const text = await tryDeepSeekChat(deepseekKey, messages, o);
+      const text = await tryDeepSeekChat(deepseekKey, enrichedMessages, o);
       if (text) return { text, provider: "deepseek", model: DEEPSEEK_MODEL };
     } catch {
       // fall through
@@ -242,7 +260,7 @@ export async function chatMessages(
   const openaiKey = envAny(["OPENAI_API_KEY"], "");
   if (openaiKey) {
     try {
-      const text = await tryOpenAIChat(openaiKey, messages, o);
+      const text = await tryOpenAIChat(openaiKey, enrichedMessages, o);
       if (text) return { text, provider: "openai", model: OPENAI_MODEL };
     } catch {
       // fall through
@@ -252,7 +270,7 @@ export async function chatMessages(
   const geminiKey = envAny(["GEMINI_API_KEY", "GOOGLE_API_KEY"], "");
   if (geminiKey) {
     try {
-      const text = await tryGeminiChat(geminiKey, messages, o);
+      const text = await tryGeminiChat(geminiKey, enrichedMessages, o);
       if (text) return { text, provider: "gemini", model: GEMINI_MODEL };
     } catch {
       // fall through
@@ -266,10 +284,15 @@ export async function chatMessages(
 
 /** Complete a prompt. Provider order: DeepSeek → OpenAI → Gemini. */
 export async function completeText(o: CompleteOptions): Promise<LlmResult> {
+  const enrichedOptions = {
+    ...o,
+    system: enrichKnottySystemPrompt(o.system),
+  };
+
   const deepseekKey = envAny(["DEEPSEEK_API_KEY"], "");
   if (deepseekKey) {
     try {
-      const text = await tryDeepSeek(deepseekKey, o);
+      const text = await tryDeepSeek(deepseekKey, enrichedOptions);
       if (text) return { text, provider: "deepseek", model: DEEPSEEK_MODEL };
     } catch {
       // fall through
@@ -279,7 +302,7 @@ export async function completeText(o: CompleteOptions): Promise<LlmResult> {
   const openaiKey = envAny(["OPENAI_API_KEY"], "");
   if (openaiKey) {
     try {
-      const text = await tryOpenAI(openaiKey, o);
+      const text = await tryOpenAI(openaiKey, enrichedOptions);
       if (text) return { text, provider: "openai", model: OPENAI_MODEL };
     } catch {
       // fall through
@@ -289,7 +312,7 @@ export async function completeText(o: CompleteOptions): Promise<LlmResult> {
   const geminiKey = envAny(["GEMINI_API_KEY", "GOOGLE_API_KEY"], "");
   if (geminiKey) {
     try {
-      const text = await tryGemini(geminiKey, o);
+      const text = await tryGemini(geminiKey, enrichedOptions);
       if (text) return { text, provider: "gemini", model: GEMINI_MODEL };
     } catch {
       // fall through — caller uses its own fallback

--- a/src/lib/knotty/faq.ts
+++ b/src/lib/knotty/faq.ts
@@ -1,4 +1,6 @@
 import { getPublicTherapists } from "@/app/_lib/directory";
+import { PLANS } from "@/lib/pricing";
+import { KNOTTY_OFFICIAL_URLS } from "@/lib/knotty/website-knowledge";
 
 type KnottyFaqAnswer = {
   answer: string;
@@ -6,24 +8,44 @@ type KnottyFaqAnswer = {
   nextStepHref?: string;
 };
 
+function providerPricingSummary() {
+  return PLANS.map((plan) => `${plan.name} $${plan.price}/mo`).join(", ");
+}
+
 const PRODUCT_QUESTION_PATTERNS: Array<{
   pattern: RegExp;
   answer: KnottyFaqAnswer | ((message: string) => Promise<KnottyFaqAnswer>);
 }> = [
   {
+    pattern: /\b(sign ?up|join|create (?:an )?account|create (?:a )?profile|where do i register|how do i register)\b/i,
+    answer: {
+      answer: `You can create your MasseurMatch account here: ${KNOTTY_OFFICIAL_URLS.signup}. Start with your account, then complete your therapist profile with your location, services, photos, and contact details.`,
+      nextStepLabel: "Create your account",
+      nextStepHref: "/signup/account",
+    },
+  },
+  {
+    pattern: /\b(how does masseurmatch work|how does it work|what is masseurmatch|what does masseurmatch do)\b/i,
+    answer: {
+      answer:
+        "MasseurMatch is an LGBTQ+ inclusive directory for independent massage therapists. Clients discover profiles and contact therapists directly, while therapists stay in control of their own scheduling and client payments.",
+      nextStepLabel: "Learn about MasseurMatch",
+      nextStepHref: "/for-therapists",
+    },
+  },
+  {
     pattern: /\b(contact|phone|email|reach|message someone)\b/i,
     answer: {
       answer:
-        "MasseurMatch is a directory. Open a therapist profile and use the listed call, text, or WhatsApp options to contact that provider directly.",
+        "MasseurMatch is a directory. Open a therapist profile and use the listed call, text, WhatsApp, or consented email option to contact that provider directly.",
       nextStepLabel: "Open the directory",
       nextStepHref: "/search",
     },
   },
   {
-    pattern: /\b(pro tier|elite tier|standard tier|tier|plan|billing|subscription|portal)\b/i,
+    pattern: /\b(pro tier|elite tier|standard tier|free plan|tier|plan|billing|subscription|provider pricing|membership price|how much is masseurmatch)\b/i,
     answer: {
-      answer:
-        "Plans mainly affect visibility and premium profile tools. Standard improves trust visibility, Pro and Elite add stronger placement, richer media, and more analytics for providers.",
+      answer: `Current provider plans are ${providerPricingSummary()}. Paid plans add more visibility and profile tools. Full details: ${KNOTTY_OFFICIAL_URLS.pricing}`,
       nextStepLabel: "View pricing",
       nextStepHref: "/pricing",
     },
@@ -32,9 +54,18 @@ const PRODUCT_QUESTION_PATTERNS: Array<{
     pattern: /\bwhat is knotty|how does knotty work|how do you work\b/i,
     answer: {
       answer:
-        "Knotty is a concierge layer for the directory. It detects intent, pre-ranks therapists using product signals like availability and distance, then explains the strongest match instead of making you browse cold lists.",
-      nextStepLabel: "Try Explore",
-      nextStepHref: "/explore",
+        "Knotty is MasseurMatch's conversational assistant. I can explain the platform, answer provider questions, and help people narrow down therapist options using current directory information.",
+      nextStepLabel: "Browse the directory",
+      nextStepHref: "/search",
+    },
+  },
+  {
+    pattern: /\b(verified|verification|verify|license|licensed)\b/i,
+    answer: {
+      answer:
+        `MasseurMatch can show trust and verification signals, but a badge should not be treated as a guarantee of licensing, quality, safety, or outcome. For current safety information, see ${KNOTTY_OFFICIAL_URLS.safety}`,
+      nextStepLabel: "Safety information",
+      nextStepHref: "/safety",
     },
   },
   {
@@ -50,14 +81,14 @@ const PRODUCT_QUESTION_PATTERNS: Array<{
       if (prices.length === 0) {
         return {
           answer:
-            "Pricing varies by therapist. The fastest way to compare is to open profiles with visible incall or outcall rates.",
-          nextStepLabel: "Browse pricing",
+            "Session pricing is set by each independent therapist. The fastest way to compare is to open profiles with visible incall or outcall rates.",
+          nextStepLabel: "Browse session prices",
           nextStepHref: "/search",
         };
       }
 
       return {
-        answer: `From the current public sample, visible session rates range from $${Math.min(...prices)} to $${Math.max(...prices)}.`,
+        answer: `From the current public sample, visible session rates range from $${Math.min(...prices)} to $${Math.max(...prices)}. Individual therapists set their own prices.`,
         nextStepLabel: "Compare profiles",
         nextStepHref: "/search",
       };

--- a/src/lib/knotty/website-knowledge.ts
+++ b/src/lib/knotty/website-knowledge.ts
@@ -1,0 +1,87 @@
+import { PLANS } from "@/lib/pricing";
+
+const BASE_URL = "https://www.masseurmatch.com";
+
+export const KNOTTY_OFFICIAL_URLS = {
+  home: `${BASE_URL}/`,
+  signup: `${BASE_URL}/signup/account`,
+  therapists: `${BASE_URL}/for-therapists`,
+  pricing: `${BASE_URL}/pricing`,
+  contact: `${BASE_URL}/contact`,
+  safety: `${BASE_URL}/safety`,
+  login: `${BASE_URL}/login`,
+  about: `${BASE_URL}/about`,
+  terms: `${BASE_URL}/terms`,
+  privacy: `${BASE_URL}/privacy`,
+  smsTerms: `${BASE_URL}/sms-terms`,
+  search: `${BASE_URL}/search`,
+} as const;
+
+function pricingContext() {
+  return PLANS.map((plan) => {
+    const trial = plan.trialDays > 0 ? `; ${plan.trialDays}-day trial` : "";
+    return `${plan.name}: $${plan.price}/month${trial}. Features: ${plan.features.join(", ")}.`;
+  }).join("\n");
+}
+
+export function getKnottyWebsiteKnowledge(): string {
+  return `
+MASSEURMATCH OFFICIAL KNOWLEDGE BASE
+
+Use MasseurMatch.com and the application data provided to you as the source of truth for platform questions. Never invent pricing, features, verification claims, partnerships, reviews, traffic, guarantees, or policies.
+
+MasseurMatch is an LGBTQ+ inclusive directory for independent massage therapists. Clients discover therapist profiles and contact therapists directly. MasseurMatch does not provide massage services, employ therapists, control therapist schedules, book appointments for therapists, or process payments for massage sessions between clients and therapists.
+
+You are KNOTTY, the official MasseurMatch conversational assistant. Be warm, natural, gay-friendly, concise, lightly funny when appropriate, and helpful. Sound like a real person texting, not a corporate bot. Answer the person's actual question first, then offer one useful next step. Do not pressure people.
+
+OFFICIAL LINKS
+Main website: ${KNOTTY_OFFICIAL_URLS.home}
+Create account / signup: ${KNOTTY_OFFICIAL_URLS.signup}
+For therapists: ${KNOTTY_OFFICIAL_URLS.therapists}
+Pricing: ${KNOTTY_OFFICIAL_URLS.pricing}
+Search directory: ${KNOTTY_OFFICIAL_URLS.search}
+Login: ${KNOTTY_OFFICIAL_URLS.login}
+Safety: ${KNOTTY_OFFICIAL_URLS.safety}
+Contact / support: ${KNOTTY_OFFICIAL_URLS.contact}
+About: ${KNOTTY_OFFICIAL_URLS.about}
+Terms: ${KNOTTY_OFFICIAL_URLS.terms}
+Privacy: ${KNOTTY_OFFICIAL_URLS.privacy}
+SMS terms: ${KNOTTY_OFFICIAL_URLS.smsTerms}
+
+CURRENT PROVIDER PLANS
+${pricingContext()}
+
+PRICING RULES
+Use the plan data above as the current pricing source. If asked about price, answer briefly and include ${KNOTTY_OFFICIAL_URLS.pricing} when useful. Never quote a price that conflicts with the plan data above.
+
+SIGNUP
+If someone wants to join, create a profile, or asks where to sign up, use ${KNOTTY_OFFICIAL_URLS.signup}. Explain that therapists create an account, complete their profile, add their location/services/photos/contact details, then publish or submit the profile as required by the current signup flow.
+
+HOW IT WORKS
+Therapists have profiles. Clients search the directory, review profiles, and contact therapists directly using the contact options available on the profile. Therapists remain independent and manage their own appointments and client payments.
+
+FREE PLAN
+There is a Free plan. Do not imply a paid feature is included in Free unless it appears in the current plan data above.
+
+VERIFICATION AND SAFETY
+Do not claim MasseurMatch verifies every professional license. Do not describe a badge as a guarantee of quality, licensing, safety, or outcome. For safety or trust questions, use ${KNOTTY_OFFICIAL_URLS.safety}. If you are unsure about a verification detail, say you do not want to give outdated information and direct the person to ${KNOTTY_OFFICIAL_URLS.contact}.
+
+BILLING AND SUPPORT
+General support: support@masseurmatch.com
+Billing: billing@masseurmatch.com
+Legal: legal@masseurmatch.com
+Use these only when account-specific or human support is actually needed.
+
+OPT OUT
+If someone clearly says STOP, unsubscribe, remove me, don't contact me, wrong number, or equivalent, acknowledge briefly and do not continue marketing or persuasion.
+
+SEXUAL SERVICES
+MasseurMatch is for legitimate professional massage and bodywork discovery. Do not facilitate prostitution, sexual services, erotic services, or sexual transactions.
+
+LINK RULE
+Send the single most relevant official link instead of dumping multiple links. Answer first, then provide the link when useful.
+
+UNKNOWN INFORMATION
+If the website/application context does not establish an answer, do not guess. Say you do not want to give incorrect or outdated information and point to the appropriate official MasseurMatch page or support channel.
+`.trim();
+}


### PR DESCRIPTION
Adds the new KNOTTY system knowledge layer requested for platform conversations.

Changes:
- Injects official MasseurMatch knowledge into KNOTTY prompts before DeepSeek/OpenAI/Gemini calls
- Uses canonical pricing data from `src/lib/pricing.ts`
- Adds official MasseurMatch URLs for signup, pricing, therapist info, search, login, safety, contact, about, terms, privacy, and SMS terms
- Adds clear platform rules: directory only, direct therapist contact, independent scheduling/payments, no invented verification/licensing claims
- Expands deterministic FAQ fallbacks for signup, platform operation, provider pricing, verification, and session pricing
- Keeps non-KNOTTY AI calls unchanged

The implementation intentionally scopes prompt enrichment only to system prompts containing both `Knotty` and `MasseurMatch`.