### PR TITLE
fix: canonicalize profile view analytics

### DIFF
--- a/src/app/api/pro/analytics/route.ts
+++ b/src/app/api/pro/analytics/route.ts
@@ -4,23 +4,32 @@ import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 
 const WINDOW_DAYS = 30;
 
-function dayKey(iso: string) {
-  return iso.slice(0, 10);
-}
+type AnalyticsRpcResult = {
+  series?: Array<{ date?: string; views?: number }>;
+  windowViews?: number;
+  windowUniqueVisitors?: number;
+  allTimeViews?: number;
+};
 
-function emptySeries(since: Date) {
-  return Array.from({ length: WINDOW_DAYS }, (_, index) => ({
-    date: dayKey(new Date(since.getTime() + index * 86_400_000).toISOString()),
-    visitors: 0,
-  }));
+function emptySeries() {
+  const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000);
+  const firstDay = new Date(since);
+  firstDay.setUTCHours(0, 0, 0, 0);
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  const points: Array<{ date: string; visitors: number }> = [];
+  for (let cursor = firstDay.getTime(); cursor <= today.getTime(); cursor += 86_400_000) {
+    points.push({ date: new Date(cursor).toISOString().slice(0, 10), visitors: 0 });
+  }
+  return points;
 }
 
 export async function GET(request: Request) {
   try {
     const session = await requireRequestSession(request);
     const admin = createSupabaseAdminClient();
-    const since = new Date(Date.now() - (WINDOW_DAYS - 1) * 86_400_000);
-    since.setUTCHours(0, 0, 0, 0);
+    const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
 
     const { data: profile, error: profileError } = await admin
       .from("profiles")
@@ -35,7 +44,7 @@ export async function GET(request: Request) {
         ok: true,
         windowDays: WINDOW_DAYS,
         isLive: false,
-        series: emptySeries(since),
+        series: emptySeries(),
         totals: {
           windowViews: 0,
           windowUniqueVisitors: 0,
@@ -45,35 +54,20 @@ export async function GET(request: Request) {
       });
     }
 
-    const [windowResult, allTimeResult] = await Promise.all([
-      admin
-        .from("profile_view_analytics")
-        .select("created_at, session_id")
-        .eq("profile_id", profile.id)
-        .gte("created_at", since.toISOString())
-        .order("created_at", { ascending: false })
-        .limit(10_000),
-      admin
-        .from("profile_view_analytics")
-        .select("id", { count: "exact", head: true })
-        .eq("profile_id", profile.id),
-    ]);
+    const { data: analytics, error: analyticsError } = await admin.rpc("get_profile_view_analytics", {
+      p_profile_id: profile.id,
+      p_since: since,
+    });
 
-    if (windowResult.error) throw new RouteError(500, windowResult.error.message);
-    if (allTimeResult.error) throw new RouteError(500, allTimeResult.error.message);
+    if (analyticsError) throw new RouteError(500, analyticsError.message);
 
-    const buckets = new Map(emptySeries(since).map((point) => [point.date, 0]));
-    const uniqueSessions = new Set<string>();
+    const result = (analytics ?? {}) as AnalyticsRpcResult;
+    const series = (result.series ?? []).map((point) => ({
+      date: String(point.date ?? ""),
+      visitors: Number(point.views) || 0,
+    }));
 
-    for (const event of windowResult.data ?? []) {
-      if (!event.created_at) continue;
-      const key = dayKey(event.created_at);
-      if (buckets.has(key)) buckets.set(key, (buckets.get(key) ?? 0) + 1);
-      if (event.session_id) uniqueSessions.add(event.session_id);
-    }
-
-    const series = Array.from(buckets.entries()).map(([date, visitors]) => ({ date, visitors }));
-    const windowViews = (windowResult.data ?? []).length;
+    const windowViews = Number(result.windowViews) || 0;
     const isLive = Boolean(
       profile.is_active ||
       profile.visibility_status === "public" ||
@@ -89,8 +83,8 @@ export async function GET(request: Request) {
       series,
       totals: {
         windowViews,
-        windowUniqueVisitors: uniqueSessions.size || windowViews,
-        allTimeViews: allTimeResult.count ?? windowViews,
+        windowUniqueVisitors: Number(result.windowUniqueVisitors) || 0,
+        allTimeViews: Number(result.allTimeViews) || windowViews,
         allTimeContactClicks: Number(profile.contact_clicks) || 0,
       },
     });

--- a/src/app/pro/dashboard/layout.tsx
+++ b/src/app/pro/dashboard/layout.tsx
@@ -1,11 +1,5 @@
 import type { ReactNode } from "react";
-import { DashboardAnalyticsEnhancer } from "@/components/pro/dashboard/DashboardAnalyticsEnhancer";
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
-  return (
-    <>
-      {children}
-      <DashboardAnalyticsEnhancer />
-    </>
-  );
+  return <>{children}</>;
 }

--- a/src/app/therapists/[slug]/_components/ProfileViewTracker.tsx
+++ b/src/app/therapists/[slug]/_components/ProfileViewTracker.tsx
@@ -8,16 +8,29 @@ interface ProfileViewTrackerProps {
   source?: "search" | "explore" | "direct" | "recommendation";
 }
 
+const ANALYTICS_SESSION_KEY = "mm:analytics:session_id";
+
+function getAnalyticsSessionId() {
+  try {
+    const existing = sessionStorage.getItem(ANALYTICS_SESSION_KEY);
+    if (existing) return existing;
+
+    const sessionId = crypto.randomUUID();
+    sessionStorage.setItem(ANALYTICS_SESSION_KEY, sessionId);
+    return sessionId;
+  } catch {
+    return undefined;
+  }
+}
+
 export function ProfileViewTracker({ profileId, source = "direct" }: ProfileViewTrackerProps) {
   useEffect(() => {
-    // Track profile view
     trackProfileView({
       profile_id: profileId,
       source,
-      session_id: typeof window !== "undefined" ? sessionStorage.getItem("session_id") || undefined : undefined,
+      session_id: getAnalyticsSessionId(),
     });
   }, [profileId, source]);
 
-  // This component doesn't render anything
   return null;
 }

--- a/supabase/migrations/20260814142746_sync_profile_view_counters.sql
+++ b/supabase/migrations/20260814142746_sync_profile_view_counters.sql
@@ -1,0 +1,59 @@
+LOCK TABLE public.profile_view_analytics IN SHARE ROW EXCLUSIVE MODE;
+
+CREATE OR REPLACE FUNCTION public.sync_profile_view_counters()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.profiles
+    SET profile_views = COALESCE(profile_views, 0) + 1,
+        view_count = COALESCE(view_count, 0) + 1
+    WHERE id = NEW.profile_id;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.profiles
+    SET profile_views = GREATEST(COALESCE(profile_views, 0) - 1, 0),
+        view_count = GREATEST(COALESCE(view_count, 0) - 1, 0)
+    WHERE id = OLD.profile_id;
+    RETURN OLD;
+  ELSIF TG_OP = 'UPDATE' AND NEW.profile_id IS DISTINCT FROM OLD.profile_id THEN
+    UPDATE public.profiles
+    SET profile_views = GREATEST(COALESCE(profile_views, 0) - 1, 0),
+        view_count = GREATEST(COALESCE(view_count, 0) - 1, 0)
+    WHERE id = OLD.profile_id;
+
+    UPDATE public.profiles
+    SET profile_views = COALESCE(profile_views, 0) + 1,
+        view_count = COALESCE(view_count, 0) + 1
+    WHERE id = NEW.profile_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_profile_view_counters ON public.profile_view_analytics;
+CREATE TRIGGER trg_sync_profile_view_counters
+AFTER INSERT OR DELETE OR UPDATE OF profile_id ON public.profile_view_analytics
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_profile_view_counters();
+
+WITH counts AS (
+  SELECT profile_id, COUNT(*)::integer AS total
+  FROM public.profile_view_analytics
+  WHERE profile_id IS NOT NULL
+  GROUP BY profile_id
+), normalized AS (
+  SELECT p.id, COALESCE(c.total, 0) AS total
+  FROM public.profiles p
+  LEFT JOIN counts c ON c.profile_id = p.id
+)
+UPDATE public.profiles p
+SET profile_views = n.total,
+    view_count = n.total
+FROM normalized n
+WHERE p.id = n.id
+  AND (p.profile_views IS DISTINCT FROM n.total OR p.view_count IS DISTINCT FROM n.total);

--- a/supabase/migrations/20260814143126_canonical_profile_view_analytics_rpc.sql
+++ b/supabase/migrations/20260814143126_canonical_profile_view_analytics_rpc.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION public.get_profile_view_analytics(
+  p_profile_id uuid,
+  p_since timestamptz
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+WITH bounds AS (
+  SELECT
+    p_since AS since_ts,
+    date_trunc('day', p_since AT TIME ZONE 'UTC')::date AS since_day,
+    date_trunc('day', now() AT TIME ZONE 'UTC')::date AS today_day
+),
+days AS (
+  SELECT generate_series(b.since_day, b.today_day, interval '1 day')::date AS day
+  FROM bounds b
+),
+daily AS (
+  SELECT
+    (e.created_at AT TIME ZONE 'UTC')::date AS day,
+    count(*)::bigint AS views
+  FROM public.profile_view_analytics e, bounds b
+  WHERE e.profile_id = p_profile_id
+    AND e.created_at >= b.since_ts
+  GROUP BY 1
+),
+summary AS (
+  SELECT
+    count(*) FILTER (WHERE e.created_at >= b.since_ts)::bigint AS window_views,
+    count(DISTINCT e.session_id) FILTER (
+      WHERE e.created_at >= b.since_ts AND e.session_id IS NOT NULL
+    )::bigint AS window_unique_visitors,
+    count(*)::bigint AS all_time_views
+  FROM public.profile_view_analytics e, bounds b
+  WHERE e.profile_id = p_profile_id
+)
+SELECT jsonb_build_object(
+  'series', COALESCE((
+    SELECT jsonb_agg(
+      jsonb_build_object('date', d.day::text, 'views', COALESCE(v.views, 0))
+      ORDER BY d.day
+    )
+    FROM days d
+    LEFT JOIN daily v ON v.day = d.day
+  ), '[]'::jsonb),
+  'windowViews', COALESCE((SELECT window_views FROM summary), 0),
+  'windowUniqueVisitors', COALESCE((SELECT window_unique_visitors FROM summary), 0),
+  'allTimeViews', COALESCE((SELECT all_time_views FROM summary), 0)
+);
+$$;


### PR DESCRIPTION
Fixes dashboard profile-view accuracy and consistency.

Changes:
- canonical server-side aggregation for profile views (no 10k row cap)
- 30-day window aligned with AI Coach rolling 30-day semantics
- stable browser-session IDs for future unique visitor counts
- automatic synchronization/backfill of profiles.profile_views and profiles.view_count
- removes obsolete DOM-based DashboardAnalyticsEnhancer wiring
- adds the production Supabase migrations to source control

Production DB migrations were applied before this PR and validated read-only: 374 analytics events, 374 profile_views, 374 view_count, 0 mismatched profiles.