### PR TITLE
fix: make Demand Radar run accurate and decision ready

### DIFF
--- a/.github/workflows/demand-radar-collector.yml
+++ b/.github/workflows/demand-radar-collector.yml
@@ -1,13 +1,14 @@
 name: Demand Radar Collector
 
 on:
-  push:
-    branches:
-      - fix/demand-radar-national-trends
+  pull_request:
+    branches: [main]
     paths:
       - .github/workflows/demand-radar-collector.yml
       - scripts/demand_radar_markets_national.json
       - scripts/collect_google_trends.py
+      - scripts/collect_google_trends_resilient.py
+      - scripts/requirements-demand-radar.txt
   schedule:
     - cron: "17 8 * * *"
   workflow_dispatch:
@@ -27,36 +28,62 @@ permissions:
   issues: write
 
 concurrency:
-  group: demand-radar-daily
+  group: demand-radar-${{ github.event_name == 'pull_request' && github.ref || 'daily' }}
   cancel-in-progress: false
 
 jobs:
-  collect:
+  validate:
+    name: Validate collector
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    env:
-      DEMAND_RADAR_APP_URL: ${{ secrets.DEMAND_RADAR_APP_URL }}
-      INTERNAL_API_KEY: ${{ secrets.INTERNAL_API_KEY }}
-      DEMAND_RADAR_MARKET_DELAY_SECONDS: "2"
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: scripts/requirements-demand-radar.txt
+      - run: pip install -r scripts/requirements-demand-radar.txt
+      - name: Compile collector scripts
+        run: python -m py_compile scripts/collect_google_trends.py scripts/collect_google_trends_resilient.py
+      - name: Validate national market configuration
+        run: |
+          PYTHONPATH=scripts python - <<'PY'
+          from pathlib import Path
+          from collect_google_trends import load_markets
+          markets = load_markets(Path("scripts/demand_radar_markets_national.json"))
+          if len(markets) < 50:
+              raise SystemExit(f"Expected national coverage, found only {len(markets)} markets")
+          print(f"Validated {len(markets)} markets")
+          PY
 
+  collect:
+    name: Collect nationwide demand
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DEMAND_RADAR_APP_URL: ${{ secrets.DEMAND_RADAR_APP_URL }}
+      INTERNAL_API_KEY: ${{ secrets.INTERNAL_API_KEY }}
+      DEMAND_RADAR_MARKET_DELAY_SECONDS: "6"
+      DEMAND_RADAR_MARKET_JITTER_SECONDS: "3"
+      DEMAND_RADAR_SECOND_PASS_COOLDOWN_SECONDS: "120"
+      DEMAND_RADAR_SECOND_PASS_MAX_MARKETS: "20"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements-demand-radar.txt
       - name: Install collector dependencies
         run: pip install -r scripts/requirements-demand-radar.txt
-
       - name: Validate required secrets
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || inputs.dry_run != true }}
+        if: ${{ github.event_name == 'schedule' || inputs.dry_run != true }}
         shell: bash
         run: |
           test -n "$DEMAND_RADAR_APP_URL" || { echo "DEMAND_RADAR_APP_URL is missing"; exit 1; }
           test -n "$INTERNAL_API_KEY" || { echo "INTERNAL_API_KEY is missing"; exit 1; }
-
       - name: Collect and ingest nationwide demand scores
         id: collect
         continue-on-error: true
@@ -72,8 +99,7 @@ jobs:
           if [[ "${{ inputs.dry_run || false }}" == "true" ]]; then
             args+=(--dry-run)
           fi
-          python scripts/collect_google_trends.py "${args[@]}"
-
+          python scripts/collect_google_trends_resilient.py "${args[@]}"
       - name: Evaluate collector result
         id: evaluate
         if: always()
@@ -95,23 +121,28 @@ jobs:
           status = run.get("status", "failed")
           errors = run.get("error_summary", []) or []
           messages = [str(item.get("error", "")) if isinstance(item, dict) else str(item) for item in errors]
-          upstream_429 = bool(messages) and all("code 429" in message for message in messages)
+          upstream_429 = bool(messages) and all("429" in message for message in messages)
+          coverage = 0.0
+          requested = int(run.get("markets_requested", 0) or 0)
+          succeeded = int(run.get("markets_succeeded", 0) or 0)
+          if requested:
+              coverage = succeeded / requested * 100
 
           output_path = os.environ.get("GITHUB_OUTPUT")
           if output_path:
               with open(output_path, "a", encoding="utf-8") as handle:
                   handle.write(f"degraded={'true' if upstream_429 else 'false'}\n")
+                  handle.write(f"coverage={coverage:.1f}\n")
 
           if status == "completed":
               sys.exit(0)
-          if upstream_429:
-              print("::warning::Google Trends rate-limited the hosted runner (HTTP 429). Data collection is degraded, but application health is unaffected.")
+          if status == "partial" and upstream_429 and succeeded > 0:
+              print(f"::warning::Google Trends rate limited part of the collection. Current run coverage: {coverage:.1f}%.")
               sys.exit(0)
 
-          print(f"Collector status is {status}; treating as a real pipeline failure", file=sys.stderr)
+          print(f"Collector status is {status}; treating as a pipeline failure", file=sys.stderr)
           sys.exit(1)
           PY
-
       - name: Publish run summary
         if: always()
         shell: bash
@@ -123,22 +154,26 @@ jobs:
           from pathlib import Path
           data = json.loads(Path("artifacts/demand-radar-run.json").read_text())
           run = data.get("run", {})
+          requested = int(run.get("markets_requested", 0) or 0)
+          succeeded = int(run.get("markets_succeeded", 0) or 0)
+          coverage = succeeded / requested * 100 if requested else 0
           print(f"- Status: **{run.get('status', 'unknown')}**")
           print(f"- Run ID: `{run.get('run_id', 'unknown')}`")
-          print(f"- Markets requested: {run.get('markets_requested', 0)}")
-          print(f"- Markets succeeded: {run.get('markets_succeeded', 0)}")
+          print(f"- Coverage: **{succeeded}/{requested} ({coverage:.1f}%)**")
           print(f"- Markets failed: {run.get('markets_failed', 0)}")
           print(f"- Rows: {len(data.get('rows', []))}")
           errors = run.get("error_summary", [])
           if errors:
-              print("\n### Errors")
-              for item in errors[:10]:
-                  print(f"- `{item}`")
+              print("\n### Unavailable markets")
+              for item in errors[:20]:
+                  if isinstance(item, dict):
+                      print(f"- {item.get('city', 'unknown')}, {item.get('state', '')}: {item.get('error', 'unknown error')}")
+                  else:
+                      print(f"- {item}")
           PY
           else
             echo "- Collector did not create an artifact." >> "$GITHUB_STEP_SUMMARY"
           fi
-
       - name: Upload collection logs
         if: always()
         uses: actions/upload-artifact@v4
@@ -147,15 +182,15 @@ jobs:
           path: artifacts/
           if-no-files-found: warn
           retention-days: 30
-
-      - name: Open or update upstream rate-limit alert
+      - name: Open or update upstream rate limit alert
         if: ${{ steps.evaluate.outputs.degraded == 'true' }}
         uses: actions/github-script@v7
         with:
           script: |
             const title = "Demand Radar upstream rate limiting";
             const marker = "<!-- demand-radar-upstream-rate-limit -->";
-            const body = `${marker}\nGoogle Trends returned HTTP 429 for the scheduled Demand Radar collection on ${new Date().toISOString()}. The application remains healthy, but fresh demand data was not available.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const coverage = "${{ steps.evaluate.outputs.coverage }}";
+            const body = `${marker}\nGoogle Trends returned HTTP 429 during the Demand Radar collection on ${new Date().toISOString()}. Current run coverage: ${coverage}%. The dashboard now isolates this run and clearly marks incomplete coverage.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: "open", per_page: 50 });
             const existing = data.find(issue => !issue.pull_request && issue.title === title);
             if (existing) {
@@ -163,7 +198,6 @@ jobs:
             } else {
               await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body });
             }
-
       - name: Open or update failure alert
         if: failure()
         uses: actions/github-script@v7
@@ -172,25 +206,10 @@ jobs:
             const title = "Demand Radar daily collection failure";
             const marker = "<!-- demand-radar-collector-alert -->";
             const body = `${marker}\nThe Demand Radar collector failed on ${new Date().toISOString()}.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\nWorkflow: \`${context.workflow}\`\nBranch: \`${context.ref}\`\n\nReview the uploaded logs and the Supabase \`demand_collection_runs\` record.`;
-            const { data } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 20,
-            });
+            const { data } = await github.rest.issues.listForRepo({ owner: context.repo.owner, repo: context.repo.repo, state: "open", per_page: 20 });
             const existing = data.find(issue => !issue.pull_request && issue.title === title);
             if (existing) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.number,
-                body,
-              });
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number, body });
             } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-              });
+              await github.rest.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body });
             }

--- a/scripts/collect_google_trends_resilient.py
+++ b/scripts/collect_google_trends_resilient.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Resilient nationwide runner for Demand Radar.
+
+Adds paced requests, jitter, a targeted second pass for HTTP 429 failures and a
+single run envelope so partial collections never masquerade as full snapshots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from collect_google_trends import (
+    ANCHOR,
+    METHOD,
+    SOURCE,
+    collect_market,
+    configure_logging,
+    load_markets,
+    post_payload,
+    trends_client,
+    write_artifact,
+)
+
+LOG = logging.getLogger("demand-radar-resilient")
+
+
+def parser() -> argparse.ArgumentParser:
+    value = argparse.ArgumentParser(description=__doc__)
+    value.add_argument("--config", type=Path, default=Path(__file__).with_name("demand_radar_markets_national.json"))
+    value.add_argument("--output", type=Path, default=Path("artifacts/demand-radar-run.json"))
+    value.add_argument("--log-file", type=Path, default=Path("artifacts/demand-radar.log"))
+    value.add_argument("--timeframe", default="today 3-m")
+    value.add_argument("--market-limit", type=int, default=0)
+    value.add_argument("--dry-run", action="store_true")
+    return value
+
+
+def is_rate_limited(error: object) -> bool:
+    message = str(error).lower()
+    return "429" in message or "too many requests" in message or "rate limit" in message
+
+
+def sleep_between(delay: float, jitter: float) -> None:
+    duration = delay + random.uniform(0.0, jitter)
+    if duration > 0:
+        time.sleep(duration)
+
+
+def collect_pass(
+    markets: list[dict[str, Any]],
+    timeframe: str,
+    run_id: str,
+    delay: float,
+    jitter: float,
+    label: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    rows: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    client = trends_client()
+    for index, market in enumerate(markets, start=1):
+        try:
+            LOG.info("%s %s/%s: %s, %s", label, index, len(markets), market["city"], market["state"])
+            rows.append(collect_market(client, market, timeframe, run_id))
+        except Exception as exc:
+            LOG.exception("%s failed for %s, %s", label, market["city"], market["state"])
+            errors.append({"city": market["city"], "state": market["state"], "error": str(exc)[:500]})
+            if is_rate_limited(exc):
+                client = trends_client()
+        if index < len(markets):
+            sleep_between(delay, jitter)
+    return rows, errors
+
+
+def main() -> int:
+    args = parser().parse_args()
+    configure_logging(args.log_file)
+    started = datetime.now(UTC)
+    run_id = str(uuid4())
+    rows: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    markets: list[dict[str, Any]] = []
+
+    try:
+        markets = load_markets(args.config)
+        if args.market_limit > 0:
+            markets = markets[: args.market_limit]
+        if not markets:
+            raise RuntimeError("No markets selected")
+
+        delay = max(float(os.getenv("DEMAND_RADAR_MARKET_DELAY_SECONDS", "6")), 0.0)
+        jitter = max(float(os.getenv("DEMAND_RADAR_MARKET_JITTER_SECONDS", "3")), 0.0)
+        cooldown = max(float(os.getenv("DEMAND_RADAR_SECOND_PASS_COOLDOWN_SECONDS", "120")), 0.0)
+        retry_cap = max(int(os.getenv("DEMAND_RADAR_SECOND_PASS_MAX_MARKETS", "20")), 0)
+
+        first_rows, first_errors = collect_pass(markets, args.timeframe, run_id, delay, jitter, "Primary pass")
+        rows.extend(first_rows)
+        errors = first_errors
+
+        rate_limited = [item for item in errors if is_rate_limited(item.get("error", ""))]
+        if rate_limited and 0 < len(errors) <= retry_cap:
+            LOG.warning("%s markets failed. Cooling down %.0fs before targeted retry.", len(errors), cooldown)
+            time.sleep(cooldown)
+            market_map = {(market["city"], market["state"]): market for market in markets}
+            retry_markets = [market_map[(item["city"], item["state"])] for item in errors if (item["city"], item["state"]) in market_map]
+            retry_rows, retry_errors = collect_pass(retry_markets, args.timeframe, run_id, delay, jitter, "Retry pass")
+            rows.extend(retry_rows)
+            errors = retry_errors
+
+        status = "completed" if rows and not errors else "partial" if rows else "failed"
+        completed = datetime.now(UTC)
+        payload = {
+            "run": {
+                "run_id": run_id,
+                "status": status,
+                "started_at": started.isoformat(),
+                "completed_at": completed.isoformat(),
+                "markets_requested": len(markets),
+                "markets_succeeded": len(rows),
+                "markets_failed": len(errors),
+                "error_summary": errors,
+                "metadata": {
+                    "anchor_keyword": ANCHOR,
+                    "timeframe": args.timeframe,
+                    "methodology_version": METHOD,
+                    "source": SOURCE,
+                    "dry_run": args.dry_run,
+                    "runner": "resilient-v1",
+                    "pacing": {
+                        "market_delay_seconds": delay,
+                        "market_jitter_seconds": jitter,
+                        "second_pass_cooldown_seconds": cooldown,
+                        "second_pass_max_markets": retry_cap,
+                    },
+                },
+            },
+            "rows": rows,
+        }
+
+        api_response = None
+        if not args.dry_run:
+            url = os.getenv("DEMAND_RADAR_APP_URL") or os.getenv("NEXT_PUBLIC_APP_URL") or ""
+            key = os.getenv("INTERNAL_API_KEY") or ""
+            if not url or not key:
+                raise RuntimeError("DEMAND_RADAR_APP_URL and INTERNAL_API_KEY are required")
+            api_response = post_payload(url, key, payload)
+
+        write_artifact(args.output, {**payload, "api_response": api_response})
+        return 0 if status == "completed" else 2
+    except Exception as exc:
+        LOG.exception("Demand Radar resilient run failed")
+        errors.append({"scope": "run", "error": str(exc)[:1000]})
+        payload = {
+            "run": {
+                "run_id": run_id,
+                "status": "failed",
+                "started_at": started.isoformat(),
+                "completed_at": datetime.now(UTC).isoformat(),
+                "markets_requested": len(markets),
+                "markets_succeeded": len(rows),
+                "markets_failed": max(len(errors), 1),
+                "error_summary": errors,
+                "metadata": {"methodology_version": METHOD, "source": SOURCE, "dry_run": args.dry_run, "runner": "resilient-v1"},
+            },
+            "rows": rows,
+        }
+        write_artifact(args.output, payload)
+        if not args.dry_run:
+            url = os.getenv("DEMAND_RADAR_APP_URL") or os.getenv("NEXT_PUBLIC_APP_URL") or ""
+            key = os.getenv("INTERNAL_API_KEY") or ""
+            if url and key:
+                try:
+                    post_payload(url, key, payload)
+                except Exception:
+                    LOG.exception("Failed to persist failed resilient run")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-db-contract.mjs
+++ b/scripts/validate-db-contract.mjs
@@ -8,6 +8,7 @@ const SCHEMA_PATH = path.join(ROOT, "supabase/PRODUCTION_SCHEMA_LOCK.sql");
 const SCHEMA_EXTENSION_PATHS = [
   path.join(ROOT, "supabase/migrations/20260806220000_harden_demand_radar.sql"),
   path.join(ROOT, "supabase/migrations/20260806230000_demand_radar_pipeline.sql"),
+  path.join(ROOT, "supabase/migrations/20260814184500_sync_profile_extras_contract.sql"),
 ];
 const SCAN_DIRS = ["src", "scripts", "tests", "supabase"];
 // Every .sql file that can define a database function. Unlike the table/column

--- a/src/app/_components/auth-forms.tsx
+++ b/src/app/_components/auth-forms.tsx
@@ -71,6 +71,7 @@ export function AuthForms({
   const { toast } = useToast();
   const { signIn, signUp } = useAuth();
   const [fullName, setFullName] = useState("");
+  const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -117,7 +118,7 @@ export function AuthForms({
 
     const result = isLogin
       ? await signIn(email.trim(), password)
-      : await signUp(email.trim(), password, fullName.trim());
+      : await signUp(email.trim(), password, fullName.trim(), phone.trim());
 
     setLoading(false);
 
@@ -243,16 +244,31 @@ export function AuthForms({
         )}
         <form onSubmit={onSubmit} className="space-y-3">
           {!isLogin ? (
-            <AppInput
-              aria-label="Full name"
-              placeholder="Full name"
-              value={fullName}
-              onChange={(event) => setFullName(event.target.value)}
-              minLength={2}
-              maxLength={120}
-              required
-              disabled={loading}
-            />
+            <>
+              <AppInput
+                aria-label="Full name"
+                placeholder="Full name"
+                value={fullName}
+                onChange={(event) => setFullName(event.target.value)}
+                minLength={2}
+                maxLength={120}
+                autoComplete="name"
+                required
+                disabled={loading}
+              />
+              <AppInput
+                type="tel"
+                inputMode="tel"
+                aria-label="Phone number"
+                placeholder="Phone number"
+                value={phone}
+                onChange={(event) => setPhone(event.target.value)}
+                autoComplete="tel"
+                maxLength={40}
+                required
+                disabled={loading}
+              />
+            </>
           ) : null}
           <AppInput
             type="email"

--- a/src/app/api/pro/demand-radar/route.ts
+++ b/src/app/api/pro/demand-radar/route.ts
@@ -1,44 +1,272 @@
 import { errorResponse, json, RouteError } from "@/app/api/_lib/http";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { requireRequestSession } from "@/app/api/_lib/session";
-import { getDemandFreshness, getOpportunityScore, rankDemandRecords, type DemandScoreRecord } from "@/lib/demand-radar";
+import {
+  getCompetitionSignalStatus,
+  getDemandFreshness,
+  getMarketPercentile,
+  getOpportunityScore,
+  rankDemandRecords,
+  type CompetitionSignalStatus,
+  type DemandScoreRecord,
+} from "@/lib/demand-radar";
 
 type Db = { from: (table: string) => any };
 
+type CollectionRunRecord = {
+  run_id: string;
+  status: "completed" | "partial";
+  started_at: string;
+  completed_at: string | null;
+  markets_requested: number;
+  markets_succeeded: number;
+  markets_failed: number;
+  rows_ingested: number;
+  error_summary: unknown;
+  metadata: Record<string, unknown> | null;
+};
+
+type FailedMarket = { city: string; state: string; reason: "upstream_rate_limit" | "collection_error" };
+
+const SCORE_SELECT = "id,city,state,neighborhood,score,trend,spike_score,search_volume_index,competition_index,confidence,source,week_start,collected_at,expires_at,run_id,methodology_version,baseline_index,growth_pct,velocity_score,persistence_score,sample_size,score_components";
+
 function toPreviewRow(row: DemandScoreRecord) {
-  return { id: row.id, city: row.city, state: row.state, neighborhood: null, score: row.score, trend: row.trend, spike_score: row.spike_score, week_start: row.week_start, collected_at: row.collected_at };
+  return {
+    id: row.id,
+    city: row.city,
+    state: row.state,
+    neighborhood: null,
+    score: row.score,
+    trend: row.trend,
+    spike_score: row.spike_score,
+    week_start: row.week_start,
+    collected_at: row.collected_at,
+    growth_pct: row.growth_pct ?? null,
+    run_id: row.run_id ?? null,
+  };
+}
+
+function toFullRow(row: DemandScoreRecord, competitionStatus: CompetitionSignalStatus) {
+  return {
+    ...row,
+    opportunity_score: competitionStatus === "reliable" ? getOpportunityScore(row) : null,
+  };
+}
+
+function normalize(value: unknown) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function sameMarket(row: Pick<DemandScoreRecord, "city" | "state">, city: string, state: string) {
+  return normalize(row.city) === normalize(city) && String(row.state ?? "").trim().toUpperCase() === String(state ?? "").trim().toUpperCase();
+}
+
+function safeFailedMarkets(value: unknown): FailedMarket[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    const city = String(record.city ?? "").trim();
+    const state = String(record.state ?? "").trim().toUpperCase();
+    if (!city || state.length !== 2) return [];
+    const error = String(record.error ?? "");
+    return [{ city, state, reason: error.includes("429") ? "upstream_rate_limit" : "collection_error" } as FailedMarket];
+  });
+}
+
+function dateWeeksAgo(weeks: number) {
+  const value = new Date();
+  value.setUTCDate(value.getUTCDate() - weeks * 7);
+  return value.toISOString().slice(0, 10);
+}
+
+function mostRecent(rows: DemandScoreRecord[]) {
+  return [...rows].sort((a, b) => String(b.collected_at ?? "").localeCompare(String(a.collected_at ?? "")))[0] ?? null;
+}
+
+function uniqueLocalHistory(rows: DemandScoreRecord[], city: string, state: string, currentWeek: string | null, current: DemandScoreRecord | null) {
+  const byWeek = new Map<string, DemandScoreRecord>();
+  for (const row of rows) {
+    if (!sameMarket(row, city, state) || (currentWeek && row.week_start === currentWeek)) continue;
+    const existing = byWeek.get(row.week_start);
+    if (!existing || String(row.collected_at ?? "") > String(existing.collected_at ?? "")) byWeek.set(row.week_start, row);
+  }
+  if (current) byWeek.set(current.week_start, current);
+  return [...byWeek.values()].sort((a, b) => a.week_start.localeCompare(b.week_start)).slice(-12);
 }
 
 export async function GET(request: Request) {
   try {
     const session = await requireRequestSession(request);
     const db = createSupabaseAdminClient() as unknown as Db;
-    const { data: profile, error: profileError } = await db.from("profiles").select("id,city,state,subscription_tier").eq("user_id", session.userId).maybeSingle();
+    const { data: profile, error: profileError } = await db
+      .from("profiles")
+      .select("id,city,state,subscription_tier")
+      .eq("user_id", session.userId)
+      .maybeSingle();
     if (profileError) throw new RouteError(500, profileError.message);
     if (!profile) throw new RouteError(404, "Provider profile not found.");
 
     const tier = String(profile.subscription_tier ?? "free").toLowerCase();
     const hasFullAccess = tier === "elite" || session.role === "admin";
-    const { data, error } = await db.from("demand_scores")
-      .select("id,city,state,neighborhood,score,trend,spike_score,search_volume_index,competition_index,confidence,source,week_start,collected_at,expires_at")
-      .eq("is_sample", false).order("week_start", { ascending: false }).order("score", { ascending: false }).limit(500);
-    if (error) throw new RouteError(500, error.message);
 
-    const allRows = (data ?? []) as DemandScoreRecord[];
-    const latestWeek = allRows[0]?.week_start ?? null;
-    const latestRows = latestWeek ? allRows.filter((row) => row.week_start === latestWeek) : [];
-    const ranked = rankDemandRecords(latestRows);
-    const currentCity = String(profile.city ?? "").trim().toLowerCase();
+    const { data: latestRunRaw, error: runError } = await db
+      .from("demand_collection_runs")
+      .select("run_id,status,started_at,completed_at,markets_requested,markets_succeeded,markets_failed,rows_ingested,error_summary,metadata")
+      .in("status", ["completed", "partial"])
+      .order("completed_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (runError) throw new RouteError(500, runError.message);
+
+    const latestRun = (latestRunRaw ?? null) as CollectionRunRecord | null;
+    if (!latestRun) {
+      return json({
+        ok: true,
+        access: { tier, full: hasFullAccess, preview: !hasFullAccess },
+        collection: { status: "unknown", runId: null, coveragePct: 0, marketsRequested: 0, marketsSucceeded: 0, marketsFailed: 0, rowsIngested: 0, completedAt: null, failedMarkets: [] },
+        market: { city: profile.city ?? null, state: profile.state ?? null, weekStart: null, freshness: "unknown", collectedAt: null },
+        local: [],
+        localFallback: null,
+        localHistory: [],
+        opportunities: [],
+        fastestRising: [],
+        highestDemand: [],
+        insights: null,
+        methodology: { version: null, source: null, competitionStatus: "unavailable", opportunityStatus: "unavailable" },
+        disclaimer: "Demand Radar shows relative market signals. Scores do not guarantee searches, inquiries, contacts, or revenue.",
+      });
+    }
+
+    const { data: currentData, error: currentError } = await db
+      .from("demand_scores")
+      .select(SCORE_SELECT)
+      .eq("is_sample", false)
+      .eq("run_id", latestRun.run_id)
+      .limit(500);
+    if (currentError) throw new RouteError(500, currentError.message);
+
+    const currentRows = (currentData ?? []) as DemandScoreRecord[];
+    const methodologyVersion = typeof latestRun.metadata?.methodology_version === "string" ? latestRun.metadata.methodology_version : currentRows[0]?.methodology_version ?? null;
+
+    let historyQuery = db
+      .from("demand_scores")
+      .select(SCORE_SELECT)
+      .eq("is_sample", false)
+      .gte("week_start", dateWeeksAgo(13))
+      .order("week_start", { ascending: false })
+      .order("collected_at", { ascending: false })
+      .limit(1000);
+    if (methodologyVersion) historyQuery = historyQuery.eq("methodology_version", methodologyVersion);
+    const { data: historyData, error: historyError } = await historyQuery;
+    if (historyError) throw new RouteError(500, historyError.message);
+
+    const historyRows = (historyData ?? []) as DemandScoreRecord[];
+    const competitionStatus = getCompetitionSignalStatus(currentRows);
+    const ranked = rankDemandRecords(currentRows, { useOpportunity: competitionStatus === "reliable" });
+    const currentCity = String(profile.city ?? "").trim();
     const currentState = String(profile.state ?? "").trim().toUpperCase();
-    const localRows = ranked.filter((row) => row.city.trim().toLowerCase() === currentCity && row.state.trim().toUpperCase() === currentState);
-    const freshestCollectedAt = ranked.map((row) => row.collected_at).filter((value): value is string => Boolean(value)).sort().at(-1) ?? null;
-    const market = { city: profile.city ?? null, state: profile.state ?? null, weekStart: latestWeek, freshness: getDemandFreshness(freshestCollectedAt), collectedAt: freshestCollectedAt };
+    const localRows = ranked.filter((row) => sameMarket(row, currentCity, currentState));
+    const localPrimary = localRows.find((row) => !row.neighborhood) ?? localRows[0] ?? null;
+    const currentWeek = currentRows.map((row) => row.week_start).sort().at(-1) ?? null;
 
-    if (!hasFullAccess) return json({ ok: true, access: { tier, full: false, preview: true }, market, local: localRows.slice(0, 1).map(toPreviewRow), opportunities: ranked.slice(0, 3).map(toPreviewRow), disclaimer: "Demand Radar Preview shows relative market signals. Scores do not guarantee searches, inquiries, contacts, or revenue." });
+    const previousWeek = historyRows
+      .map((row) => row.week_start)
+      .filter((week) => !currentWeek || week < currentWeek)
+      .sort()
+      .at(-1) ?? null;
+    const previousRows = previousWeek ? historyRows.filter((row) => row.week_start === previousWeek) : [];
+    const previousCompetitionStatus = getCompetitionSignalStatus(previousRows);
+    const previousRanked = rankDemandRecords(previousRows, { useOpportunity: previousCompetitionStatus === "reliable" });
+    const previousLocal = previousRanked.find((row) => sameMarket(row, currentCity, currentState)) ?? null;
 
-    return json({ ok: true, access: { tier, full: true, preview: false }, market,
-      local: localRows.map((row) => ({ ...row, opportunity_score: getOpportunityScore(row) })),
-      opportunities: ranked.slice(0, 20).map((row) => ({ ...row, opportunity_score: getOpportunityScore(row) })),
-      disclaimer: "Demand Radar shows relative market signals. Scores do not guarantee searches, inquiries, contacts, or revenue." });
-  } catch (error) { return errorResponse(error); }
+    const currentRank = localPrimary ? ranked.findIndex((row) => row.id === localPrimary.id) + 1 : null;
+    const previousRank = previousLocal ? previousRanked.findIndex((row) => row.id === previousLocal.id) + 1 : null;
+    const localHistory = uniqueLocalHistory(historyRows, currentCity, currentState, currentWeek, localPrimary);
+    const lastKnown = mostRecent(historyRows.filter((row) => sameMarket(row, currentCity, currentState)));
+    const localFallback = !localPrimary && lastKnown ? lastKnown : null;
+
+    const fastestRising = [...currentRows].sort((a, b) => {
+      const growth = (b.growth_pct ?? Number.NEGATIVE_INFINITY) - (a.growth_pct ?? Number.NEGATIVE_INFINITY);
+      if (Number.isFinite(growth) && growth !== 0) return growth;
+      if ((b.spike_score ?? 0) !== (a.spike_score ?? 0)) return (b.spike_score ?? 0) - (a.spike_score ?? 0);
+      return b.score - a.score;
+    });
+    const highestDemand = [...currentRows].sort((a, b) => b.score - a.score || (b.spike_score ?? 0) - (a.spike_score ?? 0));
+
+    const completedAt = latestRun.completed_at ?? latestRun.started_at;
+    const coveragePct = latestRun.markets_requested > 0 ? Math.round((latestRun.markets_succeeded / latestRun.markets_requested) * 1000) / 10 : 0;
+    const market = {
+      city: profile.city ?? null,
+      state: profile.state ?? null,
+      weekStart: currentWeek,
+      freshness: getDemandFreshness(completedAt),
+      collectedAt: completedAt,
+    };
+    const insights = localPrimary ? {
+      rank: currentRank,
+      totalMarkets: ranked.length,
+      percentile: currentRank ? getMarketPercentile(currentRank, ranked.length) : null,
+      previousRank,
+      rankChange: currentRank && previousRank ? previousRank - currentRank : null,
+      demandChange: previousLocal ? localPrimary.score - previousLocal.score : null,
+      spikeChange: previousLocal ? (localPrimary.spike_score ?? 0) - (previousLocal.spike_score ?? 0) : null,
+      growthPct: localPrimary.growth_pct ?? null,
+      previousWeek,
+    } : null;
+    const collection = {
+      status: latestRun.status,
+      runId: latestRun.run_id,
+      coveragePct,
+      marketsRequested: latestRun.markets_requested,
+      marketsSucceeded: latestRun.markets_succeeded,
+      marketsFailed: latestRun.markets_failed,
+      rowsIngested: latestRun.rows_ingested,
+      completedAt: latestRun.completed_at,
+      failedMarkets: safeFailedMarkets(latestRun.error_summary),
+    };
+    const source = typeof latestRun.metadata?.source === "string" ? latestRun.metadata.source : currentRows[0]?.source ?? null;
+    const methodology = {
+      version: methodologyVersion,
+      source,
+      competitionStatus,
+      opportunityStatus: competitionStatus === "reliable" ? "reliable" : competitionStatus === "experimental" ? "experimental" : "unavailable",
+    };
+
+    if (!hasFullAccess) {
+      return json({
+        ok: true,
+        access: { tier, full: false, preview: true },
+        collection,
+        market,
+        local: localRows.slice(0, 1).map(toPreviewRow),
+        localFallback: localFallback ? toPreviewRow(localFallback) : null,
+        localHistory: localHistory.map(toPreviewRow),
+        opportunities: ranked.slice(0, 3).map(toPreviewRow),
+        fastestRising: fastestRising.slice(0, 3).map(toPreviewRow),
+        highestDemand: highestDemand.slice(0, 3).map(toPreviewRow),
+        insights,
+        methodology,
+        disclaimer: "Demand Radar Preview shows relative market signals. Scores do not guarantee searches, inquiries, contacts, or revenue.",
+      });
+    }
+
+    return json({
+      ok: true,
+      access: { tier, full: true, preview: false },
+      collection,
+      market,
+      local: localRows.map((row) => toFullRow(row, competitionStatus)),
+      localFallback: localFallback ? toFullRow(localFallback, competitionStatus) : null,
+      localHistory: localHistory.map((row) => toFullRow(row, competitionStatus)),
+      opportunities: ranked.slice(0, 20).map((row) => toFullRow(row, competitionStatus)),
+      fastestRising: fastestRising.slice(0, 20).map((row) => toFullRow(row, competitionStatus)),
+      highestDemand: highestDemand.slice(0, 20).map((row) => toFullRow(row, competitionStatus)),
+      insights,
+      methodology,
+      disclaimer: "Demand Radar shows relative Google Trends market signals. Scores are directional intelligence, not absolute search volume, booking forecasts, or guaranteed revenue.",
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
 }

--- a/src/app/pro/demand-radar/page.tsx
+++ b/src/app/pro/demand-radar/page.tsx
@@ -2,35 +2,406 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { ArrowUpRight, Bell, CalendarDays, Loader2, LockKeyhole, MapPin, Radar, RefreshCw, TrendingUp, Zap } from "lucide-react";
-import { formatUsDate, getDemandLabel, getSpikeLabel, getSpikeWindow, type DataFreshness, type DemandTrend } from "@/lib/demand-radar";
+import {
+  Activity,
+  AlertTriangle,
+  ArrowDownRight,
+  ArrowUpRight,
+  BarChart3,
+  Bell,
+  CalendarDays,
+  Database,
+  Loader2,
+  LockKeyhole,
+  MapPin,
+  Radar,
+  RefreshCw,
+  ShieldCheck,
+  TrendingUp,
+  Zap,
+} from "lucide-react";
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  formatUsDate,
+  getDemandLabel,
+  getMarketSignalStatus,
+  getSpikeLabel,
+  getSpikeWindow,
+  type DataFreshness,
+  type DemandTrend,
+} from "@/lib/demand-radar";
 
-type RadarRow = { id:string; city:string; state:string; neighborhood:string|null; score:number; trend:DemandTrend; spike_score?:number|null; week_start:string; collected_at:string|null; search_volume_index?:number; competition_index?:number; confidence?:number|null; source?:string|null; opportunity_score?:number };
-type RadarResponse = { ok:boolean; access:{tier:string;full:boolean;preview:boolean}; market:{city:string|null;state:string|null;weekStart:string|null;freshness:DataFreshness;collectedAt:string|null}; local:RadarRow[]; opportunities:RadarRow[]; disclaimer:string; error?:string };
-const freshnessCopy:Record<DataFreshness,string>={fresh:"Fresh data",delayed:"Delayed data",stale:"Stale data",unknown:"Awaiting data"};
-function trendCopy(t:DemandTrend){return t==="rising"?"Rising":t==="falling"?"Falling":"Stable"}
-function ScoreCard({label,value,detail}:{label:string;value:string|number;detail:string}){return <div className="rounded-2xl border border-[#E8DFD8] bg-white p-5 shadow-sm"><p className="text-xs font-semibold uppercase tracking-[0.14em] text-[#81766F]">{label}</p><p className="mt-3 font-display text-3xl font-semibold text-[#211C19]">{value}</p><p className="mt-1 text-xs text-[#756C66]">{detail}</p></div>}
-function UpgradeCard(){return <div className="rounded-3xl border border-[#E4D8D1] bg-[#FCF8F5] p-6 shadow-sm"><div className="flex items-start gap-4"><div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-[#F9EDEE] text-[#8B1E2D]"><LockKeyhole className="h-5 w-5"/></div><div><p className="text-xs font-bold uppercase tracking-[0.14em] text-[#8B1E2D]">Elite intelligence</p><h2 className="mt-1 font-display text-xl font-semibold">Unlock the full Demand Radar</h2><p className="mt-2 text-sm text-[#716862]">See spike intensity, timing, opportunity, competition, confidence and full market rankings.</p><Link href="/pro/subscription" className="mt-4 inline-flex items-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-sm font-semibold text-white">View Elite plan <ArrowUpRight className="h-4 w-4"/></Link></div></div></div>}
+type RadarRow = {
+  id: string;
+  city: string;
+  state: string;
+  neighborhood: string | null;
+  score: number;
+  trend: DemandTrend;
+  spike_score?: number | null;
+  week_start: string;
+  collected_at: string | null;
+  search_volume_index?: number;
+  competition_index?: number | null;
+  confidence?: number | null;
+  source?: string | null;
+  opportunity_score?: number | null;
+  growth_pct?: number | null;
+  run_id?: string | null;
+};
 
-export default function DemandRadarPage(){
- const [data,setData]=useState<RadarResponse|null>(null); const [loading,setLoading]=useState(true); const [error,setError]=useState<string|null>(null);
- async function load(){setLoading(true);setError(null);try{const r=await fetch("/api/pro/demand-radar",{cache:"no-store"});const p=await r.json() as RadarResponse;if(!r.ok){setData(p);setError(p.error??"Demand Radar could not be loaded.");return}setData(p)}catch{setError("Demand Radar could not be loaded.")}finally{setLoading(false)}}
- useEffect(()=>{void load()},[]); const localPrimary=useMemo(()=>data?.local.find(r=>!r.neighborhood)??data?.local[0]??null,[data]);
- if(loading)return <div className="flex min-h-[60vh] items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-[#8B1E2D]"/></div>;
- if(error||!data)return <div className="mx-auto max-w-3xl p-8"><div className="rounded-2xl border border-rose-200 bg-rose-50 p-6"><p className="font-semibold text-rose-900">Demand Radar unavailable</p><p className="mt-1 text-sm text-rose-700">{error}</p><button onClick={()=>void load()} className="mt-4 inline-flex items-center gap-2 text-sm font-semibold"><RefreshCw className="h-4 w-4"/>Retry</button></div></div>;
- const isPreview=data.access.preview&&!data.access.full;
- const bestSignal=(localPrimary??data.opportunities[0]??null); const bestWindow=bestSignal?getSpikeWindow(bestSignal):null;
- return <div className="mx-auto max-w-6xl space-y-6 p-4 pb-24 md:p-8">
-  <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between"><div><div className="flex items-center gap-2 text-[#8B1E2D]"><Radar className="h-5 w-5"/><span className="text-xs font-bold uppercase tracking-[0.16em]">{isPreview?"Market Intelligence Preview":"Elite Market Intelligence"}</span></div><h1 className="mt-2 font-display text-3xl font-semibold">Demand Radar</h1><p className="mt-2 max-w-2xl text-sm text-[#716862]">Know where demand is accelerating, when the signal is strongest, and what to do next.</p></div><button onClick={()=>void load()} className="inline-flex items-center gap-2 rounded-xl border bg-white px-4 py-2.5 text-sm font-semibold"><RefreshCw className="h-4 w-4"/>Refresh</button></header>
+type CollectionHealth = {
+  status: "completed" | "partial" | "unknown";
+  runId: string | null;
+  coveragePct: number;
+  marketsRequested: number;
+  marketsSucceeded: number;
+  marketsFailed: number;
+  rowsIngested: number;
+  completedAt: string | null;
+  failedMarkets: Array<{ city: string; state: string; reason: "upstream_rate_limit" | "collection_error" }>;
+};
 
-  <div className="rounded-2xl border bg-[#FCF8F5] px-4 py-3 text-xs text-[#6D625B]">{freshnessCopy[data.market.freshness]}{data.market.collectedAt?` · Updated ${formatUsDate(data.market.collectedAt)}`:""}{data.market.weekStart?` · Week of ${formatUsDate(data.market.weekStart)}`:""}</div>
+type RadarInsights = {
+  rank: number | null;
+  totalMarkets: number;
+  percentile: number | null;
+  previousRank: number | null;
+  rankChange: number | null;
+  demandChange: number | null;
+  spikeChange: number | null;
+  growthPct: number | null;
+  previousWeek: string | null;
+};
 
-  {bestSignal&&bestWindow?<section className="rounded-3xl border border-[#E4D8D1] bg-white p-6 shadow-sm"><div className="flex items-center gap-2 text-[#8B1E2D]"><TrendingUp className="h-5 w-5"/><p className="text-xs font-bold uppercase tracking-[0.14em]">Your clearest signal</p></div><div className="mt-5 grid gap-4 md:grid-cols-3"><div className="rounded-2xl bg-[#FCF8F5] p-5"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#81766F]"><MapPin className="h-4 w-4"/>Where</div><p className="mt-3 font-display text-2xl font-semibold">{bestSignal.city}, {bestSignal.state}</p></div><div className="rounded-2xl bg-[#FCF8F5] p-5"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#81766F]"><CalendarDays className="h-4 w-4"/>When</div><p className="mt-3 text-lg font-semibold">{bestWindow.start&&bestWindow.end?`${formatUsDate(bestWindow.start)} – ${formatUsDate(bestWindow.end)}`:"No confirmed window"}</p><p className="mt-1 text-xs text-[#756C66]">{bestWindow.label}</p></div><div className="rounded-2xl bg-[#FCF8F5] p-5"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#81766F]"><Zap className="h-4 w-4"/>Signal</div><p className="mt-3 font-display text-2xl font-semibold">{getSpikeLabel(bestSignal.spike_score)}</p><p className="mt-1 text-xs text-[#756C66]">Spike {bestSignal.spike_score??"—"}/100 · Confidence {bestSignal.confidence??"—"}/100</p></div></div><div className="mt-4 rounded-2xl border border-[#E9E0DA] p-4 text-sm text-[#5F5650]"><strong>What to do:</strong> {bestWindow.action}</div>{!isPreview&&bestWindow.status==="active"?<div className="mt-4 flex items-center gap-2 text-xs text-[#6D625B]"><Bell className="h-4 w-4 text-[#8B1E2D]"/>Email alerts are sent when a confirmed high-confidence spike is detected in your profile city and market-insight emails are enabled.</div>:null}</section>:null}
+type RadarResponse = {
+  ok: boolean;
+  access: { tier: string; full: boolean; preview: boolean };
+  collection: CollectionHealth;
+  market: { city: string | null; state: string | null; weekStart: string | null; freshness: DataFreshness; collectedAt: string | null };
+  local: RadarRow[];
+  localFallback: RadarRow | null;
+  localHistory: RadarRow[];
+  opportunities: RadarRow[];
+  fastestRising: RadarRow[];
+  highestDemand: RadarRow[];
+  insights: RadarInsights | null;
+  methodology: { version: string | null; source: string | null; competitionStatus: "reliable" | "experimental" | "unavailable"; opportunityStatus: "reliable" | "experimental" | "unavailable" };
+  disclaimer: string;
+  error?: string;
+};
 
-  {localPrimary?<section className="space-y-4"><div className="flex items-center gap-2"><MapPin className="h-4 w-4 text-[#8B1E2D]"/><h2 className="font-display text-xl font-semibold">Your market: {localPrimary.city}, {localPrimary.state}</h2></div>{isPreview?<div className="grid gap-4 sm:grid-cols-3"><ScoreCard label="Demand" value={getDemandLabel(localPrimary.score)} detail={`${localPrimary.score}/100`}/><ScoreCard label="Spike" value={getSpikeLabel(localPrimary.spike_score)} detail={localPrimary.spike_score==null?"Awaiting baseline":`${localPrimary.spike_score}/100 acceleration`}/><ScoreCard label="Trend" value={trendCopy(localPrimary.trend)} detail="Direction versus recent baseline"/></div>:<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5"><ScoreCard label="Demand" value={localPrimary.score} detail={getDemandLabel(localPrimary.score)}/><ScoreCard label="Spike" value={localPrimary.spike_score??"—"} detail={getSpikeLabel(localPrimary.spike_score)}/><ScoreCard label="Opportunity" value={localPrimary.opportunity_score??"—"} detail="Demand adjusted for competition"/><ScoreCard label="Competition" value={localPrimary.competition_index??"—"} detail="Lower can mean more room"/><ScoreCard label="Confidence" value={localPrimary.confidence??"—"} detail={trendCopy(localPrimary.trend)}/></div>}</section>:null}
-  {isPreview?<UpgradeCard/>:null}
+type RankingView = "opportunity" | "rising" | "demand";
 
-  <section className="rounded-3xl border bg-white shadow-sm"><div className="flex items-center gap-3 border-b px-6 py-5"><Radar className="h-5 w-5 text-[#8B1E2D]"/><div><h2 className="font-display text-lg font-semibold">{isPreview?"Market preview":"Where spikes are happening"}</h2><p className="text-xs text-[#756C66]">Markets ranked by opportunity with a simple 7-day signal window</p></div></div>{data.opportunities.length===0?<div className="p-8 text-center text-sm">No live demand data has been ingested yet.</div>:<div className="divide-y">{data.opportunities.map((row,i)=>{const window=getSpikeWindow(row);return <div key={row.id} className="grid gap-4 px-6 py-4 md:grid-cols-[44px_1.4fr_repeat(3,minmax(110px,1fr))] md:items-center"><div className="font-display text-lg text-[#A59A92]">{i+1}</div><div><p className="font-semibold">{row.city}, {row.state}</p><p className="mt-1 text-xs text-[#7A716B]">{trendCopy(row.trend)} · {getSpikeLabel(row.spike_score)}</p></div><div><p className="text-xs text-[#8A817B]">When</p><p className="text-sm font-semibold">{window.start&&window.end?`${formatUsDate(window.start)} – ${formatUsDate(window.end)}`:"No confirmed window"}</p></div><div><p className="text-xs text-[#8A817B]">Demand</p><p className="font-semibold">{isPreview?getDemandLabel(row.score):`${row.score}/100`}</p></div><div><p className="text-xs text-[#8A817B]">Spike / Confidence</p><p className="font-semibold">{isPreview?getSpikeLabel(row.spike_score):`${row.spike_score??"—"} / ${row.confidence??"—"}`}</p></div></div>})}</div>}</section>
-  <p className="text-xs leading-5 text-[#7B726C]">{data.disclaimer} Spike windows describe current acceleration observed in fresh market data; they are statistical signals, not guaranteed future bookings or exact search volumes.</p>
- </div>
+const freshnessCopy: Record<DataFreshness, string> = {
+  fresh: "Fresh data",
+  delayed: "Delayed data",
+  stale: "Stale data",
+  unknown: "Awaiting data",
+};
+
+function trendCopy(trend: DemandTrend) {
+  return trend === "rising" ? "Rising" : trend === "falling" ? "Falling" : "Stable";
+}
+
+function shortDate(value: string) {
+  const parsed = new Date(`${value}T12:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" }).format(parsed);
+}
+
+function signed(value: number | null | undefined, suffix = "") {
+  if (value == null) return "—";
+  return `${value > 0 ? "+" : ""}${value}${suffix}`;
+}
+
+function signalCopy(row: RadarRow) {
+  const status = getMarketSignalStatus({ trend: row.trend, spike_score: row.spike_score ?? null, confidence: row.confidence ?? null });
+  return status === "spiking" ? "SPIKING" : status === "accelerating" ? "ACCELERATING" : status === "building" ? "BUILDING" : "NORMAL";
+}
+
+function Delta({ value, suffix = "" }: { value: number | null | undefined; suffix?: string }) {
+  if (value == null || value === 0) return <span className="text-xs text-[#81766F]">No material change</span>;
+  const positive = value > 0;
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs font-semibold ${positive ? "text-emerald-700" : "text-rose-700"}`}>
+      {positive ? <ArrowUpRight className="h-3.5 w-3.5" /> : <ArrowDownRight className="h-3.5 w-3.5" />}
+      {signed(value, suffix)}
+    </span>
+  );
+}
+
+function ScoreCard({ label, value, detail, delta, deltaSuffix }: { label: string; value: string | number; detail: string; delta?: number | null; deltaSuffix?: string }) {
+  return (
+    <div className="rounded-2xl border border-[#E8DFD8] bg-white p-5 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[#81766F]">{label}</p>
+      <p className="mt-3 font-display text-3xl font-semibold text-[#211C19]">{value}</p>
+      <div className="mt-1 flex min-h-5 items-center justify-between gap-2">
+        <p className="text-xs text-[#756C66]">{detail}</p>
+        {delta !== undefined ? <Delta value={delta} suffix={deltaSuffix} /> : null}
+      </div>
+    </div>
+  );
+}
+
+function UpgradeCard() {
+  return (
+    <div className="rounded-3xl border border-[#E4D8D1] bg-[#FCF8F5] p-6 shadow-sm">
+      <div className="flex items-start gap-4">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-[#F9EDEE] text-[#8B1E2D]"><LockKeyhole className="h-5 w-5" /></div>
+        <div>
+          <p className="text-xs font-bold uppercase tracking-[0.14em] text-[#8B1E2D]">Elite intelligence</p>
+          <h2 className="mt-1 font-display text-xl font-semibold">Unlock the full Demand Radar</h2>
+          <p className="mt-2 text-sm text-[#716862]">See full rankings, market acceleration, competition quality, confidence and 12 week intelligence.</p>
+          <Link href="/pro/subscription" className="mt-4 inline-flex items-center gap-2 rounded-xl bg-[#8B1E2D] px-4 py-2.5 text-sm font-semibold text-white">View Elite plan <ArrowUpRight className="h-4 w-4" /></Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TrendPanel({ rows }: { rows: RadarRow[] }) {
+  const chart = rows.map((row) => ({ week: shortDate(row.week_start), Demand: row.score, Spike: row.spike_score ?? 0 }));
+  return (
+    <section className="rounded-3xl border border-[#E8DFD8] bg-white p-5 shadow-sm md:p-6">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-[#8B1E2D]"><BarChart3 className="h-4 w-4" /><p className="text-xs font-bold uppercase tracking-[0.14em]">12 week trend</p></div>
+          <h2 className="mt-2 font-display text-xl font-semibold">Demand and acceleration over time</h2>
+        </div>
+        <p className="text-xs text-[#81766F]">Relative index · 0 to 100</p>
+      </div>
+      {chart.length < 2 ? (
+        <div className="mt-5 rounded-2xl bg-[#FCF8F5] p-6 text-sm text-[#716862]">Historical trend will become more useful as additional weekly collections accumulate.</div>
+      ) : (
+        <div className="mt-5 h-72 w-full" aria-label="Demand and spike score trend chart">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chart} margin={{ top: 8, right: 10, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="week" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+              <YAxis domain={[0, 100]} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+              <Tooltip />
+              <Line type="monotone" dataKey="Demand" stroke="#8B1E2D" strokeWidth={3} dot={{ r: 3 }} activeDot={{ r: 5 }} />
+              <Line type="monotone" dataKey="Spike" stroke="#A59A92" strokeWidth={2} strokeDasharray="5 5" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RankingRows({ rows, preview, view }: { rows: RadarRow[]; preview: boolean; view: RankingView }) {
+  if (rows.length === 0) return <div className="p-8 text-center text-sm text-[#716862]">No current markets are available for this view.</div>;
+  return (
+    <div className="divide-y">
+      {rows.map((row, index) => {
+        const window = getSpikeWindow(row);
+        return (
+          <div key={`${view}-${row.id}`} className="grid gap-4 px-5 py-4 md:grid-cols-[44px_1.4fr_repeat(3,minmax(110px,1fr))] md:items-center md:px-6">
+            <div className="font-display text-lg text-[#A59A92]">{index + 1}</div>
+            <div>
+              <p className="font-semibold">{row.city}, {row.state}</p>
+              <p className="mt-1 text-xs text-[#7A716B]">{trendCopy(row.trend)} · {getSpikeLabel(row.spike_score)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-[#8A817B]">Demand</p>
+              <p className="font-semibold">{preview ? getDemandLabel(row.score) : `${row.score}/100`}</p>
+            </div>
+            <div>
+              <p className="text-xs text-[#8A817B]">Movement</p>
+              <p className="font-semibold">{row.growth_pct == null ? trendCopy(row.trend) : signed(Math.round(row.growth_pct), "%")}</p>
+            </div>
+            <div>
+              <p className="text-xs text-[#8A817B]">Signal</p>
+              <p className="font-semibold">{preview ? getSpikeLabel(row.spike_score) : `${row.spike_score ?? "—"} spike · ${row.confidence ?? "—"} conf.`}</p>
+              {window.status !== "normal" ? <p className="mt-1 text-[11px] text-[#8B1E2D]">7 day window active</p> : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function DemandRadarPage() {
+  const [data, setData] = useState<RadarResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [rankingView, setRankingView] = useState<RankingView>("opportunity");
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/pro/demand-radar", { cache: "no-store" });
+      const payload = await response.json() as RadarResponse;
+      if (!response.ok) {
+        setData(payload);
+        setError(payload.error ?? "Demand Radar could not be loaded.");
+        return;
+      }
+      setData(payload);
+    } catch {
+      setError("Demand Radar could not be loaded.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  const localPrimary = useMemo(() => data?.local.find((row) => !row.neighborhood) ?? data?.local[0] ?? null, [data]);
+
+  if (loading) return <div className="flex min-h-[60vh] items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-[#8B1E2D]" /></div>;
+  if (error || !data) {
+    return (
+      <div className="mx-auto max-w-3xl p-8">
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-6">
+          <p className="font-semibold text-rose-900">Demand Radar unavailable</p>
+          <p className="mt-1 text-sm text-rose-700">{error}</p>
+          <button onClick={() => void load()} className="mt-4 inline-flex items-center gap-2 text-sm font-semibold"><RefreshCw className="h-4 w-4" />Retry</button>
+        </div>
+      </div>
+    );
+  }
+
+  const isPreview = data.access.preview && !data.access.full;
+  const bestSignal = localPrimary ?? data.opportunities[0] ?? null;
+  const bestWindow = bestSignal ? getSpikeWindow(bestSignal) : null;
+  const rankingRows = rankingView === "rising" ? data.fastestRising : rankingView === "demand" ? data.highestDemand : data.opportunities;
+  const opportunityReliable = data.methodology.opportunityStatus === "reliable";
+  const collectionPartial = data.collection.status === "partial";
+  const topPulse = data.highestDemand.slice(0, isPreview ? 3 : 8);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 p-4 pb-24 md:p-8">
+      <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-[#8B1E2D]"><Radar className="h-5 w-5" /><span className="text-xs font-bold uppercase tracking-[0.16em]">{isPreview ? "Market Intelligence Preview" : "Elite Market Intelligence"}</span></div>
+          <h1 className="mt-2 font-display text-3xl font-semibold">Demand Radar</h1>
+          <p className="mt-2 max-w-2xl text-sm text-[#716862]">See what changed, how your market ranks, where demand is moving and how reliable the current signal is.</p>
+        </div>
+        <button onClick={() => void load()} className="inline-flex items-center gap-2 rounded-xl border bg-white px-4 py-2.5 text-sm font-semibold"><RefreshCw className="h-4 w-4" />Refresh</button>
+      </header>
+
+      <section className={`rounded-2xl border p-4 ${collectionPartial ? "border-amber-200 bg-amber-50" : "border-[#E4D8D1] bg-[#FCF8F5]"}`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            {collectionPartial ? <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" /> : <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-700" />}
+            <div>
+              <p className="text-sm font-semibold text-[#211C19]">National coverage {data.collection.marketsSucceeded}/{data.collection.marketsRequested} · {data.collection.coveragePct}%</p>
+              <p className="mt-1 text-xs text-[#6D625B]">{collectionPartial ? `${data.collection.marketsFailed} markets were unavailable in this collection. Rankings use only the current run.` : "Current run completed with full configured coverage."}</p>
+            </div>
+          </div>
+          <div className="text-xs text-[#6D625B] sm:text-right">
+            <p>{freshnessCopy[data.market.freshness]}{data.market.collectedAt ? ` · Updated ${formatUsDate(data.market.collectedAt)}` : ""}</p>
+            <p className="mt-1">{data.market.weekStart ? `Week of ${formatUsDate(data.market.weekStart)}` : "No active week"}</p>
+          </div>
+        </div>
+      </section>
+
+      {localPrimary ? (
+        <section className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div className="flex items-center gap-2"><MapPin className="h-4 w-4 text-[#8B1E2D]" /><h2 className="font-display text-xl font-semibold">Your market: {localPrimary.city}, {localPrimary.state}</h2></div>
+            <div className="inline-flex w-fit items-center rounded-full bg-[#F9EDEE] px-3 py-1 text-xs font-bold tracking-wide text-[#8B1E2D]">{signalCopy(localPrimary)}</div>
+          </div>
+          {isPreview ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <ScoreCard label="Demand" value={getDemandLabel(localPrimary.score)} detail={`${localPrimary.score}/100`} delta={data.insights?.demandChange} />
+              <ScoreCard label="Spike" value={getSpikeLabel(localPrimary.spike_score)} detail={localPrimary.spike_score == null ? "Awaiting baseline" : `${localPrimary.spike_score}/100 acceleration`} delta={data.insights?.spikeChange} />
+              <ScoreCard label="Trend" value={trendCopy(localPrimary.trend)} detail="Direction versus recent baseline" />
+              <ScoreCard label="National rank" value={data.insights?.rank ? `#${data.insights.rank}` : "—"} detail={`${data.insights?.totalMarkets ?? 0} current markets`} delta={data.insights?.rankChange} />
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+              <ScoreCard label="Demand" value={localPrimary.score} detail={getDemandLabel(localPrimary.score)} delta={data.insights?.demandChange} />
+              <ScoreCard label="Spike" value={localPrimary.spike_score ?? "—"} detail={getSpikeLabel(localPrimary.spike_score)} delta={data.insights?.spikeChange} />
+              <ScoreCard label="National rank" value={data.insights?.rank ? `#${data.insights.rank}` : "—"} detail={data.insights?.percentile != null ? `${data.insights.percentile}th percentile` : "Current run"} delta={data.insights?.rankChange} />
+              <ScoreCard label="Opportunity" value={opportunityReliable ? localPrimary.opportunity_score ?? "—" : "Beta"} detail={opportunityReliable ? "Demand adjusted for competition" : "Competition signal not differentiated yet"} />
+              <ScoreCard label="Confidence" value={localPrimary.confidence ?? "—"} detail={trendCopy(localPrimary.trend)} />
+            </div>
+          )}
+        </section>
+      ) : data.localFallback ? (
+        <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" />
+            <div>
+              <p className="font-semibold text-amber-950">Your market was not captured in the latest national run</p>
+              <p className="mt-1 text-sm text-amber-900">Last known signal for {data.localFallback.city}, {data.localFallback.state}: demand {data.localFallback.score}/100, collected {formatUsDate(data.localFallback.collected_at)}. It is shown as historical context and is not mixed into the current national ranking.</p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {localPrimary && data.insights ? (
+        <section className="rounded-3xl border border-[#E8DFD8] bg-white p-5 shadow-sm md:p-6">
+          <div className="flex items-center gap-2 text-[#8B1E2D]"><Activity className="h-4 w-4" /><p className="text-xs font-bold uppercase tracking-[0.14em]">What changed</p></div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-2xl bg-[#FCF8F5] p-4"><p className="text-xs text-[#81766F]">Demand</p><p className="mt-2 text-xl font-semibold">{signed(data.insights.demandChange)}</p><p className="mt-1 text-xs text-[#716862]">points vs previous week</p></div>
+            <div className="rounded-2xl bg-[#FCF8F5] p-4"><p className="text-xs text-[#81766F]">Spike</p><p className="mt-2 text-xl font-semibold">{signed(data.insights.spikeChange)}</p><p className="mt-1 text-xs text-[#716862]">acceleration points</p></div>
+            <div className="rounded-2xl bg-[#FCF8F5] p-4"><p className="text-xs text-[#81766F]">Rank movement</p><p className="mt-2 text-xl font-semibold">{data.insights.rankChange == null ? "—" : data.insights.rankChange > 0 ? `↑ ${data.insights.rankChange}` : data.insights.rankChange < 0 ? `↓ ${Math.abs(data.insights.rankChange)}` : "No change"}</p><p className="mt-1 text-xs text-[#716862]">positions nationally</p></div>
+            <div className="rounded-2xl bg-[#FCF8F5] p-4"><p className="text-xs text-[#81766F]">Baseline growth</p><p className="mt-2 text-xl font-semibold">{data.insights.growthPct == null ? "—" : signed(Math.round(data.insights.growthPct), "%")}</p><p className="mt-1 text-xs text-[#716862]">recent signal vs baseline</p></div>
+          </div>
+        </section>
+      ) : null}
+
+      {data.localHistory.length > 0 ? <TrendPanel rows={data.localHistory} /> : null}
+
+      {bestSignal && bestWindow ? (
+        <section className="rounded-3xl border border-[#E4D8D1] bg-white p-6 shadow-sm">
+          <div className="flex items-center gap-2 text-[#8B1E2D]"><TrendingUp className="h-5 w-5" /><p className="text-xs font-bold uppercase tracking-[0.14em]">{localPrimary ? "Your clearest signal" : "Strongest current market signal"}</p></div>
+          <div className="mt-5 grid gap-4 md:grid-cols-3">
+            <div className="rounded-2xl bg-[#FCF8F5] p-5"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#81766F]"><MapPin className="h-4 w-4" />Where</div><p className="mt-3 font-display text-2xl font-semibold">{bestSignal.city}, {bestSignal.state}</p></div>
+            <div className="rounded-2xl bg-[#FCF8F5] p-5"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#81766F]"><CalendarDays className="h-4 w-4" />When</div><p className="mt-3 text-lg font-semibold">{bestWindow.start && bestWindow.end ? `${formatUsDate(bestWindow.start)} – ${formatUsDate(bestWindow.end)}` : "No confirmed window"}</p><p className="mt-1 text-xs text-[#756C66]">{bestWindow.label}</p></div>
+            <div className="rounded-2xl bg-[#FCF8F5] p-5"><div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#81766F]"><Zap className="h-4 w-4" />Status</div><p className="mt-3 font-display text-2xl font-semibold">{signalCopy(bestSignal)}</p><p className="mt-1 text-xs text-[#756C66]">Spike {bestSignal.spike_score ?? "—"}/100 · Confidence {bestSignal.confidence ?? "—"}/100</p></div>
+          </div>
+          <div className="mt-4 rounded-2xl border border-[#E9E0DA] p-4 text-sm text-[#5F5650]"><strong>Action now:</strong> {bestWindow.action}</div>
+          {!isPreview && bestWindow.status === "active" ? <div className="mt-4 flex items-center gap-2 text-xs text-[#6D625B]"><Bell className="h-4 w-4 text-[#8B1E2D]" />Email alerts are sent when a confirmed high confidence spike is detected in your profile city and market insight emails are enabled.</div> : null}
+        </section>
+      ) : null}
+
+      {isPreview ? <UpgradeCard /> : null}
+
+      <section className="rounded-3xl border border-[#E8DFD8] bg-white p-5 shadow-sm md:p-6">
+        <div className="flex items-center gap-2 text-[#8B1E2D]"><Radar className="h-4 w-4" /><p className="text-xs font-bold uppercase tracking-[0.14em]">National market pulse</p></div>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {topPulse.map((row) => (
+            <div key={`pulse-${row.id}`} className="rounded-2xl bg-[#FCF8F5] p-4">
+              <div className="flex items-center justify-between gap-2"><p className="font-semibold">{row.city}, {row.state}</p><span className="text-xs font-semibold text-[#8B1E2D]">{row.score}</span></div>
+              <div className="mt-3 h-2 overflow-hidden rounded-full bg-[#EDE5E0]"><div className="h-full rounded-full bg-[#8B1E2D]" style={{ width: `${Math.max(2, Math.min(100, row.score))}%` }} /></div>
+              <p className="mt-2 text-xs text-[#716862]">{trendCopy(row.trend)} · {getSpikeLabel(row.spike_score)}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border bg-white shadow-sm">
+        <div className="border-b px-5 py-5 md:px-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="flex items-center gap-3"><Radar className="h-5 w-5 text-[#8B1E2D]" /><div><h2 className="font-display text-lg font-semibold">Market rankings</h2><p className="text-xs text-[#756C66]">Every ranking uses only markets captured in the latest collection run.</p></div></div>
+            <div className="flex flex-wrap gap-2" role="group" aria-label="Market ranking view">
+              <button type="button" aria-pressed={rankingView === "opportunity"} onClick={() => setRankingView("opportunity")} className={`rounded-xl px-3 py-2 text-xs font-semibold ${rankingView === "opportunity" ? "bg-[#8B1E2D] text-white" : "bg-[#F7F2EE] text-[#5F5650]"}`}>{opportunityReliable ? "Top opportunities" : "Market ranking"}</button>
+              <button type="button" aria-pressed={rankingView === "rising"} onClick={() => setRankingView("rising")} className={`rounded-xl px-3 py-2 text-xs font-semibold ${rankingView === "rising" ? "bg-[#8B1E2D] text-white" : "bg-[#F7F2EE] text-[#5F5650]"}`}>Fastest rising</button>
+              <button type="button" aria-pressed={rankingView === "demand"} onClick={() => setRankingView("demand")} className={`rounded-xl px-3 py-2 text-xs font-semibold ${rankingView === "demand" ? "bg-[#8B1E2D] text-white" : "bg-[#F7F2EE] text-[#5F5650]"}`}>Highest demand</button>
+            </div>
+          </div>
+          {!opportunityReliable ? <div className="mt-4 rounded-xl bg-amber-50 px-3 py-2 text-xs text-amber-900">Opportunity scoring is marked beta because the current competition signal is not sufficiently differentiated. It is not used to claim a precise competitive advantage.</div> : null}
+        </div>
+        <RankingRows rows={rankingRows} preview={isPreview} view={rankingView} />
+      </section>
+
+      <section className="rounded-3xl border border-[#E8DFD8] bg-[#FCF8F5] p-5 md:p-6">
+        <div className="grid gap-5 md:grid-cols-3">
+          <div><div className="flex items-center gap-2 text-[#8B1E2D]"><Database className="h-4 w-4" /><p className="text-xs font-bold uppercase tracking-[0.14em]">Collection</p></div><p className="mt-2 text-sm font-semibold">{data.collection.status === "completed" ? "Complete" : data.collection.status === "partial" ? "Partial" : "Unknown"} · {data.collection.coveragePct}% coverage</p><p className="mt-1 text-xs text-[#716862]">{data.collection.rowsIngested} rows from run {data.collection.runId ? data.collection.runId.slice(0, 8) : "—"}</p></div>
+          <div><div className="flex items-center gap-2 text-[#8B1E2D]"><ShieldCheck className="h-4 w-4" /><p className="text-xs font-bold uppercase tracking-[0.14em]">Methodology</p></div><p className="mt-2 text-sm font-semibold">{data.methodology.version ?? "Pending"}</p><p className="mt-1 text-xs text-[#716862]">Source: {data.methodology.source ?? "not available"}</p></div>
+          <div><div className="flex items-center gap-2 text-[#8B1E2D]"><Activity className="h-4 w-4" /><p className="text-xs font-bold uppercase tracking-[0.14em]">Competition quality</p></div><p className="mt-2 text-sm font-semibold capitalize">{data.methodology.competitionStatus}</p><p className="mt-1 text-xs text-[#716862]">Opportunity is shown as beta until competition varies enough to support a differentiated score.</p></div>
+        </div>
+      </section>
+
+      <p className="text-xs leading-5 text-[#7B726C]">{data.disclaimer} Spike windows describe current acceleration observed in fresh market data; they are statistical signals, not guaranteed future bookings or exact search volumes.</p>
+    </div>
+  );
 }

--- a/src/lib/demand-radar.ts
+++ b/src/lib/demand-radar.ts
@@ -1,6 +1,8 @@
 export type DemandTrend = "rising" | "stable" | "falling";
 export type DataFreshness = "fresh" | "delayed" | "stale" | "unknown";
 export type SpikeWindowStatus = "active" | "watch" | "normal";
+export type CompetitionSignalStatus = "reliable" | "experimental" | "unavailable";
+export type MarketSignalStatus = "spiking" | "accelerating" | "building" | "normal";
 
 export interface DemandScoreRecord {
   id: string;
@@ -17,6 +19,14 @@ export interface DemandScoreRecord {
   week_start: string;
   collected_at: string | null;
   expires_at: string | null;
+  run_id?: string | null;
+  methodology_version?: string | null;
+  baseline_index?: number | null;
+  growth_pct?: number | null;
+  velocity_score?: number | null;
+  persistence_score?: number | null;
+  sample_size?: number | null;
+  score_components?: Record<string, unknown> | null;
 }
 
 export interface SpikeWindow {
@@ -59,8 +69,15 @@ export function getSpikeLabel(score: number | null | undefined): string {
   return "Normal";
 }
 
-// Accepts partial rows (API responses may omit optional signal fields); the
-// implementation already treats missing values as "no signal".
+export function getMarketSignalStatus(record: Pick<DemandScoreRecord, "trend" | "spike_score" | "confidence">): MarketSignalStatus {
+  const spike = record.spike_score ?? 0;
+  const confidence = record.confidence ?? 0;
+  if (record.trend === "rising" && spike >= 80 && confidence >= 50) return "spiking";
+  if (record.trend === "rising" && spike >= 60) return "accelerating";
+  if (record.trend === "rising" || spike >= 40) return "building";
+  return "normal";
+}
+
 export function getSpikeWindow(record: {
   trend: DemandTrend;
   spike_score?: number | null;
@@ -93,13 +110,32 @@ export function getOpportunityScore(record: Pick<DemandScoreRecord, "score" | "c
   return Math.round(record.score * 0.65 + lowCompetition * 0.2 + confidence * 0.15);
 }
 
-export function rankDemandRecords(records: DemandScoreRecord[]): DemandScoreRecord[] {
+export function getCompetitionSignalStatus(records: Array<Pick<DemandScoreRecord, "competition_index">>): CompetitionSignalStatus {
+  const values = records.map((row) => row.competition_index).filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  if (values.length === 0) return "unavailable";
+  const unique = new Set(values.map((value) => Math.round(value))).size;
+  const spread = Math.max(...values) - Math.min(...values);
+  if (values.length >= 5 && unique >= 3 && spread >= 15) return "reliable";
+  return "experimental";
+}
+
+export function getMarketPercentile(rank: number, total: number): number | null {
+  if (!Number.isInteger(rank) || !Number.isInteger(total) || rank < 1 || total < 1 || rank > total) return null;
+  if (total === 1) return 100;
+  return Math.round(((total - rank) / (total - 1)) * 100);
+}
+
+export function rankDemandRecords(records: DemandScoreRecord[], options: { useOpportunity?: boolean } = {}): DemandScoreRecord[] {
+  const useOpportunity = options.useOpportunity ?? true;
   return [...records].sort((a, b) => {
-    const aOpportunity = getOpportunityScore(a);
-    const bOpportunity = getOpportunityScore(b);
-    if (aOpportunity != null && bOpportunity != null && bOpportunity !== aOpportunity) return bOpportunity - aOpportunity;
+    if (useOpportunity) {
+      const aOpportunity = getOpportunityScore(a);
+      const bOpportunity = getOpportunityScore(b);
+      if (aOpportunity != null && bOpportunity != null && bOpportunity !== aOpportunity) return bOpportunity - aOpportunity;
+    }
     if ((b.spike_score ?? 0) !== (a.spike_score ?? 0)) return (b.spike_score ?? 0) - (a.spike_score ?? 0);
     if (b.score !== a.score) return b.score - a.score;
+    if ((b.confidence ?? 0) !== (a.confidence ?? 0)) return (b.confidence ?? 0) - (a.confidence ?? 0);
     return `${a.city}-${a.neighborhood ?? ""}`.localeCompare(`${b.city}-${b.neighborhood ?? ""}`);
   });
 }

--- a/supabase/migrations/20260814184500_sync_profile_extras_contract.sql
+++ b/supabase/migrations/20260814184500_sync_profile_extras_contract.sql
@@ -1,0 +1,17 @@
+-- Synchronize the additive schema contract with profile fields already present
+-- in production. This migration is idempotent and safe for existing databases.
+
+alter table public.profiles
+  add column if not exists map_enabled boolean default false,
+  add column if not exists massage_setup text[],
+  add column if not exists mobile_extras text[],
+  add column if not exists products_used text[],
+  add column if not exists products_sold text[],
+  add column if not exists payment_methods text[],
+  add column if not exists day_of_week_discount jsonb default '[]'::jsonb,
+  add column if not exists education_entries jsonb default '[]'::jsonb,
+  add column if not exists additional_services text[],
+  add column if not exists studio_amenities text[],
+  add column if not exists rate_disclaimers text[],
+  add column if not exists affiliations text[],
+  add column if not exists start_date timestamptz;

--- a/tests/unit/demand-radar.test.ts
+++ b/tests/unit/demand-radar.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatUsDate,
+  getCompetitionSignalStatus,
   getDemandFreshness,
   getDemandLabel,
+  getMarketPercentile,
+  getMarketSignalStatus,
   getOpportunityScore,
   getSpikeWindow,
   rankDemandRecords,
@@ -26,6 +29,14 @@ const base: DemandScoreRecord = {
   week_start: "2026-08-03",
   collected_at: "2026-08-06T12:00:00.000Z",
   expires_at: null,
+  run_id: "run-1",
+  methodology_version: "test-v1",
+  baseline_index: 60,
+  growth_pct: 33,
+  velocity_score: 70,
+  persistence_score: 80,
+  sample_size: 35,
+  score_components: {},
 };
 
 describe("demand radar helpers", () => {
@@ -50,29 +61,53 @@ describe("demand radar helpers", () => {
     expect(getOpportunityScore({ ...base, competition_index: null })).toBeNull();
   });
 
-  it("ranks lower competition above equal demand when both competition values are known", () => {
+  it("marks flat competition as experimental", () => {
+    const records = Array.from({ length: 6 }, (_, index) => ({ ...base, id: String(index), competition_index: 50 }));
+    expect(getCompetitionSignalStatus(records)).toBe("experimental");
+  });
+
+  it("requires meaningful competition spread before calling it reliable", () => {
+    const values = [18, 32, 47, 61, 78, 84];
+    const records = values.map((competition_index, index) => ({ ...base, id: String(index), competition_index }));
+    expect(getCompetitionSignalStatus(records)).toBe("reliable");
+  });
+
+  it("ranks lower competition above equal demand when competition is reliable", () => {
     const lowerCompetition = { ...base, id: "2", competition_index: 20 };
     expect(rankDemandRecords([base, lowerCompetition])[0]?.id).toBe("2");
   });
 
-  it("returns plain-language demand labels", () => {
+  it("can ignore experimental competition when ranking a current run", () => {
+    const strongerSpike = { ...base, id: "2", score: 75, spike_score: 95, competition_index: 90 };
+    expect(rankDemandRecords([base, strongerSpike], { useOpportunity: false })[0]?.id).toBe("2");
+  });
+
+  it("returns plain language demand labels", () => {
     expect(getDemandLabel(90)).toBe("Very high");
     expect(getDemandLabel(75)).toBe("High");
     expect(getDemandLabel(55)).toBe("Moderate");
     expect(getDemandLabel(30)).toBe("Low");
   });
 
-  it("creates a clear seven-day active spike window", () => {
+  it("creates a clear seven day active spike window", () => {
     const window = getSpikeWindow(base);
     expect(window.status).toBe("active");
     expect(formatUsDate(window.start)).toBe("08/06/2026");
     expect(formatUsDate(window.end)).toBe("08/13/2026");
     expect(shouldSendSpikeAlert(base)).toBe(true);
+    expect(getMarketSignalStatus(base)).toBe("spiking");
   });
 
-  it("does not email normal or low-confidence signals", () => {
+  it("does not email normal or low confidence signals", () => {
     expect(shouldSendSpikeAlert({ ...base, spike_score: 55 })).toBe(false);
     expect(shouldSendSpikeAlert({ ...base, confidence: 30 })).toBe(false);
     expect(shouldSendSpikeAlert({ ...base, trend: "stable" })).toBe(false);
+  });
+
+  it("calculates a market percentile from rank", () => {
+    expect(getMarketPercentile(1, 50)).toBe(100);
+    expect(getMarketPercentile(50, 50)).toBe(0);
+    expect(getMarketPercentile(3, 5)).toBe(50);
+    expect(getMarketPercentile(0, 5)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Rebuilds Demand Radar around a trustworthy current-run snapshot and improves the nationwide collector resilience.

### Data correctness
- Binds the dashboard to the latest successful or partial `demand_collection_runs.run_id`
- Stops silently mixing stale markets from earlier runs into the current national ranking
- Adds explicit collection coverage, failed-market count, freshness and run metadata
- Keeps last-known local data separate when the provider market was not captured in the latest run

### Decision intelligence
- Adds 12-week local demand and spike trend
- Adds demand, spike and national-rank changes versus the previous week
- Adds national percentile and market status
- Adds ranking views for current market ranking, fastest rising and highest demand
- Marks opportunity scoring as beta unless competition data is sufficiently differentiated
- Adds methodology and data-quality context to avoid false precision

### Collector reliability
- Adds a resilient nationwide runner with paced requests, jitter, client reset after upstream errors and a targeted second pass after a cooldown
- Keeps a single run envelope across retry passes
- Validates collector scripts and national market configuration on pull requests
- Improves workflow summaries and partial-coverage reporting

### Tests
- Adds coverage for competition reliability, opportunity fallback ranking, market signal status and percentile logic

Risk control: current-run isolation means a partial collection can show fewer national markets, but it no longer presents stale rows as current data. Last-known local data is clearly labeled and excluded from current rankings.