### PR TITLE
Harden is_admin authorization helper

### DIFF
--- a/scripts/apply-schema-lock.mjs
+++ b/scripts/apply-schema-lock.mjs
@@ -55,8 +55,10 @@ function assertCanonicalSchemaLock(sql) {
     process.exit(1);
   }
 
-  const insecureIsAdmin = /create\s+or\s+replace\s+function\s+(?:public\.)?is_admin\s*\(\s*\)[\s\S]*?security\s+definer[\s\S]*?\$\$\s*;/i;
-  if (insecureIsAdmin.test(sql)) {
+  const isAdminHeader = sql.match(
+    /create\s+or\s+replace\s+function\s+(?:public\.)?is_admin\s*\(\s*\)([\s\S]*?)\bas\s+\$\$/i,
+  )?.[1];
+  if (isAdminHeader && /\bsecurity\s+definer\b/i.test(isAdminHeader)) {
     console.error("[apply-schema-lock] Refusing to apply a schema lock that recreates public.is_admin() as SECURITY DEFINER.");
     console.error("[apply-schema-lock] is_admin() must remain SECURITY INVOKER and rely on public.user_roles RLS.");
     process.exit(1);

--- a/scripts/apply-schema-lock.mjs
+++ b/scripts/apply-schema-lock.mjs
@@ -5,9 +5,10 @@
 // scripts/verify-live-schema.mjs.
 //
 // IMPORTANT: the historical schema lock currently contains out-of-scope
-// booking/session-payment tables. This command fails closed until those legacy
-// declarations are removed, preventing an old additive contract from
-// recreating deprecated runtime objects after the canonical cleanup migration.
+// booking/session-payment tables and an obsolete SECURITY DEFINER is_admin().
+// This command fails closed until those declarations are removed, preventing an
+// old additive contract from recreating deprecated runtime objects or restoring
+// elevated admin-helper privileges after hardening migrations.
 //
 // Env (or .env.local fallback):
 //   SUPABASE_ACCESS_TOKEN      personal access token (sbp_...), required
@@ -47,12 +48,19 @@ function assertCanonicalSchemaLock(sql) {
     return pattern.test(sql);
   });
 
-  if (offenders.length === 0) return;
+  if (offenders.length > 0) {
+    console.error("[apply-schema-lock] Refusing to apply a non-canonical schema lock to production.");
+    console.error(`[apply-schema-lock] Remove legacy table declarations first: ${offenders.join(", ")}`);
+    console.error("[apply-schema-lock] Canonical MasseurMatch is directory-only; booking, scheduling, and session-payment tables must not be recreated.");
+    process.exit(1);
+  }
 
-  console.error("[apply-schema-lock] Refusing to apply a non-canonical schema lock to production.");
-  console.error(`[apply-schema-lock] Remove legacy table declarations first: ${offenders.join(", ")}`);
-  console.error("[apply-schema-lock] Canonical MasseurMatch is directory-only; booking, scheduling, and session-payment tables must not be recreated.");
-  process.exit(1);
+  const insecureIsAdmin = /create\s+or\s+replace\s+function\s+(?:public\.)?is_admin\s*\(\s*\)[\s\S]*?security\s+definer[\s\S]*?\$\$\s*;/i;
+  if (insecureIsAdmin.test(sql)) {
+    console.error("[apply-schema-lock] Refusing to apply a schema lock that recreates public.is_admin() as SECURITY DEFINER.");
+    console.error("[apply-schema-lock] is_admin() must remain SECURITY INVOKER and rely on public.user_roles RLS.");
+    process.exit(1);
+  }
 }
 
 async function main() {

--- a/supabase/migrations/20260815172500_harden_is_admin_invoker.sql
+++ b/supabase/migrations/20260815172500_harden_is_admin_invoker.sql
@@ -1,0 +1,37 @@
+-- Harden the admin authorization helper without breaking RLS policies.
+--
+-- public.is_admin() is referenced by many public-schema policies. It must remain
+-- executable by anon/authenticated so those policies can evaluate it, but it
+-- does not need postgres privileges. SECURITY INVOKER makes the helper obey the
+-- caller's grants and user_roles RLS instead of bypassing them.
+
+alter table public.user_roles enable row level security;
+
+grant select on table public.user_roles to anon, authenticated;
+
+-- Consolidate the duplicated authenticated self-read policies into one
+-- initPlan-friendly policy. Anonymous callers may execute is_admin(), but they
+-- must never see a user_roles row.
+drop policy if exists "Users can read their own role" on public.user_roles;
+drop policy if exists user_roles_select_own on public.user_roles;
+create policy user_roles_select_own
+  on public.user_roles
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists user_roles_anon_no_rows on public.user_roles;
+create policy user_roles_anon_no_rows
+  on public.user_roles
+  for select
+  to anon
+  using (false);
+
+alter function public.is_admin() security invoker;
+
+-- Remove the implicit PUBLIC grant, then explicitly keep only the roles that
+-- legitimately evaluate this helper through RLS or trusted server execution.
+revoke execute on function public.is_admin() from public;
+grant execute on function public.is_admin() to anon, authenticated, service_role;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Hardens `public.is_admin()` without breaking the RLS policies that depend on it.

- grants `anon` and `authenticated` SELECT on `public.user_roles`, with RLS enforcing zero rows for anon and own-row-only reads for authenticated users
- consolidates duplicate authenticated `user_roles` SELECT policies
- changes `public.is_admin()` from `SECURITY DEFINER` to `SECURITY INVOKER`
- removes implicit PUBLIC execute and keeps explicit execute only for `anon`, `authenticated`, and `service_role`
- extends the production schema-lock guard so the historical lock cannot recreate `is_admin()` as `SECURITY DEFINER`

## Security rationale

The live function is owned by `postgres` and was executable by both `anon` and `authenticated`, so direct RPC invocation could run with elevated privileges. The helper only needs to inspect the caller's own admin-role row, which can safely be enforced by `user_roles` RLS.

## Scope

No product behavior, subscription billing, directory data, or messaging behavior is changed.