### PR TITLE
Consolidate local therapist discovery

### DIFF
--- a/src/app/_components/geo-area-callout.tsx
+++ b/src/app/_components/geo-area-callout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { LocateFixed } from "lucide-react";
 import { IconMapPin } from "@/components/icons";
@@ -14,6 +15,8 @@ import { formatCityLabel } from "@/data/cities";
 type GeoAreaCalloutProps = {
   className?: string;
   navigateToSearch?: boolean;
+  navigateToCity?: boolean;
+  autoNavigateToCity?: boolean;
   onResolved?: (city: CityData) => void;
   source?: string;
   tone?: "default" | "inverse";
@@ -23,6 +26,8 @@ type GeoAreaCalloutProps = {
 export function GeoAreaCallout({
   className,
   navigateToSearch = false,
+  navigateToCity = false,
+  autoNavigateToCity = false,
   onResolved,
   source = "geolocation",
   tone = "default",
@@ -33,6 +38,12 @@ export function GeoAreaCallout({
 
   const isInverse = tone === "inverse";
   const cityLabel = city ? `${formatCityLabel(city.name, city.stateCode)}` : null;
+
+  useEffect(() => {
+    if (city && navigateToCity && autoNavigateToCity) {
+      router.replace(`/${city.slug}`);
+    }
+  }, [autoNavigateToCity, city, navigateToCity, router]);
 
   const message = cityLabel
     ? `Location ready: ${cityLabel}.`
@@ -50,6 +61,11 @@ export function GeoAreaCallout({
     }
 
     onResolved?.(resolvedCity);
+
+    if (navigateToCity) {
+      router.push(`/${resolvedCity.slug}`);
+      return;
+    }
 
     if (navigateToSearch) {
       router.push(

--- a/src/app/admin/messaging/AdminMessaging.tsx
+++ b/src/app/admin/messaging/AdminMessaging.tsx
@@ -14,6 +14,7 @@ import {
   ShieldOff,
   Users,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 import { requestJson } from "@/app/_lib/request";
 import { Badge } from "@/components/ui/badge";
@@ -182,6 +183,13 @@ export default function AdminMessaging() {
   }
 
   const counts = data?.counts || { contacts: 0, optedOut: 0, pending: 0, failed: 0, openConversations: 0 };
+  const summaryCards: Array<{ label: string; value: number; Icon: LucideIcon }> = [
+    { label: "Contacts", value: counts.contacts, Icon: Users },
+    { label: "Open chats", value: counts.openConversations, Icon: MessageSquare },
+    { label: "Queued", value: counts.pending, Icon: Clock3 },
+    { label: "Failed", value: counts.failed, Icon: AlertCircle },
+    { label: "Opted out", value: counts.optedOut, Icon: ShieldOff },
+  ];
 
   return (
     <div className="space-y-5">
@@ -215,16 +223,10 @@ export default function AdminMessaging() {
       ) : null}
 
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-        {[
-          ["Contacts", counts.contacts, Users],
-          ["Open chats", counts.openConversations, MessageSquare],
-          ["Queued", counts.pending, Clock3],
-          ["Failed", counts.failed, AlertCircle],
-          ["Opted out", counts.optedOut, ShieldOff],
-        ].map(([label, value, Icon]) => (
-          <Card key={String(label)}>
+        {summaryCards.map(({ label, value, Icon }) => (
+          <Card key={label}>
             <CardContent className="flex items-center justify-between p-4">
-              <div><p className="text-xs font-medium uppercase tracking-wide text-slate-500">{String(label)}</p><p className="mt-1 text-2xl font-bold">{String(value)}</p></div>
+              <div><p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p><p className="mt-1 text-2xl font-bold">{value}</p></div>
               <Icon className="h-5 w-5 text-slate-400" />
             </CardContent>
           </Card>

--- a/src/app/api/admin/messaging/route.ts
+++ b/src/app/api/admin/messaging/route.ts
@@ -9,6 +9,7 @@ import {
   recordAuditLog,
   requireAdminSession,
 } from "@/app/api/_lib/supabase-server";
+import type { Json } from "@/integrations/supabase/types";
 
 const updateSettingsSchema = z.object({
   action: z.literal("update_settings"),
@@ -184,7 +185,7 @@ export async function POST(request: Request) {
     const db = createSupabaseAdminClient() as DbClient;
 
     if (body.action === "update_settings") {
-      const patch: Record<string, unknown> = {};
+      const patch: { [key: string]: Json | undefined } = {};
       if (body.globalPause !== undefined) patch.global_pause = body.globalPause;
       if (body.knottyEnabled !== undefined) patch.knotty_enabled = body.knottyEnabled;
       if (Object.keys(patch).length === 0) throw new RouteError(400, "No settings supplied.");
@@ -202,7 +203,7 @@ export async function POST(request: Request) {
     }
 
     if (body.action === "update_contact") {
-      const patch: Record<string, unknown> = {};
+      const patch: { [key: string]: Json | undefined } = {};
       if (body.lifecycleStatus !== undefined) patch.lifecycle_status = body.lifecycleStatus;
       if (body.knottyEnabled !== undefined) patch.knotty_enabled = body.knottyEnabled;
       if (body.optedOut !== undefined) {

--- a/src/app/api/admin/messaging/route.ts
+++ b/src/app/api/admin/messaging/route.ts
@@ -253,7 +253,7 @@ export async function POST(request: Request) {
     if (settingsError) throw new RouteError(500, settingsError.message);
     if (settings?.global_pause) throw new RouteError(409, "Messaging is globally paused.");
 
-    let { data: conversation, error: conversationError } = await db
+    const { data: existingConversation, error: conversationError } = await db
       .from("messaging_conversations")
       .select("id")
       .eq("contact_id", body.contactId)
@@ -263,6 +263,8 @@ export async function POST(request: Request) {
       .limit(1)
       .maybeSingle();
     if (conversationError) throw new RouteError(500, conversationError.message);
+
+    let conversation = existingConversation;
 
     if (!conversation) {
       const created = await db

--- a/src/app/api/pro/growth/route.ts
+++ b/src/app/api/pro/growth/route.ts
@@ -14,7 +14,7 @@ import type { Database } from "@/integrations/supabase/types";
 type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
 
 const GROWTH_SELECT =
-  "id, slug, city, subscription_tier, available_now, available_now_expires, travel_schedule, promotions, visibility_status, is_active, profile_status, profile_completion_score, profile_views";
+  "id, slug, city, subscription_tier, available_now, available_now_expires, travel_schedule, promotions, visibility_status, is_active, profile_status, profile_views";
 
 const travelEntrySchema = z.object({
   city: z.string().min(1).max(120),

--- a/src/app/near-me/page.tsx
+++ b/src/app/near-me/page.tsx
@@ -2,14 +2,12 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { JsonLd } from "@/app/_components/json-ld";
 import { GeoAreaCallout } from "@/app/_components/geo-area-callout";
-import { getCities, getPublicTherapists } from "@/app/_lib/directory";
+import { getCities } from "@/app/_lib/directory";
 import {
   buildBreadcrumbJsonLd,
   buildCollectionPageJsonLd,
-  buildItemListJsonLd,
   createPageMetadata,
 } from "@/app/_lib/seo";
-import SearchPageClient from "@/app/search/SearchPageClient";
 import { formatCityLabel } from "@/data/cities";
 
 export const dynamic = "force-dynamic";
@@ -30,7 +28,6 @@ export const metadata: Metadata = createPageMetadata({
 
 export default async function NearMePage() {
   const cities = getCities();
-  const results = await getPublicTherapists({ page: 1, pageSize: 500 });
   const topCities = cities.slice(0, 12);
 
   return (
@@ -49,17 +46,6 @@ export default async function NearMePage() {
           path: "/near-me",
         })}
       />
-      <JsonLd
-        data={buildItemListJsonLd({
-          name: "Massage therapists near me",
-          path: "/near-me",
-          items: results.items.map((item) => ({
-            name: item.display_name || item.full_name || "Therapist",
-            path: `/therapists/${item.slug || item.id}`,
-          })),
-        })}
-      />
-
       <main className="page-shell py-6 sm:py-8">
         <header className="mb-4">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-secondary">Near me</p>
@@ -67,28 +53,16 @@ export default async function NearMePage() {
             Find massage therapists near you
           </h1>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Browse profiles now, or use your location to narrow the directory to your area.
+            Use your location to open the local city directory. We do not show unrelated listings from across the country on this page.
           </p>
         </header>
 
-        <GeoAreaCallout compact navigateToSearch source="near-me" className="mb-5" />
-
-        <SearchPageClient
-          cities={cities}
-          items={results.items}
-          total={results.total}
-          filters={{
-            city: "",
-            modality: "",
-            keyword: "",
-            session: "",
-            goal: "",
-            verified: false,
-            availableToday: false,
-            masterOnly: false,
-            tier: "",
-            lgbtqAffirming: false,
-          }}
+        <GeoAreaCallout
+          compact
+          navigateToCity
+          autoNavigateToCity
+          source="near-me"
+          className="mb-5"
         />
 
         <section className="mt-10 border-t border-border pt-8">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -286,15 +286,38 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
     return permanentRedirect("/signup/plan", request);
   }
 
-  // ── 2. /explore?city=X  →  301 /explore/usa/{slug} ───────────────────────
-  if (pathname === "/explore" && searchParams.get("city")) {
-    const slug = exploreCityToSlug(searchParams.get("city")!);
-    // Guard against an empty slug, which would redirect to /explore/usa (404).
-    if (slug) {
-      return permanentRedirect(`/explore/usa/${slug}`, request);
+  // City pages are the single source of truth for local inventory. Keep the
+  // generic search surface for advanced filters, but send a location-only
+  // search straight to the canonical city directory.
+  if (pathname === "/search" && searchParams.get("city")) {
+    const nonLocationParams = [...searchParams.keys()].filter(
+      (key) => !["city", "source", "radius", "sort", "view"].includes(key),
+    );
+    const citySlug = resolveCitySlug(exploreCityToSlug(searchParams.get("city")!));
+
+    if (citySlug && nonLocationParams.length === 0) {
+      return permanentRedirect(`/${citySlug}`, request);
     }
   }
 
+  // The old city-specific Explore surface duplicated the city directory and
+  // could hide valid profiles when coordinates were incomplete. Consolidate
+  // it into the canonical city page, regardless of its legacy filter params.
+  const exploreCityMatch = pathname.match(/^\/explore\/usa\/([^/]+)\/?$/);
+  if (exploreCityMatch) {
+    const citySlug = resolveCitySlug(exploreCityMatch[1] || "");
+    if (citySlug) {
+      return permanentRedirect(`/${citySlug}`, request);
+    }
+  }
+
+  // /explore?city=X -> 301 /{city}
+  if (pathname === "/explore" && searchParams.get("city")) {
+    const citySlug = resolveCitySlug(exploreCityToSlug(searchParams.get("city")!));
+    if (citySlug) {
+      return permanentRedirect(`/${citySlug}`, request);
+    }
+  }
   // ── 3. /pt-br/  →  301 /pt-br ────────────────────────────────────────────
   if (pathname === "/pt-br/") {
     return permanentRedirect("/pt-br", request);

--- a/supabase/PRODUCTION_SCHEMA_LOCK.sql
+++ b/supabase/PRODUCTION_SCHEMA_LOCK.sql
@@ -1759,3 +1759,196 @@ create index if not exists demand_radar_spike_alert_deliveries_run_idx
   on public.demand_radar_spike_alert_deliveries(run_id, created_at desc);
 
 alter table public.demand_radar_spike_alert_deliveries enable row level security;
+
+-- Deterministic daily snapshots produced by the AI Profile Coach. This table
+-- previously existed only in migration history, which left it outside the
+-- production schema contract validated by CI.
+create table if not exists public.ai_profile_coach_daily_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  snapshot_date date not null default current_date,
+  profile_score integer not null default 0 check (profile_score between 0 and 100),
+  previous_profile_score integer check (previous_profile_score between 0 and 100),
+  score_change integer not null default 0,
+  visibility_score integer not null default 0 check (visibility_score between 0 and 100),
+  trust_score integer not null default 0 check (trust_score between 0 and 100),
+  content_score integer not null default 0 check (content_score between 0 and 100),
+  conversion_score integer not null default 0 check (conversion_score between 0 and 100),
+  profile_views_1d integer not null default 0,
+  profile_views_7d integer not null default 0,
+  profile_views_30d integer not null default 0,
+  profile_views_change_pct numeric(8,2),
+  contact_clicks_1d integer not null default 0,
+  contact_clicks_7d integer not null default 0,
+  contact_clicks_30d integer not null default 0,
+  contact_rate_pct numeric(8,2),
+  favorites_7d integer not null default 0,
+  inquiries_7d integer not null default 0,
+  average_search_position numeric(8,2),
+  local_demand_score integer,
+  local_demand_trend text,
+  strongest_keyword text,
+  weakest_section text,
+  top_recommendation_key text,
+  top_recommendation_title text,
+  top_recommendation_reason text,
+  top_recommendation_action text,
+  top_recommendation_impact text check (top_recommendation_impact in ('high','medium','low')),
+  recommended_headline text,
+  missing_fields jsonb not null default '[]'::jsonb,
+  completed_fields jsonb not null default '[]'::jsonb,
+  trust_signals jsonb not null default '{}'::jsonb,
+  photo_analysis jsonb not null default '{}'::jsonb,
+  content_analysis jsonb not null default '{}'::jsonb,
+  market_analysis jsonb not null default '{}'::jsonb,
+  recommendation_list jsonb not null default '[]'::jsonb,
+  trial_status text,
+  trial_day integer,
+  trial_days_remaining integer,
+  subscription_tier text,
+  email_subject text,
+  email_preheader text,
+  email_payload jsonb not null default '{}'::jsonb,
+  generated_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique(profile_id, snapshot_date)
+);
+
+create index if not exists ai_profile_coach_daily_snapshots_profile_date_idx
+  on public.ai_profile_coach_daily_snapshots(profile_id, snapshot_date desc);
+
+alter table public.ai_profile_coach_daily_snapshots enable row level security;
+
+-- Admin messaging control plane. All access is server-side through the
+-- service-role client; RLS keeps these records unavailable to public clients.
+create table if not exists public.messaging_settings (
+  id text primary key default 'default',
+  receiving_number text not null default '',
+  transport_mode text not null default 'automatic',
+  knotty_enabled boolean not null default true,
+  global_pause boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+insert into public.messaging_settings (id)
+values ('default')
+on conflict (id) do nothing;
+
+create table if not exists public.messaging_contacts (
+  id uuid primary key default gen_random_uuid(),
+  phone_e164 text not null unique,
+  name text,
+  city text,
+  state text,
+  timezone text,
+  profile_url text,
+  lifecycle_status text not null default 'new',
+  knotty_enabled boolean not null default true,
+  opted_out boolean not null default false,
+  opted_out_at timestamptz,
+  opted_out_reason text,
+  last_outbound_at timestamptz,
+  last_inbound_at timestamptz,
+  last_activity_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.messaging_conversations (
+  id uuid primary key default gen_random_uuid(),
+  contact_id uuid not null references public.messaging_contacts(id) on delete cascade,
+  receiving_number text not null,
+  status text not null default 'open',
+  knotty_enabled boolean not null default true,
+  current_channel text not null default 'unknown',
+  unread_count integer not null default 0,
+  last_message_at timestamptz,
+  last_inbound_at timestamptz,
+  last_outbound_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.messaging_campaigns (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  status text not null default 'draft',
+  transport_preference text not null default 'automatic',
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.messaging_messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.messaging_conversations(id) on delete cascade,
+  contact_id uuid not null references public.messaging_contacts(id) on delete cascade,
+  campaign_id uuid references public.messaging_campaigns(id) on delete set null,
+  direction text not null,
+  sender_type text not null,
+  body text not null,
+  channel text not null default 'unknown',
+  delivery_status text not null default 'queued',
+  external_id text,
+  idempotency_key text unique,
+  sent_at timestamptz,
+  delivered_at timestamptz,
+  received_at timestamptz,
+  failed_at timestamptz,
+  error_code text,
+  error_message text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.messaging_queue (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid references public.messaging_campaigns(id) on delete set null,
+  contact_id uuid not null references public.messaging_contacts(id) on delete cascade,
+  conversation_id uuid not null references public.messaging_conversations(id) on delete cascade,
+  message_id uuid not null references public.messaging_messages(id) on delete cascade,
+  body text not null,
+  transport_preference text not null default 'automatic',
+  status text not null default 'pending',
+  scheduled_for timestamptz not null default now(),
+  priority integer not null default 0,
+  attempts integer not null default 0,
+  max_attempts integer not null default 3,
+  locked_at timestamptz,
+  locked_by text,
+  last_error text,
+  sent_at timestamptz,
+  delivered_at timestamptz,
+  failed_at timestamptz,
+  idempotency_key text unique,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists messaging_contacts_activity_idx
+  on public.messaging_contacts(last_activity_at desc, created_at desc);
+
+create index if not exists messaging_conversations_contact_status_idx
+  on public.messaging_conversations(contact_id, receiving_number, status, created_at desc);
+
+create index if not exists messaging_messages_conversation_idx
+  on public.messaging_messages(conversation_id, created_at);
+
+create index if not exists messaging_queue_status_schedule_idx
+  on public.messaging_queue(status, scheduled_for, priority desc);
+
+alter table public.messaging_settings enable row level security;
+alter table public.messaging_contacts enable row level security;
+alter table public.messaging_conversations enable row level security;
+alter table public.messaging_campaigns enable row level security;
+alter table public.messaging_messages enable row level security;
+alter table public.messaging_queue enable row level security;
+
+grant all on public.ai_profile_coach_daily_snapshots to service_role;
+grant all on public.messaging_settings to service_role;
+grant all on public.messaging_contacts to service_role;
+grant all on public.messaging_conversations to service_role;
+grant all on public.messaging_campaigns to service_role;
+grant all on public.messaging_messages to service_role;
+grant all on public.messaging_queue to service_role;

--- a/tests/seo-normalization.spec.ts
+++ b/tests/seo-normalization.spec.ts
@@ -37,6 +37,11 @@ const CASES: Array<{ source: string; destination: string }> = [
   { source: "/dallas/verified-therapists", destination: "/dallas/verified-profiles" },
   { source: "/dallas/services/deep-tissue", destination: "/dallas/wellness/deep-tissue" },
   { source: "/dallas/services/sports", destination: "/dallas/wellness/sports-recovery" },
+
+  // Local discovery uses the canonical city inventory instead of maintaining
+  // competing search and Explore result sets.
+  { source: "/search?city=Dallas", destination: "/dallas" },
+  { source: "/explore/usa/dallas?city=Dallas&radius=25&sort=distance&view=grid", destination: "/dallas" },
 ];
 
 for (const { source, destination } of CASES) {


### PR DESCRIPTION
## What changed

- Redirect location-only `/search?city=...` requests to the canonical city directory.
- Redirect legacy `/explore/usa/{city}` pages to that same canonical city directory.
- Stop `/near-me` from rendering nationwide provider inventory; it now resolves the visitor's city and opens the local directory.
- Preserve `/search` for searches that contain advanced filters.
- Add redirect regression coverage.
- Fix a pre-existing lint failure introduced on the latest `main` messaging route.

## Why

Dallas inventory was visible on `/dallas` but absent from two competing discovery surfaces, while `/near-me` rendered providers from across the country. Canonical city pages now provide one source of truth for local inventory.

## Validation

- `pnpm run lint` — passed
- `pnpm run test` — passed (213 unit tests and 8 API smoke checks)
- `pnpm run validate:sitemap` — passed source validation
- `pnpm run release:audit` — passed
- Local route verification: both Dallas legacy URLs return `301` to `/dallas`, followed by `200`; `/near-me` returns `200` without national provider cards

## Known baseline issue

`pnpm run typecheck` currently reports pre-existing errors from the latest `main` in AdminMessaging, messaging JSON payload typing, and the pro growth route. The local discovery changes do not touch those errors.