### PR TITLE
Add CSV contact import to Admin Messaging

### DIFF
--- a/src/app/admin/messaging/CsvContactsImport.tsx
+++ b/src/app/admin/messaging/CsvContactsImport.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { FileUp, Loader2, UploadCloud, X } from "lucide-react";
+
+import { requestJson } from "@/app/_lib/request";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+type ParsedRow = {
+  phone: string;
+  name?: string | null;
+  city?: string | null;
+  state?: string | null;
+  timezone?: string | null;
+  profileUrl?: string | null;
+  textMessage?: string | null;
+};
+
+type ImportResult = {
+  ok: boolean;
+  received: number;
+  inserted: number;
+  updated: number;
+  skipped: number;
+  invalid: Array<{ row: number; phone: string }>;
+  duplicatesInsideFile: number;
+  protectedOptOuts: number;
+  errors: Array<{ row: number; phone: string; error: string }>;
+};
+
+const HEADER_ALIASES: Record<string, keyof ParsedRow> = {
+  phone: "phone",
+  phone_number: "phone",
+  mobile: "phone",
+  telephone: "phone",
+  name: "name",
+  full_name: "name",
+  first_name: "name",
+  city: "city",
+  state: "state",
+  timezone: "timezone",
+  time_zone: "timezone",
+  profile_url: "profileUrl",
+  url: "profileUrl",
+  text_message: "textMessage",
+  message: "textMessage",
+};
+
+function parseCsvLine(line: string) {
+  const cells: string[] = [];
+  let current = "";
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '"') {
+      if (quoted && line[index + 1] === '"') {
+        current += '"';
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
+      continue;
+    }
+    if (char === "," && !quoted) {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
+function parseCsv(text: string) {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const lines: string[] = [];
+  let buffer = "";
+  let quoted = false;
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    if (char === '"') {
+      if (quoted && normalized[index + 1] === '"') {
+        buffer += '""';
+        index += 1;
+        continue;
+      }
+      quoted = !quoted;
+    }
+    if (char === "\n" && !quoted) {
+      if (buffer.trim()) lines.push(buffer);
+      buffer = "";
+      continue;
+    }
+    buffer += char;
+  }
+  if (buffer.trim()) lines.push(buffer);
+  if (lines.length < 2) throw new Error("CSV needs a header row and at least one contact.");
+
+  const headers = parseCsvLine(lines[0]).map((header) => header.toLowerCase().trim().replace(/[^a-z0-9]+/g, "_"));
+  const mappedHeaders = headers.map((header) => HEADER_ALIASES[header] || null);
+  if (!mappedHeaders.includes("phone")) throw new Error("CSV must contain a phone column.");
+
+  const rows: ParsedRow[] = [];
+  for (const line of lines.slice(1)) {
+    const cells = parseCsvLine(line);
+    const row: ParsedRow = { phone: "" };
+    mappedHeaders.forEach((key, index) => {
+      if (!key) return;
+      const value = cells[index]?.trim() || "";
+      if (value) row[key] = value;
+    });
+    if (row.phone || row.name) rows.push(row);
+  }
+  return rows;
+}
+
+export default function CsvContactsImport({ onImported }: { onImported: () => void | Promise<void> }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [rows, setRows] = useState<ParsedRow[]>([]);
+  const [fileName, setFileName] = useState("");
+  const [duplicateMode, setDuplicateMode] = useState<"skip" | "update">("skip");
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  const preview = useMemo(() => rows.slice(0, 8), [rows]);
+
+  async function chooseFile(file: File | undefined) {
+    if (!file) return;
+    try {
+      setError("");
+      setResult(null);
+      const text = await file.text();
+      const parsed = parseCsv(text);
+      if (parsed.length > 10000) throw new Error("Maximum 10,000 contacts per CSV.");
+      setRows(parsed);
+      setFileName(file.name);
+    } catch (err) {
+      setRows([]);
+      setFileName("");
+      setError(err instanceof Error ? err.message : "Could not read CSV.");
+    }
+  }
+
+  async function importRows() {
+    if (rows.length === 0) return;
+    setImporting(true);
+    setError("");
+    setResult(null);
+    try {
+      const totals: ImportResult = {
+        ok: true,
+        received: 0,
+        inserted: 0,
+        updated: 0,
+        skipped: 0,
+        invalid: [],
+        duplicatesInsideFile: 0,
+        protectedOptOuts: 0,
+        errors: [],
+      };
+
+      for (let start = 0; start < rows.length; start += 250) {
+        const batch = rows.slice(start, start + 250);
+        const response = await requestJson<ImportResult>("/api/admin/messaging/import", {
+          method: "POST",
+          body: JSON.stringify({ rows: batch, duplicateMode, source: `admin_csv:${fileName || "upload"}` }),
+        });
+        totals.received += response.received;
+        totals.inserted += response.inserted;
+        totals.updated += response.updated;
+        totals.skipped += response.skipped;
+        totals.duplicatesInsideFile += response.duplicatesInsideFile;
+        totals.protectedOptOuts += response.protectedOptOuts;
+        totals.invalid.push(...response.invalid.map((item) => ({ ...item, row: item.row + start })));
+        totals.errors.push(...response.errors.map((item) => ({ ...item, row: item.row + start })));
+      }
+
+      setResult(totals);
+      await onImported();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Import failed.");
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function reset() {
+    setRows([]);
+    setFileName("");
+    setResult(null);
+    setError("");
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  return (
+    <Card className="mb-4">
+      <CardHeader className="pb-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base"><FileUp className="h-4 w-4" />Upload contacts CSV</CardTitle>
+            <p className="mt-1 text-sm text-slate-500">Required: phone. Optional: name, city, state, timezone, profile_url, text_message.</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <input ref={inputRef} className="hidden" type="file" accept=".csv,text/csv" onChange={(event) => void chooseFile(event.target.files?.[0])} />
+            <Button type="button" variant="outline" onClick={() => inputRef.current?.click()} disabled={importing}>
+              <UploadCloud className="mr-2 h-4 w-4" />Choose CSV
+            </Button>
+            {rows.length > 0 ? <Button type="button" variant="ghost" onClick={reset} disabled={importing}><X className="mr-2 h-4 w-4" />Clear</Button> : null}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error ? <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
+        {rows.length > 0 ? (
+          <>
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <Badge variant="outline">{fileName}</Badge>
+              <Badge variant="outline">{rows.length.toLocaleString()} contacts</Badge>
+              <span className="text-slate-500">Duplicates already in MasseurMatch:</span>
+              <Button type="button" size="sm" variant={duplicateMode === "skip" ? "default" : "outline"} onClick={() => setDuplicateMode("skip")}>Skip</Button>
+              <Button type="button" size="sm" variant={duplicateMode === "update" ? "default" : "outline"} onClick={() => setDuplicateMode("update")}>Update</Button>
+            </div>
+
+            <div className="overflow-x-auto rounded-lg border">
+              <table className="w-full min-w-[720px] text-left text-sm">
+                <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+                  <tr><th className="px-3 py-2">Name</th><th className="px-3 py-2">Phone</th><th className="px-3 py-2">City</th><th className="px-3 py-2">State</th><th className="px-3 py-2">Message</th></tr>
+                </thead>
+                <tbody>
+                  {preview.map((row, index) => (
+                    <tr key={`${row.phone}-${index}`} className="border-t">
+                      <td className="px-3 py-2">{row.name || ""}</td><td className="px-3 py-2 font-mono text-xs">{row.phone}</td><td className="px-3 py-2">{row.city || ""}</td><td className="px-3 py-2">{row.state || ""}</td><td className="max-w-[320px] truncate px-3 py-2">{row.textMessage || ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {rows.length > preview.length ? <p className="text-xs text-slate-500">Previewing first {preview.length} of {rows.length.toLocaleString()} rows.</p> : null}
+
+            <Button type="button" onClick={() => void importRows()} disabled={importing}>
+              {importing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <UploadCloud className="mr-2 h-4 w-4" />}
+              {importing ? "Importing..." : `Import ${rows.length.toLocaleString()} contacts`}
+            </Button>
+          </>
+        ) : null}
+
+        {result ? (
+          <div className="rounded-lg border bg-slate-50 p-3 text-sm">
+            <p className="font-medium">Import complete</p>
+            <p className="mt-1 text-slate-600">Inserted {result.inserted} · Updated {result.updated} · Skipped {result.skipped} · Invalid {result.invalid.length} · Errors {result.errors.length}</p>
+            {result.protectedOptOuts > 0 ? <p className="mt-1 text-amber-700">{result.protectedOptOuts} existing opt outs remained protected.</p> : null}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/admin/messaging/MessagingClientShell.tsx
+++ b/src/app/admin/messaging/MessagingClientShell.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import CsvContactsImport from "./CsvContactsImport";
+import AdminMessaging from "./AdminMessaging";
+
+export default function MessagingClientShell() {
+  return (
+    <div className="space-y-4">
+      <CsvContactsImport onImported={() => window.location.reload()} />
+      <AdminMessaging />
+    </div>
+  );
+}

--- a/src/app/admin/messaging/page.tsx
+++ b/src/app/admin/messaging/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import { createPageMetadata } from "@/app/_lib/seo";
-import AdminMessaging from "./AdminMessaging";
+import MessagingClientShell from "./MessagingClientShell";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Messaging",
@@ -11,5 +11,5 @@ export const metadata: Metadata = createPageMetadata({
 });
 
 export default function AdminMessagingPage() {
-  return <AdminMessaging />;
+  return <MessagingClientShell />;
 }

--- a/src/app/api/admin/messaging/import/route.ts
+++ b/src/app/api/admin/messaging/import/route.ts
@@ -1,0 +1,173 @@
+export const dynamic = "force-dynamic";
+
+import { z } from "zod";
+
+import { assertRateLimit } from "@/app/_lib/security";
+import { errorResponse, json, parseJsonBody, RouteError } from "@/app/api/_lib/http";
+import {
+  createSupabaseAdminClient,
+  recordAuditLog,
+  requireAdminSession,
+} from "@/app/api/_lib/supabase-server";
+
+const rowSchema = z.object({
+  phone: z.string().trim().min(7).max(40),
+  name: z.string().trim().max(160).optional().nullable(),
+  city: z.string().trim().max(120).optional().nullable(),
+  state: z.string().trim().max(80).optional().nullable(),
+  timezone: z.string().trim().max(80).optional().nullable(),
+  profileUrl: z.string().trim().max(1000).optional().nullable(),
+  textMessage: z.string().trim().max(4000).optional().nullable(),
+});
+
+const bodySchema = z.object({
+  rows: z.array(rowSchema).min(1).max(250),
+  duplicateMode: z.enum(["skip", "update"]).default("skip"),
+  source: z.string().trim().max(120).default("admin_csv"),
+});
+
+type DbClient = ReturnType<typeof createSupabaseAdminClient> & {
+  from: (table: string) => any;
+};
+
+function normalizeUsPhone(input: string) {
+  const raw = input.trim();
+  if (raw.startsWith("+")) {
+    const digits = raw.slice(1).replace(/\D/g, "");
+    if (digits.length >= 8 && digits.length <= 15) return `+${digits}`;
+    return null;
+  }
+
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  if (digits.length >= 8 && digits.length <= 15) return `+${digits}`;
+  return null;
+}
+
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdminSession(request);
+    assertRateLimit(request, "admin-messaging-import", { limit: 30, windowMs: 60_000 });
+    const body = await parseJsonBody(request, bodySchema);
+    const db = createSupabaseAdminClient() as DbClient;
+
+    const normalized = body.rows.map((row, index) => ({
+      index,
+      row,
+      phone: normalizeUsPhone(row.phone),
+    }));
+
+    const invalid = normalized.filter((item) => !item.phone);
+    const valid = normalized.filter((item): item is typeof item & { phone: string } => Boolean(item.phone));
+
+    const uniqueByPhone = new Map<string, (typeof valid)[number]>();
+    let duplicatesInsideFile = 0;
+    for (const item of valid) {
+      if (uniqueByPhone.has(item.phone)) duplicatesInsideFile += 1;
+      uniqueByPhone.set(item.phone, item);
+    }
+    const deduped = [...uniqueByPhone.values()];
+
+    const phones = deduped.map((item) => item.phone);
+    const { data: existingRows, error: existingError } = await db
+      .from("messaging_contacts")
+      .select("id,phone_e164,opted_out")
+      .in("phone_e164", phones);
+    if (existingError) throw new RouteError(500, existingError.message);
+
+    const existing = new Map<string, { id: string; opted_out: boolean }>(
+      (existingRows || []).map((row: { id: string; phone_e164: string; opted_out: boolean }) => [
+        row.phone_e164,
+        { id: row.id, opted_out: row.opted_out },
+      ]),
+    );
+
+    let inserted = 0;
+    let updated = 0;
+    let skipped = 0;
+    let protectedOptOuts = 0;
+    const errors: Array<{ row: number; phone: string; error: string }> = [];
+
+    for (const item of deduped) {
+      const current = existing.get(item.phone);
+      if (current && body.duplicateMode === "skip") {
+        skipped += 1;
+        continue;
+      }
+
+      const metadata = item.row.textMessage
+        ? { imported_text_message: item.row.textMessage }
+        : {};
+
+      if (current) {
+        if (current.opted_out) protectedOptOuts += 1;
+        const patch = {
+          name: item.row.name || null,
+          city: item.row.city || null,
+          state: item.row.state || null,
+          timezone: item.row.timezone || "America/Chicago",
+          profile_url: item.row.profileUrl || null,
+          source: body.source,
+          metadata,
+        };
+        const { error } = await db.from("messaging_contacts").update(patch).eq("id", current.id);
+        if (error) {
+          errors.push({ row: item.index + 2, phone: item.phone, error: error.message });
+        } else {
+          updated += 1;
+        }
+        continue;
+      }
+
+      const { error } = await db.from("messaging_contacts").insert({
+        phone_e164: item.phone,
+        name: item.row.name || null,
+        city: item.row.city || null,
+        state: item.row.state || null,
+        timezone: item.row.timezone || "America/Chicago",
+        profile_url: item.row.profileUrl || null,
+        source: body.source,
+        metadata,
+      });
+      if (error) {
+        errors.push({ row: item.index + 2, phone: item.phone, error: error.message });
+      } else {
+        inserted += 1;
+      }
+    }
+
+    await recordAuditLog(
+      admin.userId,
+      "admin_messaging_contacts_imported",
+      "messaging_contacts",
+      null,
+      {
+        received: body.rows.length,
+        inserted,
+        updated,
+        skipped,
+        invalid: invalid.length,
+        duplicatesInsideFile,
+        protectedOptOuts,
+        errors: errors.length,
+        duplicateMode: body.duplicateMode,
+        source: body.source,
+      },
+    );
+
+    return json({
+      ok: true,
+      received: body.rows.length,
+      inserted,
+      updated,
+      skipped,
+      invalid: invalid.map((item) => ({ row: item.index + 2, phone: item.row.phone })),
+      duplicatesInsideFile,
+      protectedOptOuts,
+      errors,
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}


### PR DESCRIPTION
## Summary

Adds CSV contact upload to `/admin/messaging`.

### Includes
- CSV file picker and preview
- supports `phone`, `name`, `city`, `state`, `timezone`, `profile_url`, `text_message`
- normalizes US phone numbers to E.164
- imports in batches of 250
- duplicate handling: Skip or Update
- existing opt-outs remain protected
- audit logging for imports
- up to 10,000 contacts per CSV

No sender is enabled by this PR. This only imports contacts into `messaging_contacts`.

Do not merge until checks are green.