### PR TITLE
fix: public profile map and gallery proportions

### DIFF
--- a/src/app/therapists/[slug]/_components/vox/VoxGallery.tsx
+++ b/src/app/therapists/[slug]/_components/vox/VoxGallery.tsx
@@ -35,7 +35,7 @@ export function VoxGallery({ images, name }: { images: string[]; name: string })
             key={`${src}-${index}`}
             type="button"
             onClick={() => setActive(index)}
-            className={`group relative overflow-hidden rounded-2xl border border-[#efe3d8] bg-[#f3e9df] ${tileRatio}`}
+            className={`group relative overflow-hidden rounded-2xl border border-[#efe3d8] bg-[#f7f3ef] ${tileRatio}`}
           >
             <Image
               src={src}
@@ -46,7 +46,7 @@ export function VoxGallery({ images, name }: { images: string[]; name: string })
                   ? "(min-width: 1024px) 768px, 100vw"
                   : "(min-width: 1024px) 360px, (min-width: 640px) 50vw, 50vw"
               }
-              className="object-cover transition-transform duration-500 group-hover:scale-[1.015]"
+              className="object-contain p-1 transition-transform duration-500 group-hover:scale-[1.015]"
               loading={index === 0 ? "eager" : "lazy"}
             />
           </button>

--- a/src/components/profile/profile-utils.ts
+++ b/src/components/profile/profile-utils.ts
@@ -34,8 +34,8 @@ export type ProfileViewModel = {
   serviceArea: string;
   serviceAreas: string[];
   nearbyCities: Array<{ name: string; slug: string }>;
-  mapLat: number | null;
-  mapLng: number | null;
+  mapLat: number | string | null;
+  mapLng: number | string | null;
   travelRadius: string;
   incallAvailable: boolean;
   outcallAvailable: boolean;
@@ -174,6 +174,10 @@ export function buildProfileViewModel(profile: PublicTherapist, photos: ProfileP
   const tier = profile.subscription_tier || String(p.tier || "");
   const seoKeywords = asStringArray(p.seo_keywords);
   const canonicalUrl = String(p.canonical_url || `${SITE_URL}/therapists/${profile.slug || profile.id}`);
+  const rawMapLat = typeof p.map_lat === "number" ? p.map_lat : profile.latitude ?? null;
+  const rawMapLng = typeof p.map_lng === "number" ? p.map_lng : profile.longitude ?? null;
+  const hasCoordinates = typeof rawMapLat === "number" && typeof rawMapLng === "number";
+  const hasRealCity = Boolean(profile.city?.trim());
 
   return {
     id: profile.id,
@@ -205,8 +209,8 @@ export function buildProfileViewModel(profile: PublicTherapist, photos: ProfileP
     serviceArea: String(p.service_area || serviceAreas.join(", ") || `${city} metro`),
     serviceAreas: serviceAreas.length ? serviceAreas : [city],
     nearbyCities,
-    mapLat: typeof p.map_lat === "number" ? p.map_lat : profile.latitude ?? null,
-    mapLng: typeof p.map_lng === "number" ? p.map_lng : profile.longitude ?? null,
+    mapLat: hasCoordinates ? rawMapLat : hasRealCity ? city : null,
+    mapLng: hasCoordinates ? rawMapLng : hasRealCity ? state : null,
     travelRadius: profile.outcall_radius_miles ? `${profile.outcall_radius_miles} miles` : p.travel_radius ? `${p.travel_radius} miles` : "Travel radius on request",
     incallAvailable,
     outcallAvailable,


### PR DESCRIPTION
Fixes two public profile issues reported from the live therapist page: gallery images now preserve their full uploaded proportions instead of being cropped with object-cover, and the location map can fall back to a city/state Google Maps query when precise coordinates are unavailable. The fallback intentionally stays city-level for privacy. No database migration. Merge only after Vercel is green.