### PR TITLE
fix: sync admin and provider dashboards with production

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getCities, getPublicTherapists } from "@/app/_lib/directory";
+import { getCities } from "@/app/_lib/directory";
 import { createSupabaseAdminClient } from "@/app/api/_lib/supabase-server";
 import { AdminPageHeader } from "@/app/admin/_components/AdminPageHeader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -12,33 +12,46 @@ import {
   Newspaper,
   Tag,
   ArrowUpRight,
-  CalendarCheck,
-  MessageSquare,
-  DollarSign,
+  BadgeCheck,
+  LifeBuoy,
 } from "lucide-react";
+
+const REVIEW_STATUSES = ["under_review", "pending", "pending_review", "pending_approval"];
 
 async function getAdminStats() {
   const supabase = createSupabaseAdminClient();
-
-  const [therapistsResult, cities, bookingCountResult, smsAlertCountResult] = await Promise.all([
-    getPublicTherapists({ page: 1, pageSize: 50 }),
+  const db = supabase as any;
+  const [
+    profilesResult,
+    reviewResult,
+    moderationResult,
+    identityResult,
+    supportResult,
+    recentResult,
+    cities,
+  ] = await Promise.all([
+    db.from("profiles").select("id", { count: "exact", head: true }).eq("role", "provider"),
+    db.from("profiles").select("id", { count: "exact", head: true }).in("profile_status", REVIEW_STATUSES),
+    db.from("moderation_queue").select("id", { count: "exact", head: true }).eq("status", "pending"),
+    db.from("identity_verifications").select("id", { count: "exact", head: true }).in("status", ["pending", "requires_input"]),
+    db.from("support_tickets").select("id", { count: "exact", head: true }).in("status", ["open", "pending", "in_progress"]),
+    db
+      .from("profiles")
+      .select("id,display_name,full_name,city,specialties,profile_status,visibility_status,updated_at")
+      .eq("role", "provider")
+      .order("updated_at", { ascending: false })
+      .limit(8),
     Promise.resolve(getCities()),
-    supabase
-      .from('booking_inquiries')
-      .select('id', { count: 'exact', head: true })
-      .eq('status', 'pending_approval'),
-    supabase
-      .from('sms_follow_up_alerts')
-      .select('id', { count: 'exact', head: true })
-      .is('resolved_at', null),
   ]);
 
   return {
-    therapists: therapistsResult.total,
+    therapists: profilesResult.count ?? 0,
     cities: cities.length,
-    recentTherapists: therapistsResult.items.slice(0, 5),
-    pendingBookings: bookingCountResult.count ?? 0,
-    smsAlerts: smsAlertCountResult.count ?? 0,
+    needsReview: reviewResult.count ?? 0,
+    moderationPending: moderationResult.count ?? 0,
+    identityAttention: identityResult.count ?? 0,
+    supportOpen: supportResult.count ?? 0,
+    recentTherapists: recentResult.data ?? [],
   };
 }
 
@@ -49,62 +62,62 @@ export default async function AdminOverviewPage() {
     {
       label: "Total Therapists",
       value: String(stats.therapists),
-      description: "Active profiles",
+      description: "Provider profiles in Supabase",
       icon: HeartHandshake,
       color: "text-primary",
       bgColor: "bg-primary/10",
+      href: "/admin/people",
+    },
+    {
+      label: "Needs Review",
+      value: String(stats.needsReview),
+      description: "Under review or pending",
+      icon: ShieldAlert,
+      color: "text-amber-700",
+      bgColor: "bg-amber-50",
+      href: "/admin/people",
+    },
+    {
+      label: "Photo Moderation",
+      value: String(stats.moderationPending),
+      description: "Pending moderation items",
+      icon: ShieldAlert,
+      color: "text-orange-700",
+      bgColor: "bg-orange-50",
+      href: "/admin/moderation",
+    },
+    {
+      label: "Identity Attention",
+      value: String(stats.identityAttention),
+      description: "Pending or requires input",
+      icon: BadgeCheck,
+      color: "text-indigo-700",
+      bgColor: "bg-indigo-50",
+      href: "/admin/people",
+    },
+    {
+      label: "Support Open",
+      value: String(stats.supportOpen),
+      description: "Open or in progress tickets",
+      icon: LifeBuoy,
+      color: "text-violet-700",
+      bgColor: "bg-violet-50",
     },
     {
       label: "Cities Covered",
       value: String(stats.cities),
-      description: "Active locations",
+      description: "Directory city definitions",
       icon: MapPin,
       color: "text-blue-600",
       bgColor: "bg-blue-50",
-    },
-    {
-      label: "Booking Approvals",
-      value: String(stats.pendingBookings),
-      description: "Need your sign-off",
-      icon: CalendarCheck,
-      color: "text-red-600",
-      bgColor: "bg-red-50",
-      href: "/admin/bookings",
-    },
-    {
-      label: "SMS Alerts",
-      value: String(stats.smsAlerts),
-      description: "Unanswered 90+ min",
-      icon: MessageSquare,
-      color: "text-violet-600",
-      bgColor: "bg-violet-50",
-      href: "/admin/sms",
-    },
-    {
-      label: "Moderation",
-      value: "—",
-      description: "Review queued listings",
-      icon: ShieldAlert,
-      color: "text-amber-600",
-      bgColor: "bg-amber-50",
-      href: "/admin/moderation",
-    },
-    {
-      label: "Revenue",
-      value: "—",
-      description: "See Stripe dashboard",
-      icon: DollarSign,
-      color: "text-emerald-600",
-      bgColor: "bg-emerald-50",
+      href: "/admin/cities",
     },
   ];
 
   const quickLinks = [
-    { href: "/admin/bookings", label: "Booking Approvals", description: `${stats.pendingBookings} inquiry${stats.pendingBookings !== 1 ? 'ies' : 'y'} waiting for your sign-off.`, icon: CalendarCheck },
-    { href: "/admin/sms", label: "SMS Auto-Reply", description: `${stats.smsAlerts} alert${stats.smsAlerts !== 1 ? 's' : ''} — conversations with no reply in 90+ min.`, icon: MessageSquare },
-    { href: "/admin/therapists", label: "Therapists", description: "Approve, suspend, verify, and feature provider profiles.", icon: HeartHandshake },
+    { href: "/admin/people", label: "People CRM", description: `${stats.needsReview} profile${stats.needsReview === 1 ? "" : "s"} currently need review.`, icon: HeartHandshake },
+    { href: "/admin/moderation", label: "Moderation", description: `${stats.moderationPending} moderation item${stats.moderationPending === 1 ? "" : "s"} pending.`, icon: ShieldAlert },
     { href: "/admin/users", label: "Users", description: "Manage provider and admin roles.", icon: Users },
-    { href: "/admin/moderation", label: "Moderation", description: "Review queued listing drafts flagged by Sightengine.", icon: ShieldAlert },
     { href: "/admin/cities", label: "Cities", description: "Edit local landing page copy and city coverage.", icon: MapPin },
     { href: "/admin/keywords", label: "Keywords", description: "Manage specialty and SEO keyword surfaces.", icon: Tag },
     { href: "/admin/blog", label: "Blog", description: "Publish and maintain editorial content.", icon: Newspaper },
@@ -112,9 +125,8 @@ export default async function AdminOverviewPage() {
 
   return (
     <div className="space-y-6">
-      <AdminPageHeader title="Dashboard" description="Admin overview — monitor platform health at a glance." />
+      <AdminPageHeader title="Dashboard" description="Admin overview grounded in the current production database." />
 
-      {/* Stat Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
         {cards.map((card) => {
           const inner = (
@@ -130,36 +142,33 @@ export default async function AdminOverviewPage() {
             </>
           );
           const cls = "rounded-2xl border border-border bg-white p-5 shadow-sm transition-shadow hover:shadow-md";
-          return 'href' in card && card.href ? (
+          return card.href ? (
             <Link key={card.label} href={card.href} className={`${cls} block`}>
               {inner}
             </Link>
           ) : (
-            <div key={card.label} className={cls}>
-              {inner}
-            </div>
+            <div key={card.label} className={cls}>{inner}</div>
           );
         })}
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">
-        {/* Recent Therapist Activity */}
         <Card className="lg:col-span-2 border-border bg-white shadow-sm">
           <CardHeader>
             <CardTitle className="font-display text-base">Recent Therapist Activity</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
-              {stats.recentTherapists.map((t) => (
-                <div key={t.id} className="flex items-center justify-between border-b border-border/50 pb-3 last:border-none last:pb-0">
-                  <div>
-                    <p className="text-sm font-medium text-foreground">{t.display_name || t.full_name || "Unknown"}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {t.city || "No city"} • {t.specialties?.[0] || "General"}
+              {stats.recentTherapists.map((t: any) => (
+                <div key={t.id} className="flex items-center justify-between gap-4 border-b border-border/50 pb-3 last:border-none last:pb-0">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-foreground">{t.display_name || t.full_name || "Unknown"}</p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {t.city || "No city"} · {t.specialties?.[0] || "General"} · {t.visibility_status || "unknown visibility"}
                     </p>
                   </div>
-                  <Badge variant={t.status === "active" ? "default" : "secondary"}>
-                    {t.status || "pending"}
+                  <Badge variant={t.profile_status === "approved" ? "default" : "secondary"}>
+                    {t.profile_status || "draft"}
                   </Badge>
                 </div>
               ))}
@@ -170,7 +179,6 @@ export default async function AdminOverviewPage() {
           </CardContent>
         </Card>
 
-        {/* Quick Links */}
         <Card className="border-border bg-white shadow-sm">
           <CardHeader>
             <CardTitle className="font-display text-base">Quick Actions</CardTitle>
@@ -178,17 +186,13 @@ export default async function AdminOverviewPage() {
           <CardContent>
             <div className="space-y-2">
               {quickLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-secondary/50"
-                >
+                <Link key={link.href} href={link.href} className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-secondary/50">
                   <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10">
                     <link.icon className="h-4 w-4 text-primary" />
                   </div>
-                  <div className="flex-1 min-w-0">
+                  <div className="min-w-0 flex-1">
                     <p className="text-sm font-medium text-foreground">{link.label}</p>
-                    <p className="text-xs text-muted-foreground truncate">{link.description}</p>
+                    <p className="truncate text-xs text-muted-foreground">{link.description}</p>
                   </div>
                   <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 </Link>

--- a/src/app/admin/people/loadPeople.ts
+++ b/src/app/admin/people/loadPeople.ts
@@ -31,6 +31,11 @@ function normalizeRole(role: string | null): AdminPerson["role"] {
   return role === "admin" || role === "provider" ? role : null;
 }
 
+function adminProfileStatus(status: string | null) {
+  if (status === "under_review") return "under_review (pending)";
+  return status || "draft";
+}
+
 export async function loadPeople(): Promise<{ items: AdminPerson[]; error: string | null }> {
   try {
     const supabase = createSupabaseAdminClient();
@@ -121,7 +126,7 @@ export async function loadPeople(): Promise<{ items: AdminPerson[]; error: strin
             email: emailMap.get(userId) || profile.email_address || null,
             city: profile.city,
             role: roleMap.get(userId) || null,
-            profileStatus: profile.profile_status || "draft",
+            profileStatus: adminProfileStatus(profile.profile_status),
             subscriptionTier: profile.subscription_tier,
             verificationStatus: identityStatusMap.get(userId) || "not_started",
             slug: profile.slug,

--- a/src/app/api/pro/growth/route.ts
+++ b/src/app/api/pro/growth/route.ts
@@ -14,7 +14,7 @@ import type { Database } from "@/integrations/supabase/types";
 type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
 
 const GROWTH_SELECT =
-  "id, slug, city, subscription_tier, available_now, available_now_expires, travel_schedule, promotions, visibility_status, is_active";
+  "id, slug, city, subscription_tier, available_now, available_now_expires, travel_schedule, promotions, visibility_status, is_active, profile_status, profile_completion_score, profile_views";
 
 const travelEntrySchema = z.object({
   city: z.string().min(1).max(120),
@@ -66,12 +66,56 @@ async function loadOrCreateGrowthProfile(
   return created;
 }
 
+async function loadDashboardInsights(
+  admin: ReturnType<typeof createSupabaseAdminClient>,
+  session: RequestSession,
+  profileId: string,
+) {
+  const db = admin as any;
+  const [snapshotResult, photosResult, identityResult, supportResult, notificationResult] = await Promise.all([
+    db
+      .from("ai_profile_coach_daily_snapshots")
+      .select("profile_score,visibility_score,trust_score,content_score,conversion_score,profile_views_7d,profile_views_30d,contact_clicks_7d,contact_rate_pct,average_search_position,local_demand_score,local_demand_trend,strongest_keyword,top_recommendation_title,top_recommendation_action,snapshot_date")
+      .eq("profile_id", profileId)
+      .order("snapshot_date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    db.from("profile_photos").select("moderation_status").eq("profile_id", profileId),
+    db
+      .from("identity_verifications")
+      .select("status,updated_at")
+      .eq("user_id", session.userId)
+      .order("updated_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    db.from("support_tickets").select("id", { count: "exact", head: true }).eq("user_id", session.userId).in("status", ["open", "pending", "in_progress"]),
+    db.from("notifications").select("id", { count: "exact", head: true }).eq("user_id", session.userId).eq("is_read", false),
+  ]);
+
+  const photoCounts = { approved: 0, pending: 0, rejected: 0 };
+  for (const photo of photosResult.data ?? []) {
+    const status = photo.moderation_status || "pending";
+    if (status === "approved") photoCounts.approved += 1;
+    else if (status === "rejected") photoCounts.rejected += 1;
+    else photoCounts.pending += 1;
+  }
+
+  return {
+    ai: snapshotResult.data ?? null,
+    photos: photoCounts,
+    identityStatus: identityResult.data?.status ?? "not_started",
+    supportOpen: supportResult.count ?? 0,
+    unreadNotifications: notificationResult.count ?? 0,
+  };
+}
+
 export async function GET(request: Request) {
   try {
     const session = await requireRequestSession(request);
     const admin = createSupabaseAdminClient();
     const data = await loadOrCreateGrowthProfile(admin, session);
-    return json({ ok: true, profile: data });
+    const insights = await loadDashboardInsights(admin, session, data.id);
+    return json({ ok: true, profile: data, insights });
   } catch (error) {
     return errorResponse(error);
   }
@@ -106,9 +150,7 @@ export async function POST(request: Request) {
       try {
         const therapistPaths = await buildTherapistRevalidatePaths({ id: next.id, slug: next.slug, city: next.city });
         const travelPaths = body.travel_schedule
-          ? await Promise.all(
-              body.travel_schedule.map((trip) => buildCityRevalidatePaths(slugify(trip.city))),
-            )
+          ? await Promise.all(body.travel_schedule.map((trip) => buildCityRevalidatePaths(slugify(trip.city))))
           : [];
         await triggerRevalidate(normalizeRevalidatePaths([...therapistPaths, ...travelPaths.flat()]), { request });
       } catch (revalidationError) {

--- a/src/app/pro/dashboard/page.tsx
+++ b/src/app/pro/dashboard/page.tsx
@@ -2,7 +2,22 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Car, Eye, EyeOff, Loader2, Plane, Settings, Zap } from "lucide-react";
+import {
+  BarChart3,
+  Bell,
+  Camera,
+  Car,
+  Eye,
+  EyeOff,
+  LifeBuoy,
+  Loader2,
+  Plane,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  TrendingUp,
+  Zap,
+} from "lucide-react";
 
 import { postJson, requestJson } from "@/app/_lib/request";
 import { Button } from "@/components/ui/button";
@@ -19,7 +34,38 @@ type DashboardProfile = {
   available_now_expires?: string | null;
   travel_schedule?: unknown;
   visibility_status?: string | null;
+  profile_status?: string | null;
+  profile_completion_score?: number | null;
+  profile_views?: number | null;
   is_active?: boolean | null;
+};
+
+type AiSnapshot = {
+  profile_score?: number | null;
+  visibility_score?: number | null;
+  profile_views_7d?: number | null;
+  profile_views_30d?: number | null;
+  contact_clicks_7d?: number | null;
+  contact_rate_pct?: number | null;
+  local_demand_score?: number | null;
+  local_demand_trend?: string | null;
+  strongest_keyword?: string | null;
+  top_recommendation_title?: string | null;
+  top_recommendation_action?: string | null;
+};
+
+type DashboardInsights = {
+  ai?: AiSnapshot | null;
+  photos?: { approved: number; pending: number; rejected: number };
+  identityStatus?: string;
+  supportOpen?: number;
+  unreadNotifications?: number;
+};
+
+type GrowthResponse = {
+  ok: boolean;
+  profile: DashboardProfile;
+  insights?: DashboardInsights;
 };
 
 function normalizeTravel(value: unknown): TravelEntry[] {
@@ -27,8 +73,7 @@ function normalizeTravel(value: unknown): TravelEntry[] {
 }
 
 function isTravelCurrentOrUpcoming(trips: TravelEntry[]) {
-  const now = new Date();
-  const today = now.toISOString().slice(0, 10);
+  const today = new Date().toISOString().slice(0, 10);
   return trips.some((trip) => Boolean(trip.city && trip.end_date && trip.end_date >= today));
 }
 
@@ -68,15 +113,33 @@ function StatusCard({
   );
 }
 
+function MetricCard({ label, value, detail, icon: Icon, href }: { label: string; value: string; detail: string; icon: typeof Zap; href?: string }) {
+  const body = (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{label}</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-950">{value}</p>
+          <p className="mt-1 text-xs leading-5 text-slate-500">{detail}</p>
+        </div>
+        <Icon className="h-5 w-5 text-slate-400" />
+      </div>
+    </div>
+  );
+  return href ? <Link href={href}>{body}</Link> : body;
+}
+
 export default function ProDashboardPage() {
   const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<DashboardProfile | null>(null);
+  const [insights, setInsights] = useState<DashboardInsights>({});
   const [saving, setSaving] = useState<string | null>(null);
 
   async function refresh() {
-    const growth = await requestJson<{ ok: boolean; profile: DashboardProfile }>("/api/pro/growth");
+    const growth = await requestJson<GrowthResponse>("/api/pro/growth");
     setProfile(growth.profile);
+    setInsights(growth.insights || {});
   }
 
   useEffect(() => {
@@ -93,6 +156,9 @@ export default function ProDashboardPage() {
   );
   const visible = profile?.is_active !== false && profile?.visibility_status !== "hidden";
   const displayName = profile?.display_name || profile?.full_name || "Your profile";
+  const profileStatus = profile?.profile_status || "draft";
+  const approved = profileStatus === "approved";
+  const ai = insights.ai;
 
   async function toggleAvailableNow() {
     setSaving("available");
@@ -123,58 +189,70 @@ export default function ProDashboardPage() {
   if (loading) return <div className="flex min-h-[55vh] items-center justify-center"><Loader2 className="h-5 w-5 animate-spin text-slate-500" /></div>;
 
   return (
-    <main className="mx-auto max-w-5xl space-y-6 p-4 pb-28 md:p-8">
+    <main className="mx-auto max-w-6xl space-y-6 p-4 pb-28 md:p-8">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Provider dashboard</p>
           <h1 className="mt-2 font-display text-3xl font-semibold tracking-tight text-slate-900">{displayName}</h1>
-          <p className="mt-1 text-sm text-slate-500">Visibility tools are independent. Turning one on no longer turns the others off.</p>
+          <p className="mt-1 text-sm text-slate-500">Live profile, visibility, growth and trust signals from your account.</p>
         </div>
         <Button asChild variant="outline"><Link href="/pro/listing"><Settings className="mr-2 h-4 w-4" />Edit listing</Link></Button>
       </header>
 
-      {!visible ? (
-        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
-          Your profile is OFF and hidden from public discovery. Available Now, travel, and mobile settings remain saved but are not publicly discoverable until visibility is turned back on.
+      {!approved ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <strong>Profile status: {profileStatus}.</strong> Your data remains saved, but public directory discovery requires an approved profile.
         </div>
       ) : null}
 
+      {!visible ? (
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+          Your profile is OFF and hidden from public discovery. Available Now, travel and mobile settings remain saved.
+        </div>
+      ) : null}
+
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
+        <MetricCard label="Profile status" value={profileStatus.replace(/_/g, " ")} detail={visible ? "Visibility enabled" : "Visibility hidden"} icon={ShieldCheck} href="/pro/approval-status" />
+        <MetricCard label="AI profile score" value={ai?.profile_score != null ? `${ai.profile_score}/100` : "—"} detail={ai?.top_recommendation_title || "Open AI Coach to generate a score"} icon={Sparkles} href="/pro/ai-coach" />
+        <MetricCard label="Views · 7 days" value={String(ai?.profile_views_7d ?? 0)} detail={`${ai?.profile_views_30d ?? profile?.profile_views ?? 0} in 30 days`} icon={BarChart3} href="/pro/analytics" />
+        <MetricCard label="Contact clicks · 7d" value={String(ai?.contact_clicks_7d ?? 0)} detail={ai?.contact_rate_pct != null ? `${Number(ai.contact_rate_pct).toFixed(1)}% contact rate` : "Contact activity"} icon={TrendingUp} href="/pro/analytics" />
+        <MetricCard label="Local demand" value={ai?.local_demand_score != null ? String(ai.local_demand_score) : "—"} detail={ai?.local_demand_trend || ai?.strongest_keyword || "Demand Radar data"} icon={TrendingUp} href="/pro/demand-radar" />
+        <MetricCard label="Profile completion" value={profile?.profile_completion_score != null ? `${profile.profile_completion_score}%` : "—"} detail="Production profile completeness" icon={Settings} href="/pro/listing" />
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricCard label="Photos" value={`${insights.photos?.approved ?? 0} approved`} detail={`${insights.photos?.pending ?? 0} pending · ${insights.photos?.rejected ?? 0} rejected`} icon={Camera} href="/pro/photos" />
+        <MetricCard label="Identity" value={(insights.identityStatus || "not_started").replace(/_/g, " ")} detail="Latest verification state" icon={ShieldCheck} />
+        <MetricCard label="Support" value={String(insights.supportOpen ?? 0)} detail="Open or in progress tickets" icon={LifeBuoy} />
+        <MetricCard label="Notifications" value={String(insights.unreadNotifications ?? 0)} detail="Unread account notifications" icon={Bell} />
+      </section>
+
+      {ai?.top_recommendation_action ? (
+        <section className="rounded-2xl border border-indigo-200 bg-indigo-50 p-5">
+          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500">AI Coach next action</p>
+          <h2 className="mt-2 font-semibold text-indigo-950">{ai.top_recommendation_title || "Improve your profile"}</h2>
+          <p className="mt-1 text-sm leading-6 text-indigo-800">{ai.top_recommendation_action}</p>
+          <Button asChild className="mt-4" size="sm"><Link href="/pro/ai-coach">Open AI Coach</Link></Button>
+        </section>
+      ) : null}
+
       <div className="grid gap-4 md:grid-cols-2">
-        <StatusCard
-          icon={Zap}
-          title="Available Now"
-          active={availableNow}
-          description="Temporary live badge. This can be active at the same time as travel and mobile service."
-        >
+        <StatusCard icon={Zap} title="Available Now" active={availableNow} description="Temporary live badge. This can be active at the same time as travel and mobile service.">
           <Button onClick={toggleAvailableNow} disabled={saving === "available"}>
             {saving === "available" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Zap className="mr-2 h-4 w-4" />}
             {availableNow ? "Turn off live badge" : "Activate Available Now"}
           </Button>
         </StatusCard>
 
-        <StatusCard
-          icon={Plane}
-          title="Traveling"
-          active={traveling}
-          description="Travel dates work independently and surface your profile in destination-city discovery."
-        >
+        <StatusCard icon={Plane} title="Traveling" active={traveling} description="Travel dates surface approved profiles in destination city discovery.">
           <Button asChild variant="outline"><Link href="/pro/growth"><Plane className="mr-2 h-4 w-4" />Manage travel dates</Link></Button>
         </StatusCard>
 
-        <StatusCard
-          icon={Car}
-          title="Mobile / Outcall"
-          description="Configure outcall service and radius separately from Available Now and travel."
-        >
+        <StatusCard icon={Car} title="Mobile / Outcall" description="Configure outcall service and radius separately from Available Now and travel.">
           <Button asChild variant="outline"><Link href="/pro/listing"><Car className="mr-2 h-4 w-4" />Configure mobile service</Link></Button>
         </StatusCard>
 
-        <StatusCard
-          icon={visible ? Eye : EyeOff}
-          title="Profile visibility"
-          active={visible}
-          description="This is the master switch. OFF is the only state that removes your profile from public discovery."
-        >
+        <StatusCard icon={visible ? Eye : EyeOff} title="Profile visibility" active={visible} description="Visibility controls discovery, while approval remains a separate trust state.">
           <Button variant={visible ? "outline" : "default"} onClick={toggleVisibility} disabled={saving === "visibility"}>
             {saving === "visibility" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : visible ? <EyeOff className="mr-2 h-4 w-4" /> : <Eye className="mr-2 h-4 w-4" />}
             {visible ? "Turn profile OFF" : "Turn profile ON"}
@@ -188,6 +266,8 @@ export default function ProDashboardPage() {
           <Button asChild variant="outline"><Link href="/pro/listing">Profile & pricing</Link></Button>
           <Button asChild variant="outline"><Link href="/pro/growth">Travel & specials</Link></Button>
           <Button asChild variant="outline"><Link href="/pro/photos">Photos</Link></Button>
+          <Button asChild variant="outline"><Link href="/pro/analytics">Analytics</Link></Button>
+          <Button asChild variant="outline"><Link href="/pro/ai-coach">AI Coach</Link></Button>
           <Button asChild variant="outline"><Link href="/pro/subscription">Subscription</Link></Button>
         </div>
       </section>


### PR DESCRIPTION
Fixes the admin review visibility bug and connects both dashboards to production Supabase signals.

Admin:
- surfaces under_review and pending profile states
- replaces public-directory-only stats with direct provider profile counts
- adds live review, moderation, identity, support and city metrics
- removes booking/SMS home cards that do not match the directory-only product

Provider dashboard:
- shows profile approval status and visibility separately
- surfaces AI profile score, views, contacts, local demand and profile completion
- shows photo moderation, identity verification, support and notification signals
- keeps Available Now, Travel, Mobile and visibility controls

No database migration or data mutation is included.