### PR TITLE
Add admin messaging dashboard foundation

### DIFF
--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -45,6 +45,7 @@ const navSections = [
   {
     title: "Communication",
     items: [
+      { href: "/admin/messaging", label: "Messaging", icon: MessageSquare },
       { href: "/admin/emails", label: "Email Center", icon: Mail },
       { href: "/admin/tickets", label: "Tickets", icon: MessageSquare },
       { href: "/admin/support", label: "Support", icon: LifeBuoy },

--- a/src/app/admin/messaging/AdminMessaging.tsx
+++ b/src/app/admin/messaging/AdminMessaging.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  Bot,
+  CirclePause,
+  CirclePlay,
+  Clock3,
+  MessageSquare,
+  RefreshCw,
+  Search,
+  Send,
+  ShieldOff,
+  Users,
+} from "lucide-react";
+
+import { requestJson } from "@/app/_lib/request";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+
+type Contact = {
+  id: string;
+  phone_e164: string;
+  name: string | null;
+  city: string | null;
+  state: string | null;
+  lifecycle_status: string;
+  knotty_enabled: boolean;
+  opted_out: boolean;
+  last_activity_at: string | null;
+};
+
+type Conversation = {
+  id: string;
+  contact_id: string;
+  current_channel: string;
+  unread_count: number;
+  last_message_at: string | null;
+  messaging_contacts?: Contact | Contact[] | null;
+};
+
+type Message = {
+  id: string;
+  direction: "inbound" | "outbound";
+  sender_type: string;
+  body: string;
+  channel: string;
+  delivery_status: string;
+  created_at: string;
+};
+
+type QueueItem = {
+  id: string;
+  status: string;
+  body: string;
+  attempts: number;
+  max_attempts: number;
+  scheduled_for: string;
+  last_error: string | null;
+  messaging_contacts?: { id: string; name: string | null; phone_e164: string; city: string | null; state: string | null } | null;
+};
+
+type Campaign = {
+  id: string;
+  name: string;
+  status: string;
+  transport_preference: string;
+  created_at: string;
+};
+
+type Snapshot = {
+  ok: boolean;
+  settings: {
+    receiving_number: string;
+    transport_mode: string;
+    knotty_enabled: boolean;
+    global_pause: boolean;
+  } | null;
+  contacts: Contact[];
+  conversations: Conversation[];
+  campaigns: Campaign[];
+  queue: QueueItem[];
+  messages: Message[];
+  counts: {
+    contacts: number;
+    optedOut: number;
+    pending: number;
+    failed: number;
+    openConversations: number;
+  };
+};
+
+function getConversationContact(conversation: Conversation): Contact | null {
+  const value = conversation.messaging_contacts;
+  if (Array.isArray(value)) return value[0] || null;
+  return value || null;
+}
+
+function when(value: string | null) {
+  if (!value) return "No activity";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+export default function AdminMessaging() {
+  const [data, setData] = useState<Snapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    try {
+      setError("");
+      const params = new URLSearchParams();
+      if (query.trim()) params.set("q", query.trim());
+      if (selectedConversationId) params.set("conversationId", selectedConversationId);
+      const next = await requestJson<Snapshot>(`/api/admin/messaging?${params.toString()}`);
+      setData(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load messaging dashboard");
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [query, selectedConversationId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => void load(true), 5000);
+    return () => window.clearInterval(timer);
+  }, [load]);
+
+  const selectedConversation = useMemo(
+    () => data?.conversations.find((item) => item.id === selectedConversationId) || null,
+    [data?.conversations, selectedConversationId],
+  );
+
+  const selectedConversationContact = selectedConversation ? getConversationContact(selectedConversation) : null;
+  const activeContactId = selectedConversationContact?.id || selectedContactId;
+  const activeContact = data?.contacts.find((item) => item.id === activeContactId) || selectedConversationContact || null;
+
+  async function post(body: Record<string, unknown>) {
+    setSaving(true);
+    try {
+      setError("");
+      await requestJson("/api/admin/messaging", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      await load(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Messaging action failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function sendMessage() {
+    if (!activeContact || !draft.trim()) return;
+    await post({ action: "queue_message", contactId: activeContact.id, body: draft.trim() });
+    setDraft("");
+  }
+
+  if (loading && !data) {
+    return <div className="flex min-h-[50vh] items-center justify-center text-sm text-slate-500">Loading messaging operations...</div>;
+  }
+
+  const counts = data?.counts || { contacts: 0, optedOut: 0, pending: 0, failed: 0, openConversations: 0 };
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-slate-950">Messaging</h1>
+          <p className="text-sm text-slate-500">Campaign queue, inbox, KNOTTY controls and delivery operations.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{data?.settings?.receiving_number || "No line"}</Badge>
+          <Badge variant="outline">Transport: {data?.settings?.transport_mode || "unknown"}</Badge>
+          <Button variant="outline" size="sm" onClick={() => void load()} disabled={loading}>
+            <RefreshCw className="mr-2 h-4 w-4" />Refresh
+          </Button>
+          <Button
+            size="sm"
+            variant={data?.settings?.global_pause ? "default" : "destructive"}
+            disabled={saving}
+            onClick={() => void post({ action: "update_settings", globalPause: !data?.settings?.global_pause })}
+          >
+            {data?.settings?.global_pause ? <CirclePlay className="mr-2 h-4 w-4" /> : <CirclePause className="mr-2 h-4 w-4" />}
+            {data?.settings?.global_pause ? "Resume" : "Pause all"}
+          </Button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <AlertCircle className="h-4 w-4" />{error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        {[
+          ["Contacts", counts.contacts, Users],
+          ["Open chats", counts.openConversations, MessageSquare],
+          ["Queued", counts.pending, Clock3],
+          ["Failed", counts.failed, AlertCircle],
+          ["Opted out", counts.optedOut, ShieldOff],
+        ].map(([label, value, Icon]) => (
+          <Card key={String(label)}>
+            <CardContent className="flex items-center justify-between p-4">
+              <div><p className="text-xs font-medium uppercase tracking-wide text-slate-500">{String(label)}</p><p className="mt-1 text-2xl font-bold">{String(value)}</p></div>
+              <Icon className="h-5 w-5 text-slate-400" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Tabs defaultValue="inbox" className="space-y-4">
+        <TabsList className="w-full justify-start overflow-x-auto">
+          <TabsTrigger value="inbox">Inbox</TabsTrigger>
+          <TabsTrigger value="contacts">Contacts</TabsTrigger>
+          <TabsTrigger value="queue">Queue</TabsTrigger>
+          <TabsTrigger value="campaigns">Campaigns</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="inbox">
+          <div className="grid min-h-[620px] gap-4 xl:grid-cols-[340px_minmax(0,1fr)]">
+            <Card className="overflow-hidden">
+              <CardHeader className="border-b p-4"><CardTitle className="text-base">Conversations</CardTitle></CardHeader>
+              <CardContent className="max-h-[700px] space-y-1 overflow-y-auto p-2">
+                {(data?.conversations || []).length === 0 ? <p className="p-4 text-sm text-slate-500">No conversations yet.</p> : null}
+                {(data?.conversations || []).map((conversation) => {
+                  const contact = getConversationContact(conversation);
+                  const active = conversation.id === selectedConversationId;
+                  return (
+                    <button
+                      key={conversation.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedConversationId(conversation.id);
+                        if (conversation.unread_count > 0) void post({ action: "mark_read", conversationId: conversation.id });
+                      }}
+                      className={`w-full rounded-lg p-3 text-left transition ${active ? "bg-slate-900 text-white" : "hover:bg-slate-50"}`}
+                    >
+                      <div className="flex items-center justify-between gap-2"><span className="truncate text-sm font-semibold">{contact?.name || contact?.phone_e164 || "Unknown"}</span>{conversation.unread_count > 0 ? <Badge>{conversation.unread_count}</Badge> : null}</div>
+                      <p className={`mt-1 truncate text-xs ${active ? "text-slate-300" : "text-slate-500"}`}>{contact?.city || "Unknown city"} · {conversation.current_channel}</p>
+                      <p className={`mt-2 text-[11px] ${active ? "text-slate-400" : "text-slate-400"}`}>{when(conversation.last_message_at)}</p>
+                    </button>
+                  );
+                })}
+              </CardContent>
+            </Card>
+
+            <Card className="flex min-h-[620px] flex-col overflow-hidden">
+              <CardHeader className="border-b p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-base">{activeContact?.name || activeContact?.phone_e164 || "Select a conversation"}</CardTitle>
+                    {activeContact ? <p className="mt-1 text-xs text-slate-500">{activeContact.phone_e164} · {activeContact.city || "Unknown city"}</p> : null}
+                  </div>
+                  {activeContact ? (
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" disabled={saving || activeContact.opted_out} onClick={() => void post({ action: "update_contact", contactId: activeContact.id, knottyEnabled: !activeContact.knotty_enabled })}>
+                        <Bot className="mr-2 h-4 w-4" />KNOTTY {activeContact.knotty_enabled ? "On" : "Off"}
+                      </Button>
+                      <Button size="sm" variant="outline" disabled={saving} onClick={() => void post({ action: "update_contact", contactId: activeContact.id, optedOut: !activeContact.opted_out, optedOutReason: activeContact.opted_out ? null : "admin" })}>
+                        {activeContact.opted_out ? "Restore" : "Opt out"}
+                      </Button>
+                    </div>
+                  ) : null}
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col p-0">
+                <div className="flex-1 space-y-3 overflow-y-auto p-4">
+                  {!selectedConversationId ? <p className="text-sm text-slate-500">Choose a conversation to view its history.</p> : null}
+                  {(data?.messages || []).map((message) => (
+                    <div key={message.id} className={`flex ${message.direction === "outbound" ? "justify-end" : "justify-start"}`}>
+                      <div className={`max-w-[82%] rounded-2xl px-4 py-3 text-sm ${message.direction === "outbound" ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-900"}`}>
+                        <p className="whitespace-pre-wrap">{message.body}</p>
+                        <div className={`mt-2 flex flex-wrap gap-2 text-[10px] ${message.direction === "outbound" ? "text-slate-300" : "text-slate-500"}`}>
+                          <span>{message.sender_type}</span><span>{message.channel}</span><span>{message.delivery_status}</span><span>{when(message.created_at)}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="border-t p-4">
+                  <div className="flex gap-2">
+                    <Textarea value={draft} onChange={(event) => setDraft(event.target.value)} placeholder={activeContact?.opted_out ? "Contact is opted out" : "Write a manual message..."} disabled={!activeContact || activeContact.opted_out || saving} className="min-h-[84px]" />
+                    <Button className="self-end" disabled={!activeContact || activeContact.opted_out || !draft.trim() || saving} onClick={() => void sendMessage()}><Send className="h-4 w-4" /></Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="contacts">
+          <Card>
+            <CardHeader className="gap-3 md:flex-row md:items-center md:justify-between">
+              <CardTitle className="text-base">Contacts</CardTitle>
+              <div className="flex w-full gap-2 md:w-auto"><Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search name, phone or city" className="md:w-80" /><Button variant="outline" onClick={() => void load()}><Search className="h-4 w-4" /></Button></div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {(data?.contacts || []).map((contact) => (
+                <div key={contact.id} className="flex flex-col gap-3 rounded-lg border p-3 md:flex-row md:items-center md:justify-between">
+                  <div><p className="font-medium">{contact.name || "Unnamed contact"}</p><p className="text-sm text-slate-500">{contact.phone_e164} · {contact.city || "Unknown city"}{contact.state ? `, ${contact.state}` : ""}</p></div>
+                  <div className="flex flex-wrap items-center gap-2"><Badge variant="outline">{contact.lifecycle_status}</Badge>{contact.opted_out ? <Badge variant="destructive">Opted out</Badge> : null}<Button size="sm" variant="outline" onClick={() => { setSelectedContactId(contact.id); setSelectedConversationId(null); }}>Open</Button></div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="queue">
+          <Card><CardHeader><CardTitle className="text-base">Outbound queue</CardTitle></CardHeader><CardContent className="space-y-2">{(data?.queue || []).map((item) => <div key={item.id} className="rounded-lg border p-3"><div className="flex flex-wrap items-center justify-between gap-2"><p className="font-medium">{item.messaging_contacts?.name || item.messaging_contacts?.phone_e164 || "Unknown contact"}</p><Badge variant="outline">{item.status}</Badge></div><p className="mt-2 line-clamp-2 text-sm text-slate-600">{item.body}</p><p className="mt-2 text-xs text-slate-400">Scheduled {when(item.scheduled_for)} · attempts {item.attempts}/{item.max_attempts}{item.last_error ? ` · ${item.last_error}` : ""}</p></div>)}</CardContent></Card>
+        </TabsContent>
+
+        <TabsContent value="campaigns">
+          <Card><CardHeader><CardTitle className="text-base">Campaigns</CardTitle></CardHeader><CardContent className="space-y-2">{(data?.campaigns || []).length === 0 ? <p className="text-sm text-slate-500">No campaigns created yet.</p> : null}{(data?.campaigns || []).map((campaign) => <div key={campaign.id} className="flex flex-col gap-2 rounded-lg border p-3 md:flex-row md:items-center md:justify-between"><div><p className="font-medium">{campaign.name}</p><p className="text-xs text-slate-500">Created {when(campaign.created_at)} · {campaign.transport_preference}</p></div><Badge variant="outline">{campaign.status}</Badge></div>)}</CardContent></Card>
+        </TabsContent>
+
+        <TabsContent value="settings">
+          <Card><CardHeader><CardTitle className="text-base">Messaging controls</CardTitle></CardHeader><CardContent className="space-y-4"><div className="rounded-lg border p-4"><p className="font-medium">Global sending</p><p className="mt-1 text-sm text-slate-500">Stops or resumes the outbound queue without deleting pending messages.</p><Button className="mt-3" variant={data?.settings?.global_pause ? "default" : "destructive"} onClick={() => void post({ action: "update_settings", globalPause: !data?.settings?.global_pause })}>{data?.settings?.global_pause ? "Resume all sending" : "Pause all sending"}</Button></div><div className="rounded-lg border p-4"><p className="font-medium">KNOTTY global switch</p><p className="mt-1 text-sm text-slate-500">Master control for automated reply eligibility. Contact opt outs remain blocking.</p><Button className="mt-3" variant="outline" onClick={() => void post({ action: "update_settings", knottyEnabled: !data?.settings?.knotty_enabled })}>KNOTTY {data?.settings?.knotty_enabled ? "Enabled" : "Disabled"}</Button></div></CardContent></Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/admin/messaging/page.tsx
+++ b/src/app/admin/messaging/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+import { createPageMetadata } from "@/app/_lib/seo";
+import AdminMessaging from "./AdminMessaging";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Messaging",
+  description: "Private MasseurMatch messaging operations dashboard.",
+  path: "/admin/messaging",
+  noIndex: true,
+});
+
+export default function AdminMessagingPage() {
+  return <AdminMessaging />;
+}

--- a/src/app/api/admin/messaging/route.ts
+++ b/src/app/api/admin/messaging/route.ts
@@ -1,0 +1,336 @@
+export const dynamic = "force-dynamic";
+
+import { z } from "zod";
+
+import { assertRateLimit } from "@/app/_lib/security";
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+
+const updateSettingsSchema = z.object({
+  action: z.literal("update_settings"),
+  globalPause: z.boolean().optional(),
+  knottyEnabled: z.boolean().optional(),
+});
+
+const updateContactSchema = z.object({
+  action: z.literal("update_contact"),
+  contactId: z.string().uuid(),
+  lifecycleStatus: z.enum(["new", "contacted", "replied", "interested", "converted", "closed"]).optional(),
+  knottyEnabled: z.boolean().optional(),
+  optedOut: z.boolean().optional(),
+  optedOutReason: z.string().trim().max(300).optional().nullable(),
+});
+
+const queueMessageSchema = z.object({
+  action: z.literal("queue_message"),
+  contactId: z.string().uuid(),
+  body: z.string().trim().min(1).max(4000),
+});
+
+const markReadSchema = z.object({
+  action: z.literal("mark_read"),
+  conversationId: z.string().uuid(),
+});
+
+const postSchema = z.discriminatedUnion("action", [
+  updateSettingsSchema,
+  updateContactSchema,
+  queueMessageSchema,
+  markReadSchema,
+]);
+
+type DbClient = ReturnType<typeof createSupabaseAdminClient> & {
+  from: (table: string) => any;
+};
+
+type QueryResult<T> = { data: T | null; error: { message: string } | null; count?: number | null };
+
+function assertQuery<T>(result: QueryResult<T>, label: string): T | null {
+  if (result.error) throw new RouteError(500, `${label}: ${result.error.message}`);
+  return result.data;
+}
+
+function safeSearch(value: string | null) {
+  if (!value) return null;
+  return value.trim().replace(/[,%()]/g, " ").slice(0, 120) || null;
+}
+
+export async function GET(request: Request) {
+  try {
+    await requireAdminSession(request);
+    assertRateLimit(request, "admin-messaging-read", { limit: 120, windowMs: 60_000 });
+
+    const url = new URL(request.url);
+    const search = safeSearch(url.searchParams.get("q"));
+    const conversationId = url.searchParams.get("conversationId");
+    if (conversationId && !z.string().uuid().safeParse(conversationId).success) {
+      throw new RouteError(400, "Invalid conversation id.");
+    }
+
+    const db = createSupabaseAdminClient() as DbClient;
+
+    let contactsQuery = db
+      .from("messaging_contacts")
+      .select(
+        "id,phone_e164,name,city,state,timezone,profile_url,lifecycle_status,knotty_enabled,opted_out,opted_out_at,opted_out_reason,last_outbound_at,last_inbound_at,last_activity_at,created_at,updated_at",
+      )
+      .order("last_activity_at", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(300);
+
+    if (search) {
+      contactsQuery = contactsQuery.or(`name.ilike.%${search}%,phone_e164.ilike.%${search}%,city.ilike.%${search}%`);
+    }
+
+    const [
+      settingsResult,
+      contactsResult,
+      conversationsResult,
+      campaignsResult,
+      queueResult,
+      totalContactsResult,
+      optedOutResult,
+      pendingQueueResult,
+      failedQueueResult,
+      openConversationsResult,
+    ] = await Promise.all([
+      db.from("messaging_settings").select("*").eq("id", "default").maybeSingle(),
+      contactsQuery,
+      db
+        .from("messaging_conversations")
+        .select(
+          "id,contact_id,receiving_number,status,knotty_enabled,current_channel,unread_count,last_message_at,last_inbound_at,last_outbound_at,created_at,updated_at,messaging_contacts(id,name,phone_e164,city,state,lifecycle_status,opted_out,knotty_enabled)",
+        )
+        .order("last_message_at", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false })
+        .limit(150),
+      db
+        .from("messaging_campaigns")
+        .select("id,name,status,transport_preference,started_at,completed_at,created_at,updated_at")
+        .order("created_at", { ascending: false })
+        .limit(20),
+      db
+        .from("messaging_queue")
+        .select(
+          "id,campaign_id,contact_id,conversation_id,message_id,body,transport_preference,status,scheduled_for,priority,attempts,max_attempts,locked_at,locked_by,last_error,sent_at,delivered_at,failed_at,created_at,messaging_contacts(id,name,phone_e164,city,state)",
+        )
+        .order("created_at", { ascending: false })
+        .limit(100),
+      db.from("messaging_contacts").select("id", { count: "exact", head: true }),
+      db.from("messaging_contacts").select("id", { count: "exact", head: true }).eq("opted_out", true),
+      db.from("messaging_queue").select("id", { count: "exact", head: true }).in("status", ["pending", "processing"]),
+      db.from("messaging_queue").select("id", { count: "exact", head: true }).eq("status", "failed"),
+      db.from("messaging_conversations").select("id", { count: "exact", head: true }).eq("status", "open"),
+    ]);
+
+    const selectedMessagesResult = conversationId
+      ? await db
+          .from("messaging_messages")
+          .select(
+            "id,conversation_id,contact_id,campaign_id,direction,sender_type,body,channel,delivery_status,external_id,sent_at,delivered_at,received_at,failed_at,error_code,error_message,created_at,updated_at",
+          )
+          .eq("conversation_id", conversationId)
+          .order("created_at", { ascending: true })
+          .limit(500)
+      : ({ data: [], error: null } as QueryResult<any[]>);
+
+    const settings = assertQuery<any>(settingsResult, "Load messaging settings");
+    const contacts = assertQuery<any[]>(contactsResult, "Load messaging contacts") || [];
+    const conversations = assertQuery<any[]>(conversationsResult, "Load messaging conversations") || [];
+    const campaigns = assertQuery<any[]>(campaignsResult, "Load messaging campaigns") || [];
+    const queue = assertQuery<any[]>(queueResult, "Load messaging queue") || [];
+    const messages = assertQuery<any[]>(selectedMessagesResult, "Load conversation messages") || [];
+
+    for (const [result, label] of [
+      [totalContactsResult, "Count contacts"],
+      [optedOutResult, "Count opt outs"],
+      [pendingQueueResult, "Count queue"],
+      [failedQueueResult, "Count failures"],
+      [openConversationsResult, "Count conversations"],
+    ] as Array<[QueryResult<unknown>, string]>) {
+      if (result.error) throw new RouteError(500, `${label}: ${result.error.message}`);
+    }
+
+    return json({
+      ok: true,
+      settings,
+      contacts,
+      conversations,
+      campaigns,
+      queue,
+      messages,
+      counts: {
+        contacts: totalContactsResult.count || 0,
+        optedOut: optedOutResult.count || 0,
+        pending: pendingQueueResult.count || 0,
+        failed: failedQueueResult.count || 0,
+        openConversations: openConversationsResult.count || 0,
+      },
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-messaging-write", { limit: 60, windowMs: 60_000 });
+    const body = await parseJsonBody(request, postSchema);
+    const db = createSupabaseAdminClient() as DbClient;
+
+    if (body.action === "update_settings") {
+      const patch: Record<string, unknown> = {};
+      if (body.globalPause !== undefined) patch.global_pause = body.globalPause;
+      if (body.knottyEnabled !== undefined) patch.knotty_enabled = body.knottyEnabled;
+      if (Object.keys(patch).length === 0) throw new RouteError(400, "No settings supplied.");
+
+      const { data, error } = await db
+        .from("messaging_settings")
+        .update(patch)
+        .eq("id", "default")
+        .select("*")
+        .single();
+      if (error) throw new RouteError(500, error.message);
+
+      await recordAuditLog(admin.userId, "admin_messaging_settings_updated", "messaging_settings", "default", patch);
+      return json({ ok: true, settings: data });
+    }
+
+    if (body.action === "update_contact") {
+      const patch: Record<string, unknown> = {};
+      if (body.lifecycleStatus !== undefined) patch.lifecycle_status = body.lifecycleStatus;
+      if (body.knottyEnabled !== undefined) patch.knotty_enabled = body.knottyEnabled;
+      if (body.optedOut !== undefined) {
+        patch.opted_out = body.optedOut;
+        patch.opted_out_at = body.optedOut ? new Date().toISOString() : null;
+        patch.opted_out_reason = body.optedOut ? body.optedOutReason || "admin" : null;
+        if (body.optedOut) patch.knotty_enabled = false;
+      }
+      if (Object.keys(patch).length === 0) throw new RouteError(400, "No contact changes supplied.");
+
+      const { data, error } = await db
+        .from("messaging_contacts")
+        .update(patch)
+        .eq("id", body.contactId)
+        .select(
+          "id,phone_e164,name,city,state,lifecycle_status,knotty_enabled,opted_out,opted_out_at,opted_out_reason,last_activity_at,updated_at",
+        )
+        .single();
+      if (error) throw new RouteError(500, error.message);
+
+      await recordAuditLog(admin.userId, "admin_messaging_contact_updated", "messaging_contact", body.contactId, patch);
+      return json({ ok: true, contact: data });
+    }
+
+    if (body.action === "mark_read") {
+      const { error } = await db
+        .from("messaging_conversations")
+        .update({ unread_count: 0 })
+        .eq("id", body.conversationId);
+      if (error) throw new RouteError(500, error.message);
+      return json({ ok: true });
+    }
+
+    const { data: contact, error: contactError } = await db
+      .from("messaging_contacts")
+      .select("id,phone_e164,opted_out,knotty_enabled")
+      .eq("id", body.contactId)
+      .single();
+    if (contactError) throw new RouteError(500, contactError.message);
+    if (!contact) throw new RouteError(404, "Contact not found.");
+    if (contact.opted_out) throw new RouteError(409, "This contact is opted out and cannot be messaged.");
+
+    const { data: settings, error: settingsError } = await db
+      .from("messaging_settings")
+      .select("receiving_number,transport_mode,global_pause")
+      .eq("id", "default")
+      .single();
+    if (settingsError) throw new RouteError(500, settingsError.message);
+    if (settings?.global_pause) throw new RouteError(409, "Messaging is globally paused.");
+
+    let { data: conversation, error: conversationError } = await db
+      .from("messaging_conversations")
+      .select("id")
+      .eq("contact_id", body.contactId)
+      .eq("receiving_number", settings.receiving_number)
+      .eq("status", "open")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (conversationError) throw new RouteError(500, conversationError.message);
+
+    if (!conversation) {
+      const created = await db
+        .from("messaging_conversations")
+        .insert({
+          contact_id: body.contactId,
+          receiving_number: settings.receiving_number,
+          current_channel: "unknown",
+          knotty_enabled: Boolean(contact.knotty_enabled),
+        })
+        .select("id")
+        .single();
+      if (created.error) throw new RouteError(500, created.error.message);
+      conversation = created.data;
+    }
+
+    const idempotencyKey = `manual:${body.contactId}:${crypto.randomUUID()}`;
+    const createdMessage = await db
+      .from("messaging_messages")
+      .insert({
+        conversation_id: conversation.id,
+        contact_id: body.contactId,
+        direction: "outbound",
+        sender_type: "human",
+        body: body.body,
+        channel: "unknown",
+        delivery_status: "queued",
+        idempotency_key: idempotencyKey,
+      })
+      .select("id")
+      .single();
+    if (createdMessage.error) throw new RouteError(500, createdMessage.error.message);
+
+    const queued = await db
+      .from("messaging_queue")
+      .insert({
+        contact_id: body.contactId,
+        conversation_id: conversation.id,
+        message_id: createdMessage.data.id,
+        body: body.body,
+        transport_preference: settings.transport_mode || "automatic",
+        status: "pending",
+        idempotency_key: idempotencyKey,
+      })
+      .select("id,status,scheduled_for")
+      .single();
+
+    if (queued.error) {
+      await db
+        .from("messaging_messages")
+        .update({ delivery_status: "failed", failed_at: new Date().toISOString(), error_message: queued.error.message })
+        .eq("id", createdMessage.data.id);
+      throw new RouteError(500, queued.error.message);
+    }
+
+    await recordAuditLog(admin.userId, "admin_messaging_message_queued", "messaging_message", createdMessage.data.id, {
+      contactId: body.contactId,
+      conversationId: conversation.id,
+      queueId: queued.data.id,
+    });
+
+    return json({
+      ok: true,
+      messageId: createdMessage.data.id,
+      queue: queued.data,
+      conversationId: conversation.id,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first admin messaging operations layer for MasseurMatch.

### Included
- `/admin/messaging` dashboard
- authenticated `/api/admin/messaging` snapshot and actions
- contacts, conversations, queue, campaigns and settings views
- manual outbound queueing
- global pause control
- per-contact KNOTTY toggle
- opt-out control
- unread conversation reset
- admin navigation entry

### Backend alignment
Uses the new Supabase `messaging_*` tables already provisioned in the MasseurMatch production project. Existing `contact_inquiries`, `sms_logs` and `sms_profiles` are not repurposed.

### Safety
- admin session required
- rate limiting on reads and writes
- opted-out contacts cannot be queued
- global pause blocks manual queueing
- outbound messages use idempotency keys
- admin actions are audit logged

Do not merge until checks are green.